### PR TITLE
アダプター主導のUI反映とクリック伝播を導入

### DIFF
--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -137,6 +137,18 @@ public sealed class GuaContext : IDisposable
         return Native.gua_enqueue_click(_handle, id) != 0;
     }
 
+    public bool ConsumeClickRequest(string id)
+    {
+        ThrowIfDisposed();
+        return Native.gua_consume_click_request(_handle, id) != 0;
+    }
+
+    public bool EmitClick(string id)
+    {
+        ThrowIfDisposed();
+        return Native.gua_emit_click(_handle, id) != 0;
+    }
+
     public bool TryPollEvent(out GuaEvent e)
     {
         ThrowIfDisposed();

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -129,6 +129,12 @@ internal static partial class Native
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int gua_enqueue_click(nint context, string nodeId);
 
+    [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int gua_consume_click_request(nint context, string nodeId);
+
+    [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int gua_emit_click(nint context, string nodeId);
+
     [LibraryImport("gua")]
     internal static unsafe partial int gua_poll_event(nint context, GuaNativeEvent* outEvent);
 }

--- a/docs/planning/gua-project-plan.md
+++ b/docs/planning/gua-project-plan.md
@@ -37,6 +37,23 @@ await page.getByText("Start").click()
 await expect(page.getByText("Loading")).toBeVisible()
 ```
 
+## Adapter-owned UI reflection update
+
+Gua adapters should prefer collecting the host UI automatically instead of
+asking game code to restate every semantic node. The core keeps the C ABI stable:
+`gua_enqueue_click` records an external automation request, adapters consume it
+with `gua_consume_click_request`, and observed host UI input is recorded with
+`gua_emit_click`.
+
+Initial adapter policy:
+
+* ImGui uses a `GuaImGui` facade such as `GuaImGui::Button(context, "Start Game##start")`.
+  It draws the ImGui widget, registers the Gua node, consumes pending click
+  requests, and emits click events.
+* Godot adapters attach to a root `Control`, collect standard controls from the
+  scene tree, connect `BaseButton.pressed` once, and dispatch external click
+  requests through the normal Godot button signal.
+
 一方で、ゲーム UI は一般的に以下の問題を持つ。
 
 * UI が Canvas / Texture / RenderTarget に描画され、DOM のような意味ツリーがない

--- a/examples/cpp-imgui/main.cpp
+++ b/examples/cpp-imgui/main.cpp
@@ -170,21 +170,43 @@ void DumpEvents(gua::Context& context)
 int RunSmoke()
 {
     gua::Context context;
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(1280.0F, 720.0F);
+    unsigned char* pixels = nullptr;
+    int font_width = 0;
+    int font_height = 0;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &font_width, &font_height);
+
     context.begin_frame("title");
     context.log(gua::LogLevel::info, "title screen opened");
-    GuaImGui::Button(
-        context,
-        "start",
-        "Start Game",
-        GuaImGui::Rect { 100.0F, 200.0F, 240.0F, 64.0F },
-        true);
+    ImGui::NewFrame();
+    GuaImGui::Button(context, "Start Game##start");
+    ImGui::EndFrame();
     context.set_screenshot("data:image/gif;base64,R0lGODlhAQABAAAAACw=", 1, 1);
     context.end_frame();
 
     std::cout << context.ui_tree_json() << '\n';
+
+    (void)context.enqueue_click("start");
+    context.begin_frame("title");
+    ImGui::NewFrame();
+    const bool requested_click = GuaImGui::Button(context, "Start Game##start");
+    ImGui::EndFrame();
+    context.end_frame();
+    std::cout << "button-return:" << (requested_click ? "true" : "false") << '\n';
+
+    context.begin_frame("loading");
+    ImGui::NewFrame();
+    GuaImGui::Text(context, "Loading...##loading");
+    ImGui::EndFrame();
+    context.end_frame();
+    std::cout << context.ui_tree_json() << '\n';
     std::cout << context.logs_json() << '\n';
     std::cout << context.screenshot_json() << '\n';
     DumpEvents(context);
+    ImGui::DestroyContext();
     return EXIT_SUCCESS;
 }
 
@@ -341,17 +363,17 @@ int main(int argc, char** argv)
             const std::lock_guard lock(gua_mutex);
             gua_context.begin_frame(loading ? "loading" : "title");
             ImGui::Begin("Gua Runtime UI");
-            ImGui::TextUnformatted("This window behaves like a small in-game UI surface.");
-            ImGui::TextUnformatted("Inspector bridge: ws://127.0.0.1:8765");
+            GuaImGui::Text(gua_context, "This window behaves like a small in-game UI surface.##sample-description");
+            GuaImGui::Text(gua_context, "Inspector bridge: ws://127.0.0.1:8765##bridge-url");
             ImGui::Separator();
 
             if (!loading) {
-                GuaImGui::Button(gua_context, "start", "Start Game");
+                if (GuaImGui::Button(gua_context, "Start Game##start")) {
+                    gua_context.log(gua::LogLevel::info, "start button clicked");
+                    loading = true;
+                }
             } else {
-                ImGui::TextUnformatted("Loading...");
-                const ImVec2 min = ImGui::GetItemRectMin();
-                const ImVec2 max = ImGui::GetItemRectMax();
-                gua_context.text("loading", "Loading...", gua::Rect { min.x, min.y, max.x - min.x, max.y - min.y });
+                GuaImGui::Text(gua_context, "Loading...##loading");
             }
 
             if (ImGui::Button("Dump UI Tree")) {
@@ -374,7 +396,6 @@ int main(int argc, char** argv)
             while (gua_context.poll_event(event)) {
                 std::cout << "click:" << event.node_id << '\n';
                 if (event.type == gua::EventType::click && event.node_id == "start") {
-                    gua_context.log(gua::LogLevel::info, "start button clicked");
                     loading = true;
                 }
             }

--- a/examples/dotnet-godot/README.md
+++ b/examples/dotnet-godot/README.md
@@ -23,7 +23,8 @@ Inspector bridge inside the running game process on:
 ws://127.0.0.1:8765
 ```
 
-Connect Gua Inspector to that URL while the game is running. The sample registers
-a title-screen semantic UI tree, publishes snapshots to the Inspector, polls Gua
-events, and transitions to a loading screen when the Inspector or the in-game UI
-clicks the `start` node.
+Connect Gua Inspector to that URL while the game is running. The sample attaches
+the Gua adapter to the root Godot `Control`; the adapter collects standard
+labels and buttons into the semantic UI tree, publishes snapshots, observes
+button clicks, and dispatches Inspector `click_node` requests through the normal
+Godot button signal.

--- a/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
+++ b/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
@@ -6,6 +6,10 @@ namespace Gua.Godot;
 public sealed class GuaGodotRuntime : IDisposable
 {
     private nint _runtime;
+    private Control? _attachedRoot;
+    private readonly Dictionary<string, BaseButton> _buttonsById = new(StringComparer.Ordinal);
+    private readonly HashSet<ulong> _connectedButtons = new();
+    private readonly HashSet<string> _suppressedButtonSignals = new(StringComparer.Ordinal);
 
     public GuaGodotRuntime()
     {
@@ -86,10 +90,43 @@ public sealed class GuaGodotRuntime : IDisposable
             enabled && !disabled);
     }
 
+    public void Attach(Control root)
+    {
+        ThrowIfDisposed();
+        _attachedRoot = root ?? throw new ArgumentNullException(nameof(root));
+    }
+
+    public void SyncAttachedTree(string screen)
+    {
+        ThrowIfDisposed();
+        if (_attachedRoot is null)
+        {
+            throw new InvalidOperationException("Gua Godot runtime is not attached to a root Control.");
+        }
+
+        BeginFrame(screen);
+        _buttonsById.Clear();
+        CollectControl(_attachedRoot, _attachedRoot);
+        EndFrame();
+        DispatchClickRequests();
+    }
+
     public bool EnqueueClick(string id)
     {
         ThrowIfDisposed();
         return GuaRuntimeNative.gua_runtime_enqueue_click(_runtime, id) != 0;
+    }
+
+    public bool ConsumeClickRequest(string id)
+    {
+        ThrowIfDisposed();
+        return GuaRuntimeNative.gua_runtime_consume_click_request(_runtime, id) != 0;
+    }
+
+    public bool EmitClick(string id)
+    {
+        ThrowIfDisposed();
+        return GuaRuntimeNative.gua_runtime_emit_click(_runtime, id) != 0;
     }
 
     public void ClickByRole(string role, string label)
@@ -163,5 +200,122 @@ public sealed class GuaGodotRuntime : IDisposable
     {
         return System.Runtime.InteropServices.Marshal.PtrToStringUTF8(value)
             ?? throw new InvalidOperationException("Native Gua runtime returned an invalid UTF-8 string.");
+    }
+
+    private void CollectControl(Control root, Control control)
+    {
+        var id = GetControlId(root, control);
+        var role = GetControlRole(control);
+        var label = GetControlLabel(control);
+        var enabled = IsControlEnabled(control);
+        RegisterNode(
+            id,
+            role,
+            label,
+            new Rect2(control.GlobalPosition, control.Size),
+            control.IsVisibleInTree(),
+            enabled);
+
+        if (control is BaseButton button)
+        {
+            _buttonsById[id] = button;
+            ConnectButtonPressed(button, id);
+        }
+
+        foreach (var child in control.GetChildren())
+        {
+            if (child is Control childControl)
+            {
+                CollectControl(root, childControl);
+            }
+        }
+    }
+
+    private void DispatchClickRequests()
+    {
+        foreach (var (id, button) in _buttonsById.ToArray())
+        {
+            while (ConsumeClickRequest(id))
+            {
+                if (button.Disabled || !button.IsVisibleInTree())
+                {
+                    continue;
+                }
+
+                EmitClick(id);
+                _suppressedButtonSignals.Add(id);
+                button.EmitSignal(BaseButton.SignalName.Pressed);
+            }
+        }
+    }
+
+    private void ConnectButtonPressed(BaseButton button, string id)
+    {
+        if (!_connectedButtons.Add(button.GetInstanceId()))
+        {
+            return;
+        }
+
+        button.Pressed += () =>
+        {
+            if (_suppressedButtonSignals.Remove(id))
+            {
+                return;
+            }
+
+            EmitClick(id);
+        };
+    }
+
+    private static string GetControlId(Control root, Control control)
+    {
+        if (control.HasMeta("gua_id"))
+        {
+            return control.GetMeta("gua_id").AsString();
+        }
+
+        if (control == root)
+        {
+            return "root";
+        }
+
+        return root.GetPathTo(control).ToString();
+    }
+
+    private static string GetControlRole(Control control)
+    {
+        return control switch
+        {
+            CheckBox => "checkbox",
+            BaseButton => "button",
+            Label => "text",
+            LineEdit => "textbox",
+            TextEdit => "textbox",
+            Slider => "slider",
+            _ => "panel",
+        };
+    }
+
+    private static string GetControlLabel(Control control)
+    {
+        return control switch
+        {
+            Button button => button.Text,
+            Label label => label.Text,
+            LineEdit lineEdit => lineEdit.Text,
+            TextEdit textEdit => textEdit.Text,
+            _ => control.Name,
+        };
+    }
+
+    private static bool IsControlEnabled(Control control)
+    {
+        return control switch
+        {
+            BaseButton button => !button.Disabled,
+            LineEdit lineEdit => lineEdit.Editable,
+            TextEdit textEdit => textEdit.Editable,
+            _ => false,
+        };
     }
 }

--- a/examples/dotnet-godot/addons/gua/GuaRuntimeNative.cs
+++ b/examples/dotnet-godot/addons/gua/GuaRuntimeNative.cs
@@ -115,6 +115,12 @@ internal static class GuaRuntimeNative
     internal static extern int gua_runtime_enqueue_click(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeId);
 
     [DllImport("gua_runtime")]
+    internal static extern int gua_runtime_consume_click_request(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeId);
+
+    [DllImport("gua_runtime")]
+    internal static extern int gua_runtime_emit_click(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeId);
+
+    [DllImport("gua_runtime")]
     internal static unsafe extern int gua_runtime_poll_event(nint runtime, NativeEvent* outEvent);
 
     [DllImport("gua_runtime")]

--- a/examples/dotnet-godot/addons/gua/README.md
+++ b/examples/dotnet-godot/addons/gua/README.md
@@ -12,7 +12,13 @@ private readonly GuaGodotRuntime _gua = new();
 
 public override void _Ready()
 {
+    _gua.Attach(this);
     _gua.StartInspectorBridge(8765);
+}
+
+public override void _Process(double delta)
+{
+    _gua.SyncAttachedTree("title");
 }
 ```
 

--- a/examples/dotnet-godot/scripts/Main.cs
+++ b/examples/dotnet-godot/scripts/Main.cs
@@ -21,7 +21,8 @@ public partial class Main : Control
     {
         _loading = false;
         BuildUi();
-        RebuildGuaFrame();
+        _gua.Attach(this);
+        _gua.SyncAttachedTree(CurrentScreen);
 
         if (StartInspectorBridgeOnReady)
         {
@@ -32,8 +33,7 @@ public partial class Main : Control
 
     public override void _Process(double delta)
     {
-        RebuildGuaFrame();
-        PollGuaEvents();
+        _gua.SyncAttachedTree(CurrentScreen);
     }
 
     public override void _ExitTree()
@@ -45,6 +45,7 @@ public partial class Main : Control
     {
         _titleLabel = new Label
         {
+            Name = "title",
             Text = "Gua C# Sample",
             Position = new Vector2(420, 220),
             Size = new Vector2(440, 56),
@@ -54,24 +55,26 @@ public partial class Main : Control
 
         _startButton = new Button
         {
+            Name = "start",
             Text = "Start Game",
             Position = new Vector2(512, 312),
             Size = new Vector2(256, 56),
         };
-        _startButton.Pressed += () => _gua.EnqueueClick("start");
+        _startButton.Pressed += ShowLoading;
         AddChild(_startButton);
 
         _settingsButton = new Button
         {
+            Name = "settings",
             Text = "Settings",
             Position = new Vector2(512, 384),
             Size = new Vector2(256, 56),
         };
-        _settingsButton.Pressed += () => _gua.EnqueueClick("settings");
         AddChild(_settingsButton);
 
         _loadingLabel = new Label
         {
+            Name = "loading",
             Text = "Loading...",
             Position = new Vector2(544, 328),
             Size = new Vector2(192, 48),
@@ -79,50 +82,6 @@ public partial class Main : Control
             Visible = false,
         };
         AddChild(_loadingLabel);
-    }
-
-    private void RebuildGuaFrame()
-    {
-        _gua.BeginFrame(_loading ? "loading" : "title");
-        _gua.RegisterNode(
-            "root",
-            "screen",
-            _loading ? "Loading Screen" : "Title Screen",
-            new Rect2(Vector2.Zero, Size),
-            visible: true,
-            enabled: false);
-
-        if (_loading)
-        {
-            RegisterControlNode("loading", "text", "Loading...", _loadingLabel, enabled: false);
-        }
-        else
-        {
-            RegisterControlNode("title", "text", "Gua C# Sample", _titleLabel, enabled: false);
-            RegisterControlNode("start", "button", "Start Game", _startButton, enabled: true);
-            RegisterControlNode("settings", "button", "Settings", _settingsButton, enabled: true);
-        }
-
-        _gua.EndFrame();
-    }
-
-    private void RegisterControlNode(string id, string role, string label, Control? control, bool enabled)
-    {
-        if (control is not null)
-        {
-            _gua.RegisterControlNode(id, role, label, control, enabled);
-        }
-    }
-
-    private void PollGuaEvents()
-    {
-        while (_gua.TryPollEvent(out var e))
-        {
-            if (e.Type == GuaEventType.Click && e.NodeId == "start")
-            {
-                ShowLoading();
-            }
-        }
     }
 
     private void ShowLoading()
@@ -151,8 +110,10 @@ public partial class Main : Control
             _loadingLabel.Visible = true;
         }
 
-        RebuildGuaFrame();
+        _gua.SyncAttachedTree(CurrentScreen);
     }
+
+    private string CurrentScreen => _loading ? "loading" : "title";
 
     private void StartInspectorBridge()
     {

--- a/examples/godot-gdscript/README.md
+++ b/examples/godot-gdscript/README.md
@@ -10,7 +10,8 @@ cmake --build --preset windows-msvc-debug --target gua-godot
 ```
 
 Then open this directory in the Godot 4.7 editor. The extension exposes
-`GuaContext` to GDScript through `addons/gua/gua.gdextension`.
+`GuaContext` to GDScript through `addons/gua/gua.gdextension`, and
+`addons/gua/gua_auto_adapter.gd` provides the standard-Control auto collector.
 
 Run the project from Godot. The sample starts the Inspector bridge inside the
 running game process on:
@@ -24,6 +25,7 @@ listen, Godot prints a `Failed to start Gua Inspector bridge` warning, usually
 because another process already owns the port or the native extension was not
 rebuilt.
 
-The sample registers a title-screen semantic UI tree, publishes snapshots to the
-Inspector, polls Gua events, and transitions to a loading screen when the
-Inspector or the in-game UI clicks the `start` node.
+The sample attaches `GuaAutoAdapter` to the root Godot `Control`; the adapter
+collects standard labels and buttons into the semantic UI tree, publishes
+snapshots, observes button clicks, and dispatches Inspector `click_node` requests
+through the normal Godot button signal.

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -1,0 +1,132 @@
+class_name GuaAutoAdapter
+extends RefCounted
+
+const META_ID := "gua_id"
+
+var context := GuaContext.new()
+var root: Control
+var buttons_by_id: Dictionary = {}
+var connected_buttons: Dictionary = {}
+var suppressed_clicks: Dictionary = {}
+
+
+func attach(root_control: Control) -> void:
+	root = root_control
+
+
+func update(screen: String) -> void:
+	if root == null:
+		push_error("GuaAutoAdapter.update called before attach.")
+		return
+
+	context.begin_frame(screen)
+	buttons_by_id.clear()
+	_collect_control(root)
+	context.end_frame()
+	_dispatch_click_requests()
+
+
+func start_inspector_bridge(port: int = 8765) -> bool:
+	return context.start_inspector_bridge(port)
+
+
+func inspector_bridge_url() -> String:
+	return context.inspector_bridge_url()
+
+
+func get_ui_tree_json() -> String:
+	return context.get_ui_tree_json()
+
+
+func _collect_control(control: Control) -> void:
+	var id := _control_id(control)
+	var role := _control_role(control)
+	var label := _control_label(control)
+	context.register_node(
+		id,
+		role,
+		label,
+		Rect2(control.global_position, control.size),
+		control.is_visible_in_tree(),
+		_control_enabled(control)
+	)
+
+	if control is BaseButton:
+		buttons_by_id[id] = control
+		_connect_button(control as BaseButton, id)
+
+	for child in control.get_children():
+		if child is Control:
+			_collect_control(child as Control)
+
+
+func _dispatch_click_requests() -> void:
+	for id in buttons_by_id.keys():
+		var button := buttons_by_id[id] as BaseButton
+		while context.consume_click_request(id):
+			if button.disabled or not button.is_visible_in_tree():
+				continue
+
+			context.emit_click(id)
+			suppressed_clicks[id] = true
+			button.emit_signal("pressed")
+
+
+func _connect_button(button: BaseButton, id: String) -> void:
+	var instance_id := button.get_instance_id()
+	if connected_buttons.has(instance_id):
+		return
+
+	connected_buttons[instance_id] = true
+	button.pressed.connect(_on_button_pressed.bind(id))
+
+
+func _on_button_pressed(id: String) -> void:
+	if suppressed_clicks.erase(id):
+		return
+
+	context.emit_click(id)
+
+
+func _control_id(control: Control) -> String:
+	if control.has_meta(META_ID):
+		return str(control.get_meta(META_ID))
+	if control == root:
+		return "root"
+	return str(root.get_path_to(control))
+
+
+func _control_role(control: Control) -> String:
+	if control is CheckBox:
+		return "checkbox"
+	if control is BaseButton:
+		return "button"
+	if control is Label:
+		return "text"
+	if control is LineEdit or control is TextEdit:
+		return "textbox"
+	if control is Slider:
+		return "slider"
+	return "panel"
+
+
+func _control_label(control: Control) -> String:
+	if control is BaseButton:
+		return (control as BaseButton).text
+	if control is Label:
+		return (control as Label).text
+	if control is LineEdit:
+		return (control as LineEdit).text
+	if control is TextEdit:
+		return (control as TextEdit).text
+	return control.name
+
+
+func _control_enabled(control: Control) -> bool:
+	if control is BaseButton:
+		return not (control as BaseButton).disabled
+	if control is LineEdit:
+		return (control as LineEdit).editable
+	if control is TextEdit:
+		return (control as TextEdit).editable
+	return false

--- a/examples/godot-gdscript/scripts/main.gd
+++ b/examples/godot-gdscript/scripts/main.gd
@@ -3,7 +3,7 @@ extends Control
 @export var start_inspector_bridge_on_ready := true
 @export var inspector_bridge_port := 8765
 
-var ui := GuaContext.new()
+var ui := GuaAutoAdapter.new()
 var loading := false
 var title_label: Label
 var start_button: Button
@@ -13,19 +13,20 @@ var loading_label: Label
 
 func _ready() -> void:
 	_build_ui()
-	_rebuild_gua_frame()
+	ui.attach(self)
+	ui.update(_current_screen())
 
 	if start_inspector_bridge_on_ready:
 		_start_inspector_bridge()
 
 
 func _process(_delta: float) -> void:
-	_rebuild_gua_frame()
-	_poll_gua_events()
+	ui.update(_current_screen())
 
 
 func _build_ui() -> void:
 	title_label = Label.new()
+	title_label.name = "title"
 	title_label.text = "Gua GDScript Sample"
 	title_label.position = Vector2(420, 220)
 	title_label.size = Vector2(440, 56)
@@ -33,76 +34,28 @@ func _build_ui() -> void:
 	add_child(title_label)
 
 	start_button = Button.new()
+	start_button.name = "start"
 	start_button.text = "Start Game"
 	start_button.position = Vector2(512, 312)
 	start_button.size = Vector2(256, 56)
-	start_button.pressed.connect(func() -> void:
-		ui.enqueue_click("start")
-	)
+	start_button.pressed.connect(_show_loading)
 	add_child(start_button)
 
 	settings_button = Button.new()
+	settings_button.name = "settings"
 	settings_button.text = "Settings"
 	settings_button.position = Vector2(512, 384)
 	settings_button.size = Vector2(256, 56)
-	settings_button.pressed.connect(func() -> void:
-		ui.enqueue_click("settings")
-	)
 	add_child(settings_button)
 
 	loading_label = Label.new()
+	loading_label.name = "loading"
 	loading_label.text = "Loading..."
 	loading_label.position = Vector2(544, 328)
 	loading_label.size = Vector2(192, 48)
 	loading_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	loading_label.visible = false
 	add_child(loading_label)
-
-
-func _rebuild_gua_frame() -> void:
-	ui.begin_frame("loading" if loading else "title")
-	ui.register_node(
-		"root",
-		"screen",
-		"Loading Screen" if loading else "Title Screen",
-		Rect2(Vector2.ZERO, size),
-		true,
-		false
-	)
-
-	if loading:
-		_register_control_node("loading", "text", "Loading...", loading_label, false)
-	else:
-		_register_control_node("title", "text", "Gua GDScript Sample", title_label, false)
-		_register_control_node("start", "button", "Start Game", start_button, true)
-		_register_control_node("settings", "button", "Settings", settings_button, true)
-
-	ui.end_frame()
-
-
-func _register_control_node(id: String, role: String, label: String, control: Control, enabled: bool) -> void:
-	var disabled := false
-	if control is BaseButton:
-		disabled = (control as BaseButton).disabled
-
-	ui.register_node(
-		id,
-		role,
-		label,
-		Rect2(control.global_position, control.size),
-		control.visible,
-		enabled and not disabled
-	)
-
-
-func _poll_gua_events() -> void:
-	while true:
-		var event := ui.poll_event()
-		if event.is_empty():
-			return
-
-		if event.get("type") == "click" and event.get("node_id") == "start":
-			_show_loading()
 
 
 func _show_loading() -> void:
@@ -113,7 +66,7 @@ func _show_loading() -> void:
 	settings_button.visible = false
 	settings_button.disabled = true
 	loading_label.visible = true
-	_rebuild_gua_frame()
+	ui.update(_current_screen())
 
 
 func _start_inspector_bridge() -> void:
@@ -122,3 +75,7 @@ func _start_inspector_bridge() -> void:
 		return
 
 	push_warning("Failed to start Gua Inspector bridge on ws://127.0.0.1:%d" % inspector_bridge_port)
+
+
+func _current_screen() -> String:
+	return "loading" if loading else "title"

--- a/examples/native-bridge/main.cpp
+++ b/examples/native-bridge/main.cpp
@@ -544,6 +544,12 @@ public:
         if (!context_.enqueue_click(node_id)) {
             return false;
         }
+        if (!context_.consume_click_request(node_id)) {
+            return false;
+        }
+        if (!context_.emit_click(node_id)) {
+            return false;
+        }
 
         context_.log(gua::LogLevel::info, "click_node(" + std::string(node_id) + ")");
         gua::Event event;

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -69,6 +69,8 @@ int gua_find_node_by_id(gua_context_t* ctx, const char* node_id, char* out_node_
 int gua_find_node_by_role(gua_context_t* ctx, const char* role, const char* name, char* out_node_id, int out_node_id_size);
 int gua_find_node_by_text(gua_context_t* ctx, const char* text, char* out_node_id, int out_node_id_size);
 int gua_enqueue_click(gua_context_t* ctx, const char* node_id);
+int gua_consume_click_request(gua_context_t* ctx, const char* node_id);
+int gua_emit_click(gua_context_t* ctx, const char* node_id);
 int gua_poll_event(gua_context_t* ctx, gua_event_t* out_event);
 
 #ifdef __cplusplus

--- a/native/gua-core/include/gua/gua.hpp
+++ b/native/gua-core/include/gua/gua.hpp
@@ -153,6 +153,18 @@ public:
         return gua_enqueue_click(context_, id_buffer_.c_str()) != 0;
     }
 
+    [[nodiscard]] bool consume_click_request(std::string_view node_id)
+    {
+        id_buffer_.assign(node_id);
+        return gua_consume_click_request(context_, id_buffer_.c_str()) != 0;
+    }
+
+    [[nodiscard]] bool emit_click(std::string_view node_id)
+    {
+        id_buffer_.assign(node_id);
+        return gua_emit_click(context_, id_buffer_.c_str()) != 0;
+    }
+
     [[nodiscard]] bool poll_event(Event& out_event)
     {
         gua_event_t native_event {};

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -101,6 +101,7 @@ struct gua_context_t {
     mutable std::mutex mutex;
     std::string screen = "unknown";
     std::vector<Node> nodes;
+    std::deque<std::string> click_requests;
     std::deque<Event> events;
     std::vector<LogEntry> logs;
     Screenshot screenshot;
@@ -430,6 +431,40 @@ extern "C" int gua_enqueue_click(gua_context_t* ctx, const char* node_id)
         return 0;
     }
 
+    ctx->click_requests.push_back(node_id);
+    return 1;
+}
+
+extern "C" int gua_consume_click_request(gua_context_t* ctx, const char* node_id)
+{
+    if (ctx == nullptr || node_id == nullptr) {
+        return 0;
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    const auto node_found = std::any_of(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
+        return node.id == node_id && node.visible && node.enabled;
+    });
+    if (!node_found) {
+        return 0;
+    }
+
+    const auto request = std::find(ctx->click_requests.begin(), ctx->click_requests.end(), node_id);
+    if (request == ctx->click_requests.end()) {
+        return 0;
+    }
+
+    ctx->click_requests.erase(request);
+    return 1;
+}
+
+extern "C" int gua_emit_click(gua_context_t* ctx, const char* node_id)
+{
+    if (ctx == nullptr || node_id == nullptr) {
+        return 0;
+    }
+
+    const std::lock_guard lock(ctx->mutex);
     ctx->events.push_back(Event { GUA_EVENT_CLICK, node_id });
     return 1;
 }

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -28,6 +28,8 @@ public:
 
     String get_ui_tree_json() const;
     bool enqueue_click(const String& node_id);
+    bool consume_click_request(const String& node_id);
+    bool emit_click(const String& node_id);
     Dictionary poll_event();
     bool start_inspector_bridge(int port = 8765);
     void stop_inspector_bridge();

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -109,6 +109,18 @@ bool GuaContext::enqueue_click(const String& node_id)
     return gua_runtime_enqueue_click(runtime_, node_id_utf8.get_data()) != 0;
 }
 
+bool GuaContext::consume_click_request(const String& node_id)
+{
+    const CharString node_id_utf8 = node_id.utf8();
+    return gua_runtime_consume_click_request(runtime_, node_id_utf8.get_data()) != 0;
+}
+
+bool GuaContext::emit_click(const String& node_id)
+{
+    const CharString node_id_utf8 = node_id.utf8();
+    return gua_runtime_emit_click(runtime_, node_id_utf8.get_data()) != 0;
+}
+
 Dictionary GuaContext::poll_event()
 {
     gua_event_t event {};
@@ -158,6 +170,8 @@ void GuaContext::_bind_methods()
         DEFVAL(true));
     ClassDB::bind_method(D_METHOD("get_ui_tree_json"), &GuaContext::get_ui_tree_json);
     ClassDB::bind_method(D_METHOD("enqueue_click", "node_id"), &GuaContext::enqueue_click);
+    ClassDB::bind_method(D_METHOD("consume_click_request", "node_id"), &GuaContext::consume_click_request);
+    ClassDB::bind_method(D_METHOD("emit_click", "node_id"), &GuaContext::emit_click);
     ClassDB::bind_method(D_METHOD("poll_event"), &GuaContext::poll_event);
     ClassDB::bind_method(D_METHOD("start_inspector_bridge", "port"), &GuaContext::start_inspector_bridge, DEFVAL(8765));
     ClassDB::bind_method(D_METHOD("stop_inspector_bridge"), &GuaContext::stop_inspector_bridge);

--- a/native/gua-imgui/include/gua/imgui_adapter.hpp
+++ b/native/gua-imgui/include/gua/imgui_adapter.hpp
@@ -10,6 +10,23 @@
 
 namespace gua::imgui {
 
+inline std::string visible_label(std::string_view label)
+{
+    const std::size_t marker = label.find("##");
+    return std::string(marker == std::string_view::npos ? label : label.substr(0, marker));
+}
+
+inline std::string semantic_id_from_label(std::string_view label)
+{
+    const std::size_t marker = label.find("##");
+    if (marker != std::string_view::npos && marker + 2U < label.size()) {
+        return std::string(label.substr(marker + 2U));
+    }
+
+    const std::string label_buffer(label);
+    return "imgui:" + std::to_string(static_cast<unsigned int>(ImGui::GetID(label_buffer.c_str())));
+}
+
 inline void register_button(
     gua_context_t* context,
     const char* id,
@@ -39,7 +56,34 @@ inline bool button(
 {
     context.button(id, label, bounds, visible, enabled);
     if (clicked && visible && enabled) {
-        return context.enqueue_click(id);
+        return context.emit_click(id);
+    }
+
+    return false;
+}
+
+inline bool button(Context& context, std::string_view label)
+{
+    const std::string label_buffer(label);
+    const std::string id = semantic_id_from_label(label);
+    const std::string visible_label_buffer = visible_label(label);
+    const bool clicked = ImGui::Button(label_buffer.c_str());
+    const ImVec2 min = ImGui::GetItemRectMin();
+    const ImVec2 max = ImGui::GetItemRectMax();
+    const bool visible = ImGui::IsItemVisible();
+    const bool enabled = true;
+
+    context.button(
+        id,
+        visible_label_buffer,
+        Rect { min.x, min.y, max.x - min.x, max.y - min.y },
+        visible,
+        enabled);
+
+    const bool requested = context.consume_click_request(id);
+    if ((clicked || requested) && visible && enabled) {
+        (void)context.emit_click(id);
+        return true;
     }
 
     return false;
@@ -47,24 +91,46 @@ inline bool button(
 
 inline bool button(Context& context, std::string_view id, std::string_view label)
 {
+    const std::string id_buffer(id);
     const std::string label_buffer(label);
+    const std::string visible_label_buffer = visible_label(label);
+    ImGui::PushID(id_buffer.c_str());
     const bool clicked = ImGui::Button(label_buffer.c_str());
     const ImVec2 min = ImGui::GetItemRectMin();
     const ImVec2 max = ImGui::GetItemRectMax();
     const bool visible = ImGui::IsItemVisible();
+    const bool enabled = true;
+    ImGui::PopID();
 
     context.button(
         id,
-        label,
+        visible_label_buffer,
         Rect { min.x, min.y, max.x - min.x, max.y - min.y },
         visible,
-        true);
+        enabled);
 
-    if (clicked && visible) {
-        return context.enqueue_click(id);
+    const bool requested = context.consume_click_request(id);
+    if ((clicked || requested) && visible && enabled) {
+        (void)context.emit_click(id);
+        return true;
     }
 
     return false;
+}
+
+inline void text(Context& context, std::string_view label)
+{
+    const std::string label_buffer(label);
+    const std::string id = semantic_id_from_label(label);
+    const std::string visible_label_buffer = visible_label(label);
+    ImGui::TextUnformatted(visible_label_buffer.c_str());
+    const ImVec2 min = ImGui::GetItemRectMin();
+    const ImVec2 max = ImGui::GetItemRectMax();
+    context.text(
+        id,
+        visible_label_buffer,
+        Rect { min.x, min.y, max.x - min.x, max.y - min.y },
+        ImGui::IsItemVisible());
 }
 
 } // namespace gua::imgui
@@ -88,6 +154,16 @@ inline bool Button(
 inline bool Button(gua::Context& context, std::string_view id, std::string_view label)
 {
     return gua::imgui::button(context, id, label);
+}
+
+inline bool Button(gua::Context& context, std::string_view label)
+{
+    return gua::imgui::button(context, label);
+}
+
+inline void Text(gua::Context& context, std::string_view label)
+{
+    gua::imgui::text(context, label);
 }
 
 } // namespace GuaImGui

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -39,6 +39,8 @@ int gua_runtime_find_node_by_id(gua_runtime_t* runtime, const char* node_id, cha
 int gua_runtime_find_node_by_role(gua_runtime_t* runtime, const char* role, const char* name, char* out_node_id, int out_node_id_size);
 int gua_runtime_find_node_by_text(gua_runtime_t* runtime, const char* text, char* out_node_id, int out_node_id_size);
 int gua_runtime_enqueue_click(gua_runtime_t* runtime, const char* node_id);
+int gua_runtime_consume_click_request(gua_runtime_t* runtime, const char* node_id);
+int gua_runtime_emit_click(gua_runtime_t* runtime, const char* node_id);
 int gua_runtime_poll_event(gua_runtime_t* runtime, gua_event_t* out_event);
 
 int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int port);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -257,6 +257,26 @@ extern "C" int gua_runtime_enqueue_click(gua_runtime_t* runtime, const char* nod
     return gua_enqueue_click(runtime->context, node_id);
 }
 
+extern "C" int gua_runtime_consume_click_request(gua_runtime_t* runtime, const char* node_id)
+{
+    if (!valid_runtime(runtime)) {
+        return 0;
+    }
+
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_consume_click_request(runtime->context, node_id);
+}
+
+extern "C" int gua_runtime_emit_click(gua_runtime_t* runtime, const char* node_id)
+{
+    if (!valid_runtime(runtime)) {
+        return 0;
+    }
+
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_emit_click(runtime->context, node_id);
+}
+
 extern "C" int gua_runtime_poll_event(gua_runtime_t* runtime, gua_event_t* out_event)
 {
     if (!valid_runtime(runtime)) {

--- a/plan.md
+++ b/plan.md
@@ -37,6 +37,23 @@ await page.getByText("Start").click()
 await expect(page.getByText("Loading")).toBeVisible()
 ```
 
+## Adapter-owned UI reflection update
+
+Gua adapters should prefer collecting the host UI automatically instead of
+asking game code to restate every semantic node. The core keeps the C ABI stable:
+`gua_enqueue_click` records an external automation request, adapters consume it
+with `gua_consume_click_request`, and observed host UI input is recorded with
+`gua_emit_click`.
+
+Initial adapter policy:
+
+* ImGui uses a `GuaImGui` facade such as `GuaImGui::Button(context, "Start Game##start")`.
+  It draws the ImGui widget, registers the Gua node, consumes pending click
+  requests, and emits click events.
+* Godot adapters attach to a root `Control`, collect standard controls from the
+  scene tree, connect `BaseButton.pressed` once, and dispatch external click
+  requests through the normal Godot button signal.
+
 一方で、ゲーム UI は一般的に以下の問題を持つ。
 
 * UI が Canvas / Texture / RenderTarget に描画され、DOM のような意味ツリーがない

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -13,6 +13,22 @@ A UI tree response describes one frame or snapshot of runtime UI state.
 Nodes are intentionally semantic. They describe role, label, state, bounds, and
 supported actions, not rendering internals.
 
+## Adapter-Owned Reflection
+
+Runtime adapters should rebuild the semantic tree from the host UI every frame
+or snapshot. Game code should not have to restate its visible buttons, labels,
+and controls as separate Gua calls when the adapter can observe those controls.
+
+- If a host UI element disappears, the next adapter snapshot omits its Gua node.
+- If a host UI element is clicked by the user, the adapter emits a Gua event.
+- If automation requests `click_node`, the core records a pending click request.
+  The adapter consumes that request when it reaches the matching host UI element
+  and then activates the host control through the same path normal game code
+  already uses.
+
+This keeps the C ABI as the stable protocol boundary while letting ImGui, Godot,
+and later engine adapters own the engine-specific reflection details.
+
 ## Inspector Snapshots
 
 The v0.3 Inspector consumes three protocol payloads:
@@ -94,9 +110,11 @@ request/response WebSocket payloads for the runtime side.
 
 ## Events
 
-Events are queued by the runtime core when commands should be observed by the
-game code. Language bindings should poll events instead of passing callbacks
-across ABI boundaries.
+Events are queued by the runtime core when adapters observe host UI input.
+Language bindings should poll events instead of passing callbacks across ABI
+boundaries. External commands such as `click_node` are requests first; adapters
+consume them and emit events only after the corresponding host UI action has
+been applied.
 
 Initial event types:
 


### PR DESCRIPTION
## Summary
- `click_node` を単なる要求として扱い、アダプター側で消費して実UIのクリック経路に流すように変更
- `gua_consume_click_request` と `gua_emit_click` を C ABI / .NET / Godot ランタイムへ追加
- ImGui と Godot のサンプルを、ホストUIを自動収集するアダプター方式に更新
- `plan.md` と `protocol/specs/protocol.md` に新しい反映ポリシーを追記

## Testing
- Not run (not requested)