### PR TITLE
Inspector と MCP のリリース自動化を追加

### DIFF
--- a/.github/workflows/inspector-release.yml
+++ b/.github/workflows/inspector-release.yml
@@ -1,0 +1,68 @@
+name: Inspector Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/inspector-release.yml
+      - bun.lock
+      - package.json
+      - tsconfig.base.json
+      - packages/inspector/**
+      - packages/bridge-ws/**
+      - native/gua-core/**
+      - native/gua-imgui/**
+      - native/gua-ws-bridge/**
+      - examples/cpp-imgui/**
+      - protocol/**
+
+permissions:
+  contents: write
+
+concurrency:
+  group: inspector-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-release:
+    name: Build Inspector and attach release assets
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build web inspector
+        run: bun run --filter @gua/inspector build
+
+      - name: Build Tauri inspector
+        run: bun run --filter @gua/inspector tauri:build
+
+      - name: Collect release metadata
+        id: meta
+        shell: pwsh
+        run: |
+          $shortSha = "${env:GITHUB_SHA}".Substring(0, 12)
+          "tag=inspector-$shortSha" >> $env:GITHUB_OUTPUT
+          "name=Gua Inspector $shortSha" >> $env:GITHUB_OUTPUT
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.name }}
+          body: |
+            Automated Gua Inspector build from `${{ github.sha }}`.
+
+            This release is created when the Inspector or its protocol/bridge inputs change on `main`.
+          files: packages/inspector/src-tauri/target/release/bundle/**/*
+          fail_on_unmatched_files: true

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Node.js for npm publish
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.22.2
           registry-url: https://registry.npmjs.org
 
       - name: Update npm

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -26,6 +26,7 @@ jobs:
   publish:
     name: Publish gui-mcp to npm
     runs-on: ubuntu-latest
+    environment: release
     defaults:
       run:
         working-directory: packages/mcp
@@ -41,6 +42,9 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         working-directory: .
@@ -62,6 +66,4 @@ jobs:
         run: bun pm pack --dry-run
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --tag latest --provenance
+        run: npm publish --access public --tag latest

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,67 @@
+name: MCP npm Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/mcp-publish.yml
+      - bun.lock
+      - package.json
+      - tsconfig.base.json
+      - packages/mcp/**
+      - packages/bridge-ws/**
+      - native/gua-ws-bridge/**
+      - protocol/**
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: mcp-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish gui-mcp to npm
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/mcp
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Set up Node.js for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        working-directory: .
+        run: bun install --frozen-lockfile
+
+      - name: Check
+        run: bun run check
+
+      - name: Build
+        run: bun run build
+
+      - name: Stamp CI package version
+        shell: bash
+        run: |
+          short_sha="${GITHUB_SHA::12}"
+          npm version "0.0.0-main.${GITHUB_RUN_NUMBER}.${short_sha}" --no-git-tag-version
+
+      - name: Verify package contents
+        run: bun pm pack --dry-run
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --tag latest --provenance

--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ bun run --filter @gua/inspector tauri:dev
 
 Tauri requires a Rust toolchain in addition to the JavaScript dependencies.
 
+## Release automation
+
+GitHub Actions publishes runtime artifacts from `main` when the relevant protocol
+consumer changes:
+
+- Inspector changes build the Tauri Inspector on Windows and attach the bundle
+  outputs to a GitHub Release tagged as `inspector-<short-sha>`.
+- MCP changes build and publish `gui-mcp` to npm as
+  `0.0.0-main.<run-number>.<short-sha>` with the `latest` dist-tag.
+
+The MCP workflow requires an `NPM_TOKEN` repository secret with permission to
+publish `gui-mcp`.
+
 ## Godot 4.7 C# Sample
 
 The v0.5 C# runtime sample lives in `examples/dotnet-godot`. It is a minimal

--- a/README.md
+++ b/README.md
@@ -199,8 +199,9 @@ consumer changes:
 - MCP changes build and publish `gui-mcp` to npm as
   `0.0.0-main.<run-number>.<short-sha>` with the `latest` dist-tag.
 
-The MCP workflow requires an `NPM_TOKEN` repository secret with permission to
-publish `gui-mcp`.
+The MCP workflow uses npm trusted publishing through GitHub Actions OIDC. The
+`gui-mcp` package must be configured on npm with this repository, the
+`.github/workflows/mcp-publish.yml` workflow, and the `release` environment.
 
 ## Godot 4.7 C# Sample
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,13 @@
+# gui-mcp
+
+`gui-mcp` is the MCP server for the Gua runtime UI automation protocol.
+
+It proxies MCP tool calls to a running Gua WebSocket bridge, so game runtimes keep
+owning the semantic UI tree while MCP clients consume the protocol.
+
+## Usage
+
+```sh
+bunx gui-mcp@latest mcp
+```
+


### PR DESCRIPTION
## Summary
- `main` への変更を契機に、Inspector 用の GitHub Release 作成ワークフローを追加
- `gui-mcp` を npm へ自動 publish するワークフローを追加
- リリース手順と `gui-mcp` の利用案内を README に追記

## Testing
- Not run (not requested)
- ワークフロー定義と README の更新内容を確認