### PR TITLE
C ABI の検索・待機ヘルパーを追加し、README と最小例を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ await game.getByRole("button", { name: "Start Game" }).click()
 await expect(game.getById("loading")).toBeVisible()
 ```
 
+Current v0.2 helpers expose that shape for C++ and C# over the C ABI:
+
+```cpp
+gua::testing::get_by_role(ctx, "button", "Start Game").click();
+gua::testing::wait_for_text(ctx, "Loading...").to_be_visible();
+```
+
+```csharp
+GuaAssertions.GetByRole(ui, "button", "Start Game").Click();
+GuaAssertions.WaitForText(ui, "Loading...").ToBeVisible();
+```
+
 Gua is not a game engine.
 Gua is not an editor MCP.
 Gua is not an image-recognition QA bot.

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -2,6 +2,8 @@ namespace Gua.Core;
 
 public sealed class GuaContext : IDisposable
 {
+    private const int NodeIdBufferSize = 128;
+
     private nint _handle;
 
     public GuaContext()
@@ -54,6 +56,53 @@ public sealed class GuaContext : IDisposable
         return state;
     }
 
+    public string FindNodeById(string id)
+    {
+        ThrowIfDisposed();
+        unsafe
+        {
+            var buffer = stackalloc byte[NodeIdBufferSize];
+            if (Native.gua_find_node_by_id(_handle, id, buffer, NodeIdBufferSize) == 0)
+            {
+                throw new InvalidOperationException($"Gua node not found by id: {id}");
+            }
+
+            return ReadUtf8NodeId(buffer);
+        }
+    }
+
+    public string FindNodeByRole(string role, string? name = null)
+    {
+        ThrowIfDisposed();
+        unsafe
+        {
+            var buffer = stackalloc byte[NodeIdBufferSize];
+            if (Native.gua_find_node_by_role(_handle, role, name, buffer, NodeIdBufferSize) == 0)
+            {
+                throw new InvalidOperationException(name is null
+                    ? $"Gua node not found by role: {role}"
+                    : $"Gua node not found by role and name: {role}, {name}");
+            }
+
+            return ReadUtf8NodeId(buffer);
+        }
+    }
+
+    public string FindNodeByText(string text)
+    {
+        ThrowIfDisposed();
+        unsafe
+        {
+            var buffer = stackalloc byte[NodeIdBufferSize];
+            if (Native.gua_find_node_by_text(_handle, text, buffer, NodeIdBufferSize) == 0)
+            {
+                throw new InvalidOperationException($"Gua node not found by text: {text}");
+            }
+
+            return ReadUtf8NodeId(buffer);
+        }
+    }
+
     public bool EnqueueClick(string id)
     {
         ThrowIfDisposed();
@@ -77,5 +126,11 @@ public sealed class GuaContext : IDisposable
         {
             throw new ObjectDisposedException(nameof(GuaContext));
         }
+    }
+
+    private static unsafe string ReadUtf8NodeId(byte* buffer)
+    {
+        return System.Runtime.InteropServices.Marshal.PtrToStringUTF8((nint)buffer)
+            ?? throw new InvalidOperationException("Native Gua returned an invalid node id.");
     }
 }

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -30,5 +30,14 @@ internal static partial class Native
     internal static partial int gua_get_node_state(nint context, string nodeId, out GuaNodeState state);
 
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
+    internal static unsafe partial int gua_find_node_by_id(nint context, string nodeId, byte* outNodeId, int outNodeIdSize);
+
+    [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
+    internal static unsafe partial int gua_find_node_by_role(nint context, string role, string? name, byte* outNodeId, int outNodeIdSize);
+
+    [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
+    internal static unsafe partial int gua_find_node_by_text(nint context, string text, byte* outNodeId, int outNodeIdSize);
+
+    [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int gua_enqueue_click(nint context, string nodeId);
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -4,9 +4,63 @@ namespace Gua.Testing;
 
 public static class GuaAssertions
 {
+    public static GuaNodeExpectation GetById(GuaContext context, string id)
+    {
+        return new GuaNodeExpectation(context, context.FindNodeById(id));
+    }
+
+    public static GuaNodeExpectation GetByRole(GuaContext context, string role, string? name = null)
+    {
+        return new GuaNodeExpectation(context, context.FindNodeByRole(role, name));
+    }
+
+    public static GuaNodeExpectation GetByText(GuaContext context, string text)
+    {
+        return new GuaNodeExpectation(context, context.FindNodeByText(text));
+    }
+
     public static GuaNodeExpectation ExpectNode(GuaContext context, string id)
     {
-        return new GuaNodeExpectation(context, id);
+        return GetById(context, id);
+    }
+
+    public static void WaitFor(GuaNodeExpectation expectation, TimeSpan? timeout = null)
+    {
+        expectation.WaitFor(timeout);
+    }
+
+    public static GuaNodeExpectation WaitForId(GuaContext context, string id, TimeSpan? timeout = null)
+    {
+        return WaitForQuery(() => GetById(context, id), $"id: {id}", timeout);
+    }
+
+    public static GuaNodeExpectation WaitForRole(GuaContext context, string role, string? name = null, TimeSpan? timeout = null)
+    {
+        return WaitForQuery(() => GetByRole(context, role, name), name is null ? $"role: {role}" : $"role and name: {role}, {name}", timeout);
+    }
+
+    public static GuaNodeExpectation WaitForText(GuaContext context, string text, TimeSpan? timeout = null)
+    {
+        return WaitForQuery(() => GetByText(context, text), $"text: {text}", timeout);
+    }
+
+    private static GuaNodeExpectation WaitForQuery(Func<GuaNodeExpectation> query, string description, TimeSpan? timeout)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(1));
+        do
+        {
+            try
+            {
+                return query();
+            }
+            catch (InvalidOperationException)
+            {
+                Thread.Sleep(10);
+            }
+        }
+        while (DateTime.UtcNow < deadline);
+
+        throw new TimeoutException($"Timed out waiting for Gua node by {description}");
     }
 }
 
@@ -50,5 +104,25 @@ public sealed class GuaNodeExpectation
         {
             throw new InvalidOperationException($"Failed to click Gua node: {_id}");
         }
+    }
+
+    public void WaitFor(TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(1));
+        do
+        {
+            try
+            {
+                _context.GetNodeState(_id);
+                return;
+            }
+            catch (InvalidOperationException)
+            {
+                Thread.Sleep(10);
+            }
+        }
+        while (DateTime.UtcNow < deadline);
+
+        throw new TimeoutException($"Timed out waiting for Gua node: {_id}");
     }
 }

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -1,11 +1,23 @@
 # Minimal Example
 
-This example will demonstrate the smallest Gua loop:
+The smallest Gua loop is:
 
 1. Create a runtime context.
 2. Begin a frame.
 3. Register a `Start Game` button.
-4. Export the UI tree.
+4. Query it with a testing helper.
 5. Enqueue and poll a click event.
 
-The executable is intentionally left for the v0.1 implementation milestone.
+```cpp
+gua::Context context;
+context.begin_frame("title");
+context.button("start", "Start Game", { 100.0F, 200.0F, 240.0F, 64.0F });
+context.end_frame();
+
+gua::testing::get_by_role(context.native_handle(), "button", "Start Game").click();
+
+gua::Event event;
+while (context.poll_event(event)) {
+    // event.node_id == "start"
+}
+```

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -47,6 +47,9 @@ void gua_register_node(
 
 const char* gua_get_ui_tree_json(gua_context_t* ctx);
 int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state);
+int gua_find_node_by_id(gua_context_t* ctx, const char* node_id, char* out_node_id, int out_node_id_size);
+int gua_find_node_by_role(gua_context_t* ctx, const char* role, const char* name, char* out_node_id, int out_node_id_size);
+int gua_find_node_by_text(gua_context_t* ctx, const char* text, char* out_node_id, int out_node_id_size);
 int gua_enqueue_click(gua_context_t* ctx, const char* node_id);
 int gua_poll_event(gua_context_t* ctx, gua_event_t* out_event);
 

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <deque>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <utility>
@@ -51,6 +52,16 @@ std::string escape_json(const std::string& value)
         }
     }
     return out;
+}
+
+int write_node_id(const std::string& node_id, char* out_node_id, int out_node_id_size)
+{
+    if (out_node_id == nullptr || out_node_id_size <= 0) {
+        return 0;
+    }
+
+    std::snprintf(out_node_id, static_cast<std::size_t>(out_node_id_size), "%s", node_id.c_str());
+    return 1;
 }
 
 } // namespace
@@ -175,6 +186,58 @@ extern "C" int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_n
     out_state->visible = found->visible ? 1 : 0;
     out_state->enabled = found->enabled ? 1 : 0;
     return 1;
+}
+
+extern "C" int gua_find_node_by_id(gua_context_t* ctx, const char* node_id, char* out_node_id, int out_node_id_size)
+{
+    if (ctx == nullptr || node_id == nullptr) {
+        return 0;
+    }
+
+    const auto found = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
+        return node.id == node_id;
+    });
+    if (found == ctx->nodes.end()) {
+        return 0;
+    }
+
+    return write_node_id(found->id, out_node_id, out_node_id_size);
+}
+
+extern "C" int gua_find_node_by_role(gua_context_t* ctx, const char* role, const char* name, char* out_node_id, int out_node_id_size)
+{
+    if (ctx == nullptr || role == nullptr) {
+        return 0;
+    }
+
+    const auto found = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
+        if (node.role != role) {
+            return false;
+        }
+
+        return name == nullptr || std::strlen(name) == 0 || node.label == name;
+    });
+    if (found == ctx->nodes.end()) {
+        return 0;
+    }
+
+    return write_node_id(found->id, out_node_id, out_node_id_size);
+}
+
+extern "C" int gua_find_node_by_text(gua_context_t* ctx, const char* text, char* out_node_id, int out_node_id_size)
+{
+    if (ctx == nullptr || text == nullptr) {
+        return 0;
+    }
+
+    const auto found = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
+        return node.label == text;
+    });
+    if (found == ctx->nodes.end()) {
+        return 0;
+    }
+
+    return write_node_id(found->id, out_node_id, out_node_id_size);
 }
 
 extern "C" int gua_enqueue_click(gua_context_t* ctx, const char* node_id)

--- a/native/gua-testing/include/gua/testing.hpp
+++ b/native/gua-testing/include/gua/testing.hpp
@@ -2,18 +2,26 @@
 
 #include "gua/gua.h"
 
+#include <chrono>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <thread>
 #include <utility>
 
 namespace gua::testing {
 
-class ExpectNode {
+class Locator {
 public:
-    ExpectNode(gua_context_t* context, std::string id)
+    Locator(gua_context_t* context, std::string id)
         : context_(context)
         , id_(std::move(id))
     {
+    }
+
+    [[nodiscard]] const std::string& id() const noexcept
+    {
+        return id_;
     }
 
     void to_exist() const
@@ -44,6 +52,21 @@ public:
         }
     }
 
+    void wait_for(std::chrono::milliseconds timeout = std::chrono::milliseconds(1000)) const
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        do {
+            gua_node_state_t state {};
+            if (gua_get_node_state(context_, id_.c_str(), &state) != 0) {
+                return;
+            }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        } while (std::chrono::steady_clock::now() < deadline);
+
+        throw std::runtime_error("Timed out waiting for Gua node: " + id_);
+    }
+
 private:
     gua_node_state_t read_state() const
     {
@@ -58,9 +81,114 @@ private:
     std::string id_;
 };
 
-inline ExpectNode expect_node(gua_context_t* context, std::string id)
+inline std::string read_node_id(char const* description, int found, const char* buffer)
 {
-    return ExpectNode(context, std::move(id));
+    if (found == 0) {
+        throw std::runtime_error(std::string("Gua node not found by ") + description);
+    }
+    return buffer;
+}
+
+inline Locator get_by_id(gua_context_t* context, std::string id)
+{
+    char node_id[128] {};
+    return Locator(context, read_node_id("id", gua_find_node_by_id(context, id.c_str(), node_id, static_cast<int>(sizeof(node_id))), node_id));
+}
+
+inline Locator get_by_role(gua_context_t* context, std::string_view role)
+{
+    char node_id[128] {};
+    std::string role_buffer(role);
+    return Locator(context, read_node_id("role", gua_find_node_by_role(context, role_buffer.c_str(), nullptr, node_id, static_cast<int>(sizeof(node_id))), node_id));
+}
+
+inline Locator get_by_role(gua_context_t* context, std::string_view role, std::string_view name)
+{
+    char node_id[128] {};
+    std::string role_buffer(role);
+    std::string name_buffer(name);
+    return Locator(context, read_node_id("role and name", gua_find_node_by_role(context, role_buffer.c_str(), name_buffer.c_str(), node_id, static_cast<int>(sizeof(node_id))), node_id));
+}
+
+inline Locator get_by_text(gua_context_t* context, std::string_view text)
+{
+    char node_id[128] {};
+    std::string text_buffer(text);
+    return Locator(context, read_node_id("text", gua_find_node_by_text(context, text_buffer.c_str(), node_id, static_cast<int>(sizeof(node_id))), node_id));
+}
+
+inline Locator expect_node(gua_context_t* context, std::string id)
+{
+    return get_by_id(context, std::move(id));
+}
+
+inline void wait_for(const Locator& locator, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+{
+    locator.wait_for(timeout);
+}
+
+inline Locator wait_for_id(gua_context_t* context, std::string id, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    do {
+        char node_id[128] {};
+        if (gua_find_node_by_id(context, id.c_str(), node_id, static_cast<int>(sizeof(node_id))) != 0) {
+            return Locator(context, node_id);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    } while (std::chrono::steady_clock::now() < deadline);
+
+    throw std::runtime_error("Timed out waiting for Gua node by id: " + id);
+}
+
+inline Locator wait_for_role(gua_context_t* context, std::string_view role, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    std::string role_buffer(role);
+    do {
+        char node_id[128] {};
+        if (gua_find_node_by_role(context, role_buffer.c_str(), nullptr, node_id, static_cast<int>(sizeof(node_id))) != 0) {
+            return Locator(context, node_id);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    } while (std::chrono::steady_clock::now() < deadline);
+
+    throw std::runtime_error("Timed out waiting for Gua node by role: " + role_buffer);
+}
+
+inline Locator wait_for_role(gua_context_t* context, std::string_view role, std::string_view name, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    std::string role_buffer(role);
+    std::string name_buffer(name);
+    do {
+        char node_id[128] {};
+        if (gua_find_node_by_role(context, role_buffer.c_str(), name_buffer.c_str(), node_id, static_cast<int>(sizeof(node_id))) != 0) {
+            return Locator(context, node_id);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    } while (std::chrono::steady_clock::now() < deadline);
+
+    throw std::runtime_error("Timed out waiting for Gua node by role and name: " + role_buffer + ", " + name_buffer);
+}
+
+inline Locator wait_for_text(gua_context_t* context, std::string_view text, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    std::string text_buffer(text);
+    do {
+        char node_id[128] {};
+        if (gua_find_node_by_text(context, text_buffer.c_str(), node_id, static_cast<int>(sizeof(node_id))) != 0) {
+            return Locator(context, node_id);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    } while (std::chrono::steady_clock::now() < deadline);
+
+    throw std::runtime_error("Timed out waiting for Gua node by text: " + text_buffer);
 }
 
 } // namespace gua::testing


### PR DESCRIPTION
## Summary
- C ABI に `id` / `role` / `text` ベースのノード検索関数を追加し、C++/C# から参照できるようにしました。
- `gua::testing` と `Gua.Testing` に `GetBy*` / `WaitFor*` 系のロケータ API を追加し、待機付きの検証を簡潔にしました。
- README と minimal example を新しいテスト補助 API に合わせて更新しました。

## Testing
- 既存の実装差分を確認し、C ABI 宣言・C++ ラッパー・.NET バインディングの整合を確認しました。
- 新規の検索/待機 API が既存の `GetNodeState` / `Click` フローと一貫していることを確認しました。