### PR TITLE
C ABI の JSON 取得をコピー型 API に切り替え、Inspector の送信競合を防止

### DIFF
--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -47,7 +47,7 @@ public sealed class GuaContext : IDisposable
     public string GetUiTreeJson()
     {
         ThrowIfDisposed();
-        return ReadNativeUtf8(Native.gua_get_ui_tree_json(_handle));
+        return ReadCopiedJson(JsonSource.UiTree, _handle);
     }
 
     public void AddLog(GuaLogLevel level, string message)
@@ -59,7 +59,7 @@ public sealed class GuaContext : IDisposable
     public string GetLogsJson()
     {
         ThrowIfDisposed();
-        return ReadNativeUtf8(Native.gua_get_logs_json(_handle));
+        return ReadCopiedJson(JsonSource.Logs, _handle);
     }
 
     public void SetScreenshot(string dataUri, int width, int height)
@@ -71,7 +71,7 @@ public sealed class GuaContext : IDisposable
     public string GetScreenshotJson()
     {
         ThrowIfDisposed();
-        return ReadNativeUtf8(Native.gua_get_screenshot_json(_handle));
+        return ReadCopiedJson(JsonSource.Screenshot, _handle);
     }
 
     public GuaNodeState GetNodeState(string id)
@@ -188,9 +188,51 @@ public sealed class GuaContext : IDisposable
             ?? throw new InvalidOperationException("Native Gua returned an invalid event node id.");
     }
 
-    private static string ReadNativeUtf8(nint value)
+    private static unsafe string ReadCopiedJson(JsonSource source, nint handle)
     {
-        return System.Runtime.InteropServices.Marshal.PtrToStringUTF8(value)
-            ?? throw new InvalidOperationException("Native Gua returned an invalid UTF-8 string.");
+        var requiredSize = CopyJson(source, handle, null, 0);
+        if (requiredSize <= 0)
+        {
+            throw new InvalidOperationException("Native Gua returned an invalid JSON size.");
+        }
+
+        while (true)
+        {
+            var buffer = new byte[requiredSize];
+            fixed (byte* bufferPointer = buffer)
+            {
+                var actualSize = CopyJson(source, handle, bufferPointer, buffer.Length);
+                if (actualSize <= 0)
+                {
+                    throw new InvalidOperationException("Native Gua returned an invalid JSON size.");
+                }
+
+                if (actualSize <= buffer.Length)
+                {
+                    return System.Runtime.InteropServices.Marshal.PtrToStringUTF8((nint)bufferPointer)
+                        ?? throw new InvalidOperationException("Native Gua returned an invalid UTF-8 string.");
+                }
+
+                requiredSize = actualSize;
+            }
+        }
+    }
+
+    private static unsafe int CopyJson(JsonSource source, nint handle, byte* buffer, int bufferSize)
+    {
+        return source switch
+        {
+            JsonSource.UiTree => Native.gua_copy_ui_tree_json(handle, buffer, bufferSize),
+            JsonSource.Logs => Native.gua_copy_logs_json(handle, buffer, bufferSize),
+            JsonSource.Screenshot => Native.gua_copy_screenshot_json(handle, buffer, bufferSize),
+            _ => throw new ArgumentOutOfRangeException(nameof(source), source, null),
+        };
+    }
+
+    private enum JsonSource
+    {
+        UiTree,
+        Logs,
+        Screenshot,
     }
 }

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -93,17 +93,26 @@ internal static partial class Native
     [LibraryImport("gua")]
     internal static partial nint gua_get_ui_tree_json(nint context);
 
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_copy_ui_tree_json(nint context, byte* outJson, int outJsonSize);
+
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial void gua_add_log(nint context, int level, string message);
 
     [LibraryImport("gua")]
     internal static partial nint gua_get_logs_json(nint context);
 
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_copy_logs_json(nint context, byte* outJson, int outJsonSize);
+
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial void gua_set_screenshot(nint context, string dataUri, int width, int height);
 
     [LibraryImport("gua")]
     internal static partial nint gua_get_screenshot_json(nint context);
+
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_copy_screenshot_json(nint context, byte* outJson, int outJsonSize);
 
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int gua_get_node_state(nint context, string nodeId, out GuaNodeState state);

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -54,10 +54,16 @@ void gua_register_node(
 );
 
 const char* gua_get_ui_tree_json(gua_context_t* ctx);
+/* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
+int gua_copy_ui_tree_json(gua_context_t* ctx, char* out_json, int out_json_size);
 void gua_add_log(gua_context_t* ctx, int level, const char* message);
 const char* gua_get_logs_json(gua_context_t* ctx);
+/* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
+int gua_copy_logs_json(gua_context_t* ctx, char* out_json, int out_json_size);
 void gua_set_screenshot(gua_context_t* ctx, const char* data_uri, int width, int height);
 const char* gua_get_screenshot_json(gua_context_t* ctx);
+/* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
+int gua_copy_screenshot_json(gua_context_t* ctx, char* out_json, int out_json_size);
 int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state);
 int gua_find_node_by_id(gua_context_t* ctx, const char* node_id, char* out_node_id, int out_node_id_size);
 int gua_find_node_by_role(gua_context_t* ctx, const char* role, const char* name, char* out_node_id, int out_node_id_size);

--- a/native/gua-core/include/gua/gua.hpp
+++ b/native/gua-core/include/gua/gua.hpp
@@ -122,7 +122,7 @@ public:
 
     [[nodiscard]] std::string ui_tree_json() const
     {
-        return gua_get_ui_tree_json(context_);
+        return copy_json(gua_copy_ui_tree_json);
     }
 
     void log(LogLevel level, std::string_view message)
@@ -133,7 +133,7 @@ public:
 
     [[nodiscard]] std::string logs_json() const
     {
-        return gua_get_logs_json(context_);
+        return copy_json(gua_copy_logs_json);
     }
 
     void set_screenshot(std::string_view data_uri, int width, int height)
@@ -144,7 +144,7 @@ public:
 
     [[nodiscard]] std::string screenshot_json() const
     {
-        return gua_get_screenshot_json(context_);
+        return copy_json(gua_copy_screenshot_json);
     }
 
     [[nodiscard]] bool enqueue_click(std::string_view node_id)
@@ -166,6 +166,28 @@ public:
     }
 
 private:
+    template <typename CopyJson>
+    [[nodiscard]] std::string copy_json(CopyJson copy) const
+    {
+        int required_size = copy(context_, nullptr, 0);
+        if (required_size <= 0) {
+            throw std::runtime_error("Failed to copy Gua JSON");
+        }
+
+        for (;;) {
+            std::string json(static_cast<std::size_t>(required_size), '\0');
+            const int actual_size = copy(context_, json.data(), static_cast<int>(json.size()));
+            if (actual_size <= 0) {
+                throw std::runtime_error("Failed to copy Gua JSON");
+            }
+            if (actual_size <= static_cast<int>(json.size())) {
+                json.resize(static_cast<std::size_t>(actual_size - 1));
+                return json;
+            }
+            required_size = actual_size;
+        }
+    }
+
     void reset() noexcept
     {
         gua_destroy_context(context_);

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -5,6 +5,7 @@
 #include <deque>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -97,6 +98,7 @@ int write_node_id(const std::string& node_id, char* out_node_id, int out_node_id
 } // namespace
 
 struct gua_context_t {
+    mutable std::mutex mutex;
     std::string screen = "unknown";
     std::vector<Node> nodes;
     std::deque<Event> events;
@@ -108,68 +110,23 @@ struct gua_context_t {
     std::string screenshot_json_cache;
 };
 
-extern "C" gua_context_t* gua_create_context(void)
-{
-    return new gua_context_t();
-}
+namespace {
 
-extern "C" void gua_destroy_context(gua_context_t* ctx)
+int copy_json_string(const std::string& json, char* out_json, int out_json_size)
 {
-    delete ctx;
-}
-
-extern "C" void gua_begin_frame(gua_context_t* ctx, const char* screen)
-{
-    if (ctx == nullptr) {
-        return;
+    const int required_size = static_cast<int>(json.size() + 1U);
+    if (out_json != nullptr && out_json_size > 0) {
+        std::snprintf(out_json, static_cast<std::size_t>(out_json_size), "%s", json.c_str());
     }
-
-    ctx->screen = screen != nullptr ? screen : "unknown";
-    ctx->nodes.clear();
+    return required_size;
 }
 
-extern "C" void gua_end_frame(gua_context_t* ctx)
+std::string build_ui_tree_json(const gua_context_t& ctx)
 {
-    if (ctx == nullptr) {
-        return;
-    }
+    std::string json = "{\"screen\":\"" + escape_json(ctx.screen) + "\",\"nodes\":[";
 
-    ctx->json_cache.clear();
-}
-
-extern "C" void gua_register_node(
-    gua_context_t* ctx,
-    const char* id,
-    const char* role,
-    const char* label,
-    gua_bounds_t bounds,
-    int visible,
-    int enabled)
-{
-    if (ctx == nullptr || id == nullptr || role == nullptr) {
-        return;
-    }
-
-    ctx->nodes.push_back(Node {
-        id,
-        role,
-        label != nullptr ? label : "",
-        bounds,
-        visible != 0,
-        enabled != 0,
-    });
-}
-
-extern "C" const char* gua_get_ui_tree_json(gua_context_t* ctx)
-{
-    if (ctx == nullptr) {
-        return "{}";
-    }
-
-    std::string json = "{\"screen\":\"" + escape_json(ctx->screen) + "\",\"nodes\":[";
-
-    for (std::size_t i = 0; i < ctx->nodes.size(); ++i) {
-        const Node& node = ctx->nodes[i];
+    for (std::size_t i = 0; i < ctx.nodes.size(); ++i) {
+        const Node& node = ctx.nodes[i];
         if (i > 0) {
             json += ",";
         }
@@ -201,8 +158,118 @@ extern "C" const char* gua_get_ui_tree_json(gua_context_t* ctx)
     }
 
     json += "]}";
-    ctx->json_cache = std::move(json);
+    return json;
+}
+
+std::string build_logs_json(const gua_context_t& ctx)
+{
+    std::string json = "[";
+    for (std::size_t i = 0; i < ctx.logs.size(); ++i) {
+        const LogEntry& entry = ctx.logs[i];
+        if (i > 0) {
+            json += ",";
+        }
+
+        json += "{\"sequence\":";
+        json += std::to_string(entry.sequence);
+        json += ",\"level\":\"";
+        json += log_level_name(entry.level);
+        json += "\",\"message\":\"";
+        json += escape_json(entry.message);
+        json += "\"}";
+    }
+    json += "]";
+    return json;
+}
+
+std::string build_screenshot_json(const gua_context_t& ctx)
+{
+    std::string json = "{\"dataUri\":\"";
+    json += escape_json(ctx.screenshot.data_uri);
+    json += "\",\"width\":";
+    json += std::to_string(ctx.screenshot.width);
+    json += ",\"height\":";
+    json += std::to_string(ctx.screenshot.height);
+    json += "}";
+    return json;
+}
+
+} // namespace
+
+extern "C" gua_context_t* gua_create_context(void)
+{
+    return new gua_context_t();
+}
+
+extern "C" void gua_destroy_context(gua_context_t* ctx)
+{
+    delete ctx;
+}
+
+extern "C" void gua_begin_frame(gua_context_t* ctx, const char* screen)
+{
+    if (ctx == nullptr) {
+        return;
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    ctx->screen = screen != nullptr ? screen : "unknown";
+    ctx->nodes.clear();
+}
+
+extern "C" void gua_end_frame(gua_context_t* ctx)
+{
+    if (ctx == nullptr) {
+        return;
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    ctx->json_cache.clear();
+}
+
+extern "C" void gua_register_node(
+    gua_context_t* ctx,
+    const char* id,
+    const char* role,
+    const char* label,
+    gua_bounds_t bounds,
+    int visible,
+    int enabled)
+{
+    if (ctx == nullptr || id == nullptr || role == nullptr) {
+        return;
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    ctx->nodes.push_back(Node {
+        id,
+        role,
+        label != nullptr ? label : "",
+        bounds,
+        visible != 0,
+        enabled != 0,
+    });
+}
+
+extern "C" const char* gua_get_ui_tree_json(gua_context_t* ctx)
+{
+    if (ctx == nullptr) {
+        return "{}";
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    ctx->json_cache = build_ui_tree_json(*ctx);
     return ctx->json_cache.c_str();
+}
+
+extern "C" int gua_copy_ui_tree_json(gua_context_t* ctx, char* out_json, int out_json_size)
+{
+    if (ctx == nullptr) {
+        return copy_json_string("{}", out_json, out_json_size);
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    return copy_json_string(build_ui_tree_json(*ctx), out_json, out_json_size);
 }
 
 extern "C" void gua_add_log(gua_context_t* ctx, int level, const char* message)
@@ -211,6 +278,7 @@ extern "C" void gua_add_log(gua_context_t* ctx, int level, const char* message)
         return;
     }
 
+    const std::lock_guard lock(ctx->mutex);
     ctx->logs.push_back(LogEntry {
         level,
         message,
@@ -225,25 +293,19 @@ extern "C" const char* gua_get_logs_json(gua_context_t* ctx)
         return "[]";
     }
 
-    std::string json = "[";
-    for (std::size_t i = 0; i < ctx->logs.size(); ++i) {
-        const LogEntry& entry = ctx->logs[i];
-        if (i > 0) {
-            json += ",";
-        }
-
-        json += "{\"sequence\":";
-        json += std::to_string(entry.sequence);
-        json += ",\"level\":\"";
-        json += log_level_name(entry.level);
-        json += "\",\"message\":\"";
-        json += escape_json(entry.message);
-        json += "\"}";
-    }
-    json += "]";
-
-    ctx->logs_json_cache = std::move(json);
+    const std::lock_guard lock(ctx->mutex);
+    ctx->logs_json_cache = build_logs_json(*ctx);
     return ctx->logs_json_cache.c_str();
+}
+
+extern "C" int gua_copy_logs_json(gua_context_t* ctx, char* out_json, int out_json_size)
+{
+    if (ctx == nullptr) {
+        return copy_json_string("[]", out_json, out_json_size);
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    return copy_json_string(build_logs_json(*ctx), out_json, out_json_size);
 }
 
 extern "C" void gua_set_screenshot(gua_context_t* ctx, const char* data_uri, int width, int height)
@@ -252,6 +314,7 @@ extern "C" void gua_set_screenshot(gua_context_t* ctx, const char* data_uri, int
         return;
     }
 
+    const std::lock_guard lock(ctx->mutex);
     ctx->screenshot.data_uri = data_uri != nullptr ? data_uri : "";
     ctx->screenshot.width = std::max(0, width);
     ctx->screenshot.height = std::max(0, height);
@@ -264,16 +327,19 @@ extern "C" const char* gua_get_screenshot_json(gua_context_t* ctx)
         return "{\"dataUri\":\"\",\"width\":0,\"height\":0}";
     }
 
-    std::string json = "{\"dataUri\":\"";
-    json += escape_json(ctx->screenshot.data_uri);
-    json += "\",\"width\":";
-    json += std::to_string(ctx->screenshot.width);
-    json += ",\"height\":";
-    json += std::to_string(ctx->screenshot.height);
-    json += "}";
-
-    ctx->screenshot_json_cache = std::move(json);
+    const std::lock_guard lock(ctx->mutex);
+    ctx->screenshot_json_cache = build_screenshot_json(*ctx);
     return ctx->screenshot_json_cache.c_str();
+}
+
+extern "C" int gua_copy_screenshot_json(gua_context_t* ctx, char* out_json, int out_json_size)
+{
+    if (ctx == nullptr) {
+        return copy_json_string("{\"dataUri\":\"\",\"width\":0,\"height\":0}", out_json, out_json_size);
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    return copy_json_string(build_screenshot_json(*ctx), out_json, out_json_size);
 }
 
 extern "C" int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state)
@@ -282,6 +348,7 @@ extern "C" int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_n
         return 0;
     }
 
+    const std::lock_guard lock(ctx->mutex);
     const auto found = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
         return node.id == node_id;
     });
@@ -300,6 +367,7 @@ extern "C" int gua_find_node_by_id(gua_context_t* ctx, const char* node_id, char
         return 0;
     }
 
+    const std::lock_guard lock(ctx->mutex);
     const auto found = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
         return node.id == node_id;
     });
@@ -316,6 +384,7 @@ extern "C" int gua_find_node_by_role(gua_context_t* ctx, const char* role, const
         return 0;
     }
 
+    const std::lock_guard lock(ctx->mutex);
     const auto found = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
         if (node.role != role) {
             return false;
@@ -336,6 +405,7 @@ extern "C" int gua_find_node_by_text(gua_context_t* ctx, const char* text, char*
         return 0;
     }
 
+    const std::lock_guard lock(ctx->mutex);
     const auto found = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
         return node.label == text;
     });
@@ -352,6 +422,7 @@ extern "C" int gua_enqueue_click(gua_context_t* ctx, const char* node_id)
         return 0;
     }
 
+    const std::lock_guard lock(ctx->mutex);
     const auto found = std::any_of(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
         return node.id == node_id && node.visible && node.enabled;
     });
@@ -365,7 +436,12 @@ extern "C" int gua_enqueue_click(gua_context_t* ctx, const char* node_id)
 
 extern "C" int gua_poll_event(gua_context_t* ctx, gua_event_t* out_event)
 {
-    if (ctx == nullptr || out_event == nullptr || ctx->events.empty()) {
+    if (ctx == nullptr || out_event == nullptr) {
+        return 0;
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    if (ctx->events.empty()) {
         return 0;
     }
 

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -1,6 +1,10 @@
 #include "gua/godot/gua_context.hpp"
 
 #include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include <string>
+#include <vector>
 
 namespace {
 
@@ -17,6 +21,26 @@ const char* event_type_name(int type)
     }
 }
 
+godot::String copy_runtime_json(gua_runtime_t* runtime, int (*copy_json)(gua_runtime_t*, char*, int))
+{
+    int required_size = copy_json(runtime, nullptr, 0);
+    if (required_size <= 0) {
+        return godot::String();
+    }
+
+    for (;;) {
+        std::vector<char> buffer(static_cast<std::size_t>(required_size));
+        const int actual_size = copy_json(runtime, buffer.data(), static_cast<int>(buffer.size()));
+        if (actual_size <= 0) {
+            return godot::String();
+        }
+        if (actual_size <= static_cast<int>(buffer.size())) {
+            return godot::String::utf8(buffer.data());
+        }
+        required_size = actual_size;
+    }
+}
+
 } // namespace
 
 namespace godot {
@@ -24,6 +48,10 @@ namespace godot {
 GuaContext::GuaContext()
     : runtime_(gua_runtime_create())
 {
+    if (runtime_ == nullptr) {
+        UtilityFunctions::push_error(
+            "GuaContext failed to create a Gua runtime. Check that the Gua native library and dependent DLLs are available.");
+    }
 }
 
 GuaContext::~GuaContext()
@@ -72,7 +100,7 @@ void GuaContext::register_node(
 
 String GuaContext::get_ui_tree_json() const
 {
-    return String::utf8(gua_runtime_get_ui_tree_json(runtime_));
+    return copy_runtime_json(runtime_, gua_runtime_copy_ui_tree_json);
 }
 
 bool GuaContext::enqueue_click(const String& node_id)

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -24,10 +24,16 @@ void gua_runtime_register_node(
 );
 
 const char* gua_runtime_get_ui_tree_json(gua_runtime_t* runtime);
+/* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
+int gua_runtime_copy_ui_tree_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
 void gua_runtime_add_log(gua_runtime_t* runtime, int level, const char* message);
 const char* gua_runtime_get_logs_json(gua_runtime_t* runtime);
+/* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
+int gua_runtime_copy_logs_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
 void gua_runtime_set_screenshot(gua_runtime_t* runtime, const char* data_uri, int width, int height);
 const char* gua_runtime_get_screenshot_json(gua_runtime_t* runtime);
+/* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
+int gua_runtime_copy_screenshot_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
 int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* node_id, gua_node_state_t* out_state);
 int gua_runtime_find_node_by_id(gua_runtime_t* runtime, const char* node_id, char* out_node_id, int out_node_id_size);
 int gua_runtime_find_node_by_role(gua_runtime_t* runtime, const char* role, const char* name, char* out_node_id, int out_node_id_size);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -2,6 +2,7 @@
 
 #include "gua/ws_bridge.hpp"
 
+#include <cstdio>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -25,6 +26,15 @@ namespace {
 bool valid_runtime(gua_runtime_t* runtime)
 {
     return runtime != nullptr && runtime->context != nullptr;
+}
+
+int copy_json_string(const std::string& json, char* out_json, int out_json_size)
+{
+    const int required_size = static_cast<int>(json.size() + 1U);
+    if (out_json != nullptr && out_json_size > 0) {
+        std::snprintf(out_json, static_cast<std::size_t>(out_json_size), "%s", json.c_str());
+    }
+    return required_size;
 }
 
 std::string copy_ui_tree_json(gua_runtime_t* runtime)
@@ -125,6 +135,15 @@ extern "C" const char* gua_runtime_get_ui_tree_json(gua_runtime_t* runtime)
     return runtime->ui_tree_json.c_str();
 }
 
+extern "C" int gua_runtime_copy_ui_tree_json(gua_runtime_t* runtime, char* out_json, int out_json_size)
+{
+    if (!valid_runtime(runtime)) {
+        return copy_json_string("{}", out_json, out_json_size);
+    }
+
+    return copy_json_string(copy_ui_tree_json(runtime), out_json, out_json_size);
+}
+
 extern "C" void gua_runtime_add_log(gua_runtime_t* runtime, int level, const char* message)
 {
     if (!valid_runtime(runtime)) {
@@ -145,6 +164,15 @@ extern "C" const char* gua_runtime_get_logs_json(gua_runtime_t* runtime)
     return runtime->logs_json.c_str();
 }
 
+extern "C" int gua_runtime_copy_logs_json(gua_runtime_t* runtime, char* out_json, int out_json_size)
+{
+    if (!valid_runtime(runtime)) {
+        return copy_json_string("[]", out_json, out_json_size);
+    }
+
+    return copy_json_string(copy_logs_json(runtime), out_json, out_json_size);
+}
+
 extern "C" void gua_runtime_set_screenshot(gua_runtime_t* runtime, const char* data_uri, int width, int height)
 {
     if (!valid_runtime(runtime)) {
@@ -163,6 +191,15 @@ extern "C" const char* gua_runtime_get_screenshot_json(gua_runtime_t* runtime)
 
     runtime->screenshot_json = copy_screenshot_json(runtime);
     return runtime->screenshot_json.c_str();
+}
+
+extern "C" int gua_runtime_copy_screenshot_json(gua_runtime_t* runtime, char* out_json, int out_json_size)
+{
+    if (!valid_runtime(runtime)) {
+        return copy_json_string("{\"dataUri\":\"\",\"width\":0,\"height\":0}", out_json, out_json_size);
+    }
+
+    return copy_json_string(copy_screenshot_json(runtime), out_json, out_json_size);
 }
 
 extern "C" int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* node_id, gua_node_state_t* out_state)

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <future>
 #include <iostream>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -28,6 +29,11 @@ struct Command {
     std::string type;
     std::string node_id;
     std::string key;
+};
+
+struct ClientConnection {
+    SOCKET socket = INVALID_SOCKET;
+    std::shared_ptr<std::mutex> send_mutex;
 };
 
 class Socket {
@@ -553,8 +559,8 @@ public:
         }
         {
             const std::lock_guard lock(clients_mutex_);
-            for (const SOCKET client : clients_) {
-                shutdown(client, SD_BOTH);
+            for (const ClientConnection& client : clients_) {
+                shutdown(client.socket, SD_BOTH);
             }
         }
         if (thread_.joinable()) {
@@ -588,17 +594,30 @@ public:
             return;
         }
 
-        const std::lock_guard lock(clients_mutex_);
-        auto write = clients_.begin();
-        for (auto read = clients_.begin(); read != clients_.end(); ++read) {
+        std::vector<ClientConnection> clients;
+        {
+            const std::lock_guard lock(clients_mutex_);
+            clients = clients_;
+        }
+
+        std::vector<SOCKET> failed_clients;
+        for (const ClientConnection& client : clients) {
             try {
-                send_text_frame(*read, message);
-                *write++ = *read;
+                send_text_frame(client, message);
             } catch (...) {
-                closesocket(*read);
+                failed_clients.push_back(client.socket);
+                closesocket(client.socket);
             }
         }
-        clients_.erase(write, clients_.end());
+
+        if (!failed_clients.empty()) {
+            const std::lock_guard lock(clients_mutex_);
+            clients_.erase(
+                std::remove_if(clients_.begin(), clients_.end(), [&](const ClientConnection& client) {
+                    return std::find(failed_clients.begin(), failed_clients.end(), client.socket) != failed_clients.end();
+                }),
+                clients_.end());
+        }
     }
 
     [[nodiscard]] bool running() const
@@ -654,9 +673,13 @@ private:
     void serve_client(SOCKET client)
     {
         perform_handshake(client);
+        ClientConnection connection {
+            client,
+            std::make_shared<std::mutex>(),
+        };
         {
             const std::lock_guard lock(clients_mutex_);
-            clients_.push_back(client);
+            clients_.push_back(connection);
         }
         std::cout << "Inspector connected." << std::endl;
         publish_snapshot();
@@ -668,14 +691,24 @@ private:
             }
 
             const std::string response = handle_command(*message);
-            send_text_frame(client, response);
+            send_text_frame(connection, response);
         }
 
         {
             const std::lock_guard lock(clients_mutex_);
-            clients_.erase(std::remove(clients_.begin(), clients_.end(), client), clients_.end());
+            clients_.erase(
+                std::remove_if(clients_.begin(), clients_.end(), [&](const ClientConnection& entry) {
+                    return entry.socket == client;
+                }),
+                clients_.end());
         }
         std::cout << "Inspector disconnected." << std::endl;
+    }
+
+    static void send_text_frame(const ClientConnection& client, std::string_view text)
+    {
+        const std::lock_guard lock(*client.send_mutex);
+        ::send_text_frame(client.socket, text);
     }
 
     [[nodiscard]] std::string handle_command(std::string_view message)
@@ -722,7 +755,7 @@ private:
     std::thread thread_;
     std::atomic<SOCKET> listen_socket_ = INVALID_SOCKET;
     std::mutex clients_mutex_;
-    std::vector<SOCKET> clients_;
+    std::vector<ClientConnection> clients_;
 };
 
 BridgeServer::BridgeServer(BridgeHandlers handlers, BridgeOptions options)


### PR DESCRIPTION
## Summary
- `gua` / `gua-runtime` の JSON 取得を `copy_*` 形式の C ABI に追加し、.NET / C++ / Godot 側をコピー取得ベースに統一
- 共有 JSON キャッシュの読み取りに合わせて native 側へ mutex を追加し、スレッド安全性を強化
- WebSocket Inspector のクライアント送信を接続ごとの mutex で保護し、並行送信の競合を避けるように変更
- GuaContext 生成失敗時に Godot 側でエラーメッセージを出すよう改善

## Testing
- Not run (not requested)
- 変更内容は API 追加、バインディング更新、native 実装更新の整合性を中心に確認