### PR TITLE
WebSocketブリッジとMCP/Inspectorの接続を整備する

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,48 @@ adapter:
 { "id": 2, "type": "click_node", "nodeId": "start" }
 ```
 
+## MCP
+
+The MCP server is a thin protocol consumer over the same bridge used by the
+Inspector. Start a runtime bridge first:
+
+```powershell
+bun run bridge:ws
+```
+
+Then run the MCP server over stdio:
+
+```powershell
+bun run mcp
+```
+
+The package is shaped for npm publishing as `gui-mcp`. After publishing, MCP
+clients can start it with:
+
+```powershell
+bunx gui-mcp@latest mcp
+```
+
+By default it connects to `ws://127.0.0.1:8765`. Override that for another
+runtime adapter:
+
+```powershell
+$env:GUA_BRIDGE_URL = "ws://127.0.0.1:8765"
+bunx gui-mcp@latest mcp
+```
+
+The v0.4 tool surface is:
+
+```text
+get_ui_tree
+click_node
+press_key
+wait_for_node
+get_screenshot
+get_logs
+run_test
+```
+
 Build the static Inspector:
 
 ```powershell

--- a/bun.lock
+++ b/bun.lock
@@ -34,9 +34,13 @@
       },
     },
     "packages/mcp": {
-      "name": "@gua/mcp",
+      "name": "gui-mcp",
       "version": "0.0.0",
+      "bin": {
+        "gui-mcp": "./dist/cli.js",
+      },
       "devDependencies": {
+        "bun-types": "^1.3.0",
         "typescript": "^5.5.0",
       },
     },
@@ -135,8 +139,6 @@
     "@gua/bridge-ws": ["@gua/bridge-ws@workspace:packages/bridge-ws"],
 
     "@gua/inspector": ["@gua/inspector@workspace:packages/inspector"],
-
-    "@gua/mcp": ["@gua/mcp@workspace:packages/mcp"],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -269,6 +271,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "gui-mcp": ["gui-mcp@workspace:packages/mcp"],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/examples/cpp-imgui/main.cpp
+++ b/examples/cpp-imgui/main.cpp
@@ -307,6 +307,11 @@ int main(int argc, char** argv)
                 gua_context.log(gua::LogLevel::debug, "focus_node(" + id + ")");
                 return true;
             },
+            .press_key = [&](std::string_view key) {
+                const std::lock_guard lock(gua_mutex);
+                gua_context.log(gua::LogLevel::info, "press_key(" + std::string(key) + ")");
+                return !key.empty();
+            },
         },
         gua::ws::BridgeOptions { .port = 8765 });
     bridge.start();

--- a/examples/native-bridge/main.cpp
+++ b/examples/native-bridge/main.cpp
@@ -27,6 +27,7 @@ struct Command {
     int id = 0;
     std::string type;
     std::string node_id;
+    std::string key;
 };
 
 class Socket {
@@ -474,6 +475,7 @@ Command parse_command(std::string_view json)
     command.id = json_int_field(json, "id").value_or(0);
     command.type = json_string_field(json, "type").value_or("");
     command.node_id = json_string_field(json, "nodeId").value_or("");
+    command.key = json_string_field(json, "key").value_or("");
     return command;
 }
 
@@ -570,6 +572,16 @@ public:
         return true;
     }
 
+    [[nodiscard]] bool press_key(std::string_view key)
+    {
+        if (key.empty()) {
+            return false;
+        }
+
+        context_.log(gua::LogLevel::info, "press_key(" + std::string(key) + ")");
+        return true;
+    }
+
 private:
     void render_frame()
     {
@@ -644,6 +656,12 @@ std::string handle_command(DemoRuntime& runtime, std::string_view message)
         if (command.type == "focus_node") {
             if (!runtime.focus_node(command.node_id)) {
                 return error_response(command.id, "Gua node not found: " + command.node_id);
+            }
+            return ok_null_response(command.id);
+        }
+        if (command.type == "press_key") {
+            if (!runtime.press_key(command.key)) {
+                return error_response(command.id, "Gua key was not accepted: " + command.key);
             }
             return ok_null_response(command.id);
         }

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -13,6 +13,7 @@ struct BridgeHandlers {
     std::function<std::string()> get_screenshot_json;
     std::function<bool(std::string_view node_id)> click_node;
     std::function<bool(std::string_view node_id)> focus_node;
+    std::function<bool(std::string_view key)> press_key;
 };
 
 struct BridgeOptions {

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -26,6 +26,7 @@ struct Command {
     int id = 0;
     std::string type;
     std::string node_id;
+    std::string key;
 };
 
 class Socket {
@@ -460,6 +461,7 @@ Command parse_command(std::string_view json)
     command.id = json_int_field(json, "id").value_or(0);
     command.type = json_string_field(json, "type").value_or("");
     command.node_id = json_string_field(json, "nodeId").value_or("");
+    command.key = json_string_field(json, "key").value_or("");
     return command;
 }
 
@@ -682,6 +684,15 @@ private:
                 return handlers_.focus_node(command.node_id)
                     ? ok_null_response(command.id)
                     : error_response(command.id, "Gua node not found: " + command.node_id);
+            }
+            if (command.type == "press_key") {
+                if (!handlers_.press_key) {
+                    return error_response(command.id, "press_key is not supported by this bridge");
+                }
+
+                return handlers_.press_key(command.key)
+                    ? ok_null_response(command.id)
+                    : error_response(command.id, "Gua key was not accepted: " + command.key);
             }
             return error_response(command.id, "Unsupported command: " + command.type);
         } catch (const std::exception& error) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "check": "bun run --workspaces check",
     "inspector": "bun run --filter @gua/inspector dev",
-    "bridge:ws": "bun run --filter @gua/bridge-ws dev"
+    "bridge:ws": "bun run --filter @gua/bridge-ws dev",
+    "mcp": "bun packages/mcp/src/cli.ts mcp"
   }
 }

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -36,6 +36,9 @@ function handleMessage(message: string | Buffer): GuaInspectorResponse {
       case "focus_node":
         runtime.focusNode(command.nodeId);
         return ok(command.id, null);
+      case "press_key":
+        runtime.pressKey(command.key);
+        return ok(command.id, null);
     }
   } catch (error) {
     return { id: command.id, ok: false, error: (error as Error).message };
@@ -103,6 +106,14 @@ class DemoRuntime {
     this.assertNodeExists(nodeId);
     this.focusedNodeId = nodeId;
     this.log("debug", `focus_node(${nodeId})`);
+  }
+
+  pressKey(key: string): void {
+    if (key.length === 0) {
+      throw new Error("Gua key must not be empty.");
+    }
+
+    this.log("info", `press_key(${key})`);
   }
 
   log(level: GuaLogEntry["level"], message: string): void {
@@ -178,7 +189,7 @@ const server = Bun.serve({
     return Response.json({
       name: "Gua WebSocket bridge",
       websocket: `ws://127.0.0.1:${port}`,
-      commands: ["get_ui_tree", "get_logs", "get_screenshot", "click_node", "focus_node"],
+      commands: ["get_ui_tree", "get_logs", "get_screenshot", "click_node", "focus_node", "press_key"],
     });
   },
   websocket: {

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -70,7 +70,8 @@ export type GuaInspectorCommand =
   | { id: number; type: "get_logs" }
   | { id: number; type: "get_screenshot" }
   | { id: number; type: "click_node"; nodeId: string }
-  | { id: number; type: "focus_node"; nodeId: string };
+  | { id: number; type: "focus_node"; nodeId: string }
+  | { id: number; type: "press_key"; key: string };
 
 type GuaInspectorCommandInput =
   | { type: "get_ui_tree" }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,12 +1,25 @@
 {
-  "name": "@gua/mcp",
+  "name": "gui-mcp",
   "version": "0.0.0",
+  "description": "MCP server for the Gua runtime UI automation protocol.",
   "type": "module",
-  "private": true,
+  "license": "MIT",
+  "bin": {
+    "gui-mcp": "./dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ],
   "scripts": {
-    "check": "tsc --noEmit"
+    "dev": "bun run src/cli.ts mcp",
+    "check": "tsc --noEmit",
+    "build": "bun build src/cli.ts --target bun --outfile dist/cli.js",
+    "prepack": "bun run build"
   },
   "devDependencies": {
+    "bun-types": "^1.3.0",
     "typescript": "^5.5.0"
   }
 }

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+
+import { runGuaMcpServer } from "./index.js";
+
+const command = Bun.argv[2] ?? "mcp";
+
+if (command === "mcp") {
+  await runGuaMcpServer().catch((error) => {
+    process.stderr.write(`[gui-mcp] error: ${(error as Error).message}\n`);
+    process.exitCode = 1;
+  });
+} else if (command === "--help" || command === "-h" || command === "help") {
+  process.stdout.write(`Usage:
+  gui-mcp mcp
+
+Environment:
+  GUA_BRIDGE_URL  WebSocket URL for the Gua runtime bridge. Defaults to ws://127.0.0.1:8765.
+`);
+} else {
+  process.stderr.write(`[gui-mcp] error: unknown command: ${command}\n`);
+  process.stderr.write("Run `gui-mcp --help` for usage.\n");
+  process.exitCode = 1;
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,3 +1,92 @@
+type JsonRpcId = string | number | null;
+
+interface JsonRpcRequest {
+  jsonrpc?: "2.0";
+  id?: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  result?: unknown;
+  error?: JsonRpcError;
+}
+
+interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+interface GuaBounds {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+interface GuaNodeState {
+  focused?: boolean;
+  hovered?: boolean;
+  pressed?: boolean;
+  checked?: boolean;
+  value?: number | string | boolean | null;
+}
+
+interface GuaNode {
+  id: string;
+  parentId?: string;
+  role: string;
+  label?: string;
+  visible: boolean;
+  enabled: boolean;
+  bounds: GuaBounds;
+  state?: GuaNodeState;
+  actions: string[];
+}
+
+interface GuaUiTree {
+  screen: string;
+  nodes: GuaNode[];
+}
+
+interface GuaLogEntry {
+  sequence: number;
+  level: "trace" | "debug" | "info" | "warn" | "error";
+  message: string;
+}
+
+interface GuaScreenshot {
+  dataUri: string;
+  width: number;
+  height: number;
+}
+
+type GuaBridgeResponse =
+  | { id: number; ok: true; result: BridgeResult }
+  | { id: number; ok: false; error: string };
+
+interface McpTool {
+  name: GuaMcpTool;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+type BridgeResult = GuaUiTree | GuaLogEntry[] | GuaScreenshot | null;
+
+export interface GuaMcpServerOptions {
+  bridgeUrl?: string;
+}
+
+const defaultBridgeUrl = "ws://127.0.0.1:8765";
+
 export const guaMcpTools = [
   "get_ui_tree",
   "click_node",
@@ -9,3 +98,563 @@ export const guaMcpTools = [
 ] as const;
 
 export type GuaMcpTool = (typeof guaMcpTools)[number];
+
+const tools: McpTool[] = [
+  {
+    name: "get_ui_tree",
+    description: "Read the current Gua semantic UI tree from the running game bridge.",
+    inputSchema: objectSchema({}),
+  },
+  {
+    name: "click_node",
+    description: "Send a click command for a visible semantic UI node.",
+    inputSchema: objectSchema({
+      nodeId: stringProperty("The target Gua node id."),
+    }, ["nodeId"]),
+  },
+  {
+    name: "press_key",
+    description: "Send a key press command through the Gua bridge when the bridge supports it.",
+    inputSchema: objectSchema({
+      key: stringProperty("The logical key name to press, such as Enter or Escape."),
+    }, ["key"]),
+  },
+  {
+    name: "wait_for_node",
+    description: "Poll the UI tree until a node id appears or the timeout expires.",
+    inputSchema: objectSchema({
+      nodeId: stringProperty("The target Gua node id."),
+      timeoutMs: {
+        type: "integer",
+        minimum: 0,
+        description: "Maximum wait time in milliseconds. Defaults to 5000.",
+      },
+    }, ["nodeId"]),
+  },
+  {
+    name: "get_screenshot",
+    description: "Read the latest Gua screenshot payload from the running game bridge.",
+    inputSchema: objectSchema({}),
+  },
+  {
+    name: "get_logs",
+    description: "Read ordered runtime logs from the running game bridge.",
+    inputSchema: objectSchema({}),
+  },
+  {
+    name: "run_test",
+    description: "Run a small protocol-level UI test made of wait and click steps.",
+    inputSchema: objectSchema({
+      steps: {
+        type: "array",
+        minItems: 1,
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["action", "nodeId"],
+          properties: {
+            action: {
+              type: "string",
+              enum: ["wait_for_node", "click_node"],
+            },
+            nodeId: stringProperty("The target Gua node id."),
+            timeoutMs: {
+              type: "integer",
+              minimum: 0,
+            },
+          },
+        },
+      },
+    }, ["steps"]),
+  },
+];
+
+export async function runGuaMcpServer(options: GuaMcpServerOptions = {}): Promise<void> {
+  const bridgeUrl = options.bridgeUrl ?? Bun.env.GUA_BRIDGE_URL ?? defaultBridgeUrl;
+  const bridge = new GuaBridgeClient(bridgeUrl);
+
+  writeLog("info", `Gua MCP server connecting to ${bridgeUrl}`);
+
+  let pending = "";
+  const decoder = new TextDecoder();
+  try {
+    for await (const chunk of Bun.stdin.stream()) {
+      pending += decoder.decode(chunk, { stream: true });
+      pending = await drainPendingLines(pending, bridge);
+    }
+
+    pending += decoder.decode();
+    const finalLine = pending.trim();
+    if (finalLine.length > 0) {
+      await handleLine(finalLine, bridge);
+    }
+  } finally {
+    bridge.close();
+  }
+}
+
+async function drainPendingLines(input: string, bridge: GuaBridgeClient): Promise<string> {
+  let pending = input;
+  while (true) {
+    const newlineIndex = pending.indexOf("\n");
+    if (newlineIndex < 0) {
+      return pending;
+    }
+
+    const line = pending.slice(0, newlineIndex).trim();
+    pending = pending.slice(newlineIndex + 1);
+
+    if (line.length === 0) {
+      continue;
+    }
+
+    await handleLine(line, bridge);
+  }
+}
+
+async function handleLine(line: string, bridge: GuaBridgeClient): Promise<void> {
+  let request: unknown;
+  try {
+    request = JSON.parse(line) as JsonRpcRequest;
+  } catch (error) {
+    writeResponse({
+      jsonrpc: "2.0",
+      id: null,
+      error: jsonRpcError(-32700, `Invalid JSON: ${(error as Error).message}`),
+    });
+    return;
+  }
+
+  if (!isJsonRpcRequest(request)) {
+    writeResponse({
+      jsonrpc: "2.0",
+      id: isRecord(request) && isJsonRpcId(request.id) ? request.id : null,
+      error: jsonRpcError(-32600, "Invalid JSON-RPC request."),
+    });
+    return;
+  }
+
+  if (request.id === undefined) {
+    await handleNotification(request);
+    return;
+  }
+
+  try {
+    writeResponse({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: await handleRequest(request, bridge),
+    });
+  } catch (error) {
+    writeResponse({
+      jsonrpc: "2.0",
+      id: request.id,
+      error: toJsonRpcError(error),
+    });
+  }
+}
+
+async function handleNotification(request: JsonRpcRequest): Promise<void> {
+  if (request.method === "notifications/cancelled") {
+    return;
+  }
+
+  if (request.method === "notifications/initialized") {
+    return;
+  }
+}
+
+async function handleRequest(request: JsonRpcRequest, bridge: GuaBridgeClient): Promise<unknown> {
+  switch (request.method) {
+    case "initialize":
+      return {
+        protocolVersion: "2024-11-05",
+        capabilities: {
+          tools: {},
+        },
+        serverInfo: {
+          name: "gui-mcp",
+          version: "0.0.0",
+        },
+      };
+    case "ping":
+      return {};
+    case "tools/list":
+      return { tools };
+    case "tools/call":
+      return callTool(request.params, bridge);
+    default:
+      throw new RpcFailure(-32601, `Unsupported MCP method: ${request.method}`);
+  }
+}
+
+async function callTool(params: unknown, bridge: GuaBridgeClient): Promise<ToolResult> {
+  if (!isRecord(params) || typeof params.name !== "string") {
+    throw new RpcFailure(-32602, "tools/call requires a tool name.");
+  }
+
+  const name = params.name;
+  if (!isGuaMcpTool(name)) {
+    throw new RpcFailure(-32602, `Unknown Gua MCP tool: ${name}`);
+  }
+
+  try {
+    const result = await executeTool(name, isRecord(params.arguments) ? params.arguments : {}, bridge);
+    return textResult(result);
+  } catch (error) {
+    return textResult({ error: (error as Error).message }, true);
+  }
+}
+
+async function executeTool(name: GuaMcpTool, args: Record<string, unknown>, bridge: GuaBridgeClient): Promise<unknown> {
+  switch (name) {
+    case "get_ui_tree":
+      return bridge.getUiTree();
+    case "click_node":
+      await bridge.clickNode(readStringArg(args, "nodeId"));
+      return { ok: true };
+    case "press_key":
+      await bridge.pressKey(readStringArg(args, "key"));
+      return { ok: true };
+    case "wait_for_node":
+      return bridge.waitForNode(
+        readStringArg(args, "nodeId"),
+        readIntegerArg(args, "timeoutMs", 5000),
+      );
+    case "get_screenshot":
+      return bridge.getScreenshot();
+    case "get_logs":
+      return bridge.getLogs();
+    case "run_test":
+      return runTest(readTestSteps(args), bridge);
+  }
+}
+
+async function runTest(steps: TestStep[], bridge: GuaBridgeClient): Promise<{ ok: true; steps: TestStepResult[] }> {
+  const results: TestStepResult[] = [];
+
+  for (const [index, step] of steps.entries()) {
+    if (step.action === "wait_for_node") {
+      await bridge.waitForNode(step.nodeId, step.timeoutMs ?? 5000);
+    } else {
+      await bridge.clickNode(step.nodeId);
+    }
+
+    results.push({
+      index,
+      action: step.action,
+      nodeId: step.nodeId,
+      ok: true,
+    });
+  }
+
+  return { ok: true, steps: results };
+}
+
+class GuaBridgeClient {
+  private socket: WebSocket | null = null;
+  private connectPromise: Promise<WebSocket> | null = null;
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+
+  constructor(
+    private readonly url: string,
+    private readonly requestTimeoutMs = 5000,
+  ) {
+  }
+
+  async getUiTree(): Promise<GuaUiTree> {
+    return this.request<GuaUiTree>({ type: "get_ui_tree" });
+  }
+
+  async getLogs(): Promise<GuaLogEntry[]> {
+    return this.request<GuaLogEntry[]>({ type: "get_logs" });
+  }
+
+  async getScreenshot(): Promise<GuaScreenshot> {
+    return this.request<GuaScreenshot>({ type: "get_screenshot" });
+  }
+
+  async clickNode(nodeId: string): Promise<void> {
+    await this.request<null>({ type: "click_node", nodeId });
+  }
+
+  async pressKey(key: string): Promise<void> {
+    await this.request<null>({ type: "press_key", key });
+  }
+
+  async waitForNode(nodeId: string, timeoutMs: number): Promise<{ ok: true; node: GuaNode }> {
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt <= timeoutMs) {
+      const tree = await this.getUiTree();
+      const node = tree.nodes.find((candidate) => candidate.id === nodeId);
+      if (node !== undefined) {
+        return { ok: true, node };
+      }
+
+      await sleep(50);
+    }
+
+    throw new Error(`Timed out waiting for Gua node: ${nodeId}`);
+  }
+
+  close(): void {
+    this.rejectAll(new Error("Gua MCP bridge client closed."));
+    this.socket?.close();
+    this.socket = null;
+    this.connectPromise = null;
+  }
+
+  private async request<T>(command: BridgeCommandInput): Promise<T> {
+    const socket = await this.connect();
+    const id = this.nextId++;
+    const payload = { ...command, id } as BridgeCommand;
+
+    return new Promise<T>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Timed out waiting for Gua bridge command: ${command.type}`));
+      }, this.requestTimeoutMs);
+
+      this.pending.set(id, {
+        resolve: (value) => resolve(value as T),
+        reject,
+        timeoutId,
+      });
+
+      socket.send(JSON.stringify(payload));
+    });
+  }
+
+  private async connect(): Promise<WebSocket> {
+    if (this.socket !== null && this.socket.readyState === WebSocket.OPEN) {
+      return this.socket;
+    }
+
+    if (this.connectPromise !== null) {
+      return this.connectPromise;
+    }
+
+    this.connectPromise = new Promise<WebSocket>((resolve, reject) => {
+      const socket = new WebSocket(this.url);
+
+      socket.addEventListener("open", () => {
+        this.socket = socket;
+        this.connectPromise = null;
+        resolve(socket);
+      });
+
+      socket.addEventListener("message", (event) => {
+        this.handleMessage(event.data);
+      });
+
+      socket.addEventListener("close", () => {
+        this.socket = null;
+        this.connectPromise = null;
+        this.rejectAll(new Error("Gua bridge WebSocket connection closed."));
+      });
+
+      socket.addEventListener("error", () => {
+        const error = new Error(`Failed to connect to Gua bridge at ${this.url}.`);
+        this.connectPromise = null;
+        reject(error);
+        this.rejectAll(error);
+      });
+    });
+
+    return this.connectPromise;
+  }
+
+  private handleMessage(data: unknown): void {
+    if (typeof data !== "string") {
+      return;
+    }
+
+    let response: GuaBridgeResponse;
+    try {
+      response = JSON.parse(data) as GuaBridgeResponse;
+    } catch {
+      return;
+    }
+
+    if (!("id" in response)) {
+      return;
+    }
+
+    const pending = this.pending.get(response.id);
+    if (pending === undefined) {
+      return;
+    }
+
+    clearTimeout(pending.timeoutId);
+    this.pending.delete(response.id);
+
+    if (response.ok) {
+      pending.resolve(response.result);
+    } else {
+      pending.reject(new Error(response.error));
+    }
+  }
+
+  private rejectAll(error: Error): void {
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timeoutId);
+      pending.reject(error);
+      this.pending.delete(id);
+    }
+  }
+}
+
+type BridgeCommandInput =
+  | { type: "get_ui_tree" }
+  | { type: "get_logs" }
+  | { type: "get_screenshot" }
+  | { type: "click_node"; nodeId: string }
+  | { type: "press_key"; key: string };
+
+type BridgeCommand = BridgeCommandInput & { id: number };
+
+interface PendingRequest {
+  resolve(value: BridgeResult): void;
+  reject(reason: Error): void;
+  timeoutId: ReturnType<typeof setTimeout>;
+}
+
+interface TestStep {
+  action: "wait_for_node" | "click_node";
+  nodeId: string;
+  timeoutMs?: number;
+}
+
+interface TestStepResult {
+  index: number;
+  action: TestStep["action"];
+  nodeId: string;
+  ok: true;
+}
+
+function readTestSteps(args: Record<string, unknown>): TestStep[] {
+  if (!Array.isArray(args.steps) || args.steps.length === 0) {
+    throw new Error("run_test requires at least one step.");
+  }
+
+  return args.steps.map((step, index) => {
+    if (!isRecord(step)) {
+      throw new Error(`run_test step ${index} must be an object.`);
+    }
+
+    if (step.action !== "wait_for_node" && step.action !== "click_node") {
+      throw new Error(`run_test step ${index} has unsupported action.`);
+    }
+
+    return {
+      action: step.action,
+      nodeId: readStringArg(step, "nodeId"),
+      timeoutMs: readIntegerArg(step, "timeoutMs", 5000),
+    };
+  });
+}
+
+function readStringArg(args: Record<string, unknown>, name: string): string {
+  const value = args[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Expected non-empty string argument: ${name}`);
+  }
+
+  return value;
+}
+
+function readIntegerArg(args: Record<string, unknown>, name: string, fallback: number): number {
+  const value = args[name];
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`Expected non-negative integer argument: ${name}`);
+  }
+
+  return value;
+}
+
+function textResult(value: unknown, isError = false): ToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: typeof value === "string" ? value : JSON.stringify(value, null, 2),
+      },
+    ],
+    isError,
+  };
+}
+
+function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
+  return isRecord(value) && typeof value.method === "string";
+}
+
+function isJsonRpcId(value: unknown): value is JsonRpcId {
+  return typeof value === "string" || typeof value === "number" || value === null;
+}
+
+function isGuaMcpTool(value: string): value is GuaMcpTool {
+  return (guaMcpTools as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function objectSchema(
+  properties: Record<string, unknown>,
+  required: string[] = [],
+): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties,
+    required,
+  };
+}
+
+function stringProperty(description: string): Record<string, unknown> {
+  return {
+    type: "string",
+    minLength: 1,
+    description,
+  };
+}
+
+function writeResponse(response: JsonRpcResponse): void {
+  process.stdout.write(`${JSON.stringify(response)}\n`);
+}
+
+function writeLog(level: "info" | "error", message: string): void {
+  process.stderr.write(`[gui-mcp] ${level}: ${message}\n`);
+}
+
+function jsonRpcError(code: number, message: string, data?: unknown): JsonRpcError {
+  return { code, message, data };
+}
+
+function toJsonRpcError(error: unknown): JsonRpcError {
+  if (error instanceof RpcFailure) {
+    return jsonRpcError(error.code, error.message);
+  }
+
+  return jsonRpcError(-32603, (error as Error).message);
+}
+
+class RpcFailure extends Error {
+  constructor(
+    readonly code: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["bun-types"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -71,6 +71,27 @@ as authoritative runtime updates and refresh the visible panels immediately.
 }
 ```
 
+## MCP Tools
+
+The v0.4 MCP server is a protocol consumer. It does not own runtime state and it
+does not replace the Inspector bridge. By default it connects to the same Gua
+WebSocket bridge at `ws://127.0.0.1:8765`; set `GUA_BRIDGE_URL` to target another
+runtime adapter. The npm-ready CLI entrypoint is `gui-mcp mcp`, so a published
+package can be launched with `bunx gui-mcp@latest mcp`.
+
+Initial MCP tools:
+
+- `get_ui_tree`: returns the current semantic UI tree
+- `click_node`: sends a click command for a node id
+- `press_key`: sends a key command when the connected bridge supports it
+- `wait_for_node`: polls `get_ui_tree` until a node id appears
+- `get_screenshot`: returns the latest screenshot payload
+- `get_logs`: returns ordered runtime logs
+- `run_test`: executes a small list of `wait_for_node` and `click_node` steps
+
+The MCP server uses stdio JSON-RPC for MCP clients and the existing Gua
+request/response WebSocket payloads for the runtime side.
+
 ## Events
 
 Events are queued by the runtime core when commands should be observed by the


### PR DESCRIPTION
## Summary
- WebSocketブリッジのWin32実装とC++ヘッダを整理し、`native-bridge` と `cpp-imgui` の例を更新
- `bridge-ws`、`inspector`、`mcp` の各パッケージを接続し直し、CLI と公開エントリを整備
- `protocol/specs/protocol.md` と README を更新し、プロトコル記述と利用導線を合わせた
- `bun.lock` と `package.json` を同期して依存関係を更新

## Testing
- 実行はしていません（依頼なし）
- 変更範囲の整合性は、プロトコル仕様・ブリッジ・Inspector/MCP の更新内容を通して確認