### PR TITLE
Godot GDScript addonの読み込み安定化とWindows配布リリースを追加

### DIFF
--- a/.github/workflows/godot-plugin-release.yml
+++ b/.github/workflows/godot-plugin-release.yml
@@ -1,0 +1,84 @@
+name: Godot Plugin Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/godot-plugin-release.yml
+      - CMakeLists.txt
+      - CMakePresets.json
+      - examples/godot-gdscript/addons/gua/**
+      - native/gua-core/**
+      - native/gua-runtime/**
+      - native/gua-godot/**
+      - native/gua-ws-bridge/**
+      - protocol/**
+
+permissions:
+  contents: write
+
+concurrency:
+  group: godot-plugin-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-release:
+    name: Build Godot plugin and attach release asset
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Configure native build
+        run: cmake --preset windows-msvc-debug
+
+      - name: Build Godot GDExtension
+        run: cmake --build --preset windows-msvc-debug --target gua-godot
+
+      - name: Package Godot plugin
+        id: package
+        shell: pwsh
+        run: |
+          $shortSha = "${env:GITHUB_SHA}".Substring(0, 12)
+          $packageRoot = Join-Path $env:RUNNER_TEMP "gua-godot-plugin"
+          $addonSource = "examples/godot-gdscript/addons/gua"
+          $addonTarget = Join-Path $packageRoot "addons/gua"
+          $zipPath = Join-Path $env:RUNNER_TEMP "gua-godot-plugin-windows-debug-$shortSha.zip"
+
+          Remove-Item -Recurse -Force $packageRoot, $zipPath -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force $addonTarget | Out-Null
+          New-Item -ItemType Directory -Force (Join-Path $addonTarget "bin") | Out-Null
+
+          Copy-Item "$addonSource/gua.gdextension" $addonTarget
+          Copy-Item "$addonSource/gua.gdextension.uid" $addonTarget
+          Copy-Item "$addonSource/gua_auto_adapter.gd" $addonTarget
+          Copy-Item "$addonSource/plugin.cfg" $addonTarget
+          Copy-Item "$addonSource/plugin.gd" $addonTarget
+          Copy-Item "$addonSource/plugin.gd.uid" $addonTarget
+          Copy-Item "$addonSource/bin/*.dll" (Join-Path $addonTarget "bin")
+
+          Compress-Archive -Path (Join-Path $packageRoot "addons") -DestinationPath $zipPath -CompressionLevel Optimal
+
+          "asset=$zipPath" >> $env:GITHUB_OUTPUT
+          "tag=godot-plugin-$shortSha" >> $env:GITHUB_OUTPUT
+          "name=Gua Godot Plugin $shortSha" >> $env:GITHUB_OUTPUT
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gua-godot-plugin-windows-debug
+          path: ${{ steps.package.outputs.asset }}
+          if-no-files-found: error
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.package.outputs.tag }}
+          name: ${{ steps.package.outputs.name }}
+          body: |
+            Automated Gua Godot plugin build from `${{ github.sha }}`.
+
+            This release contains `addons/gua` with the Windows debug GDExtension DLLs built by `cmake --build --preset windows-msvc-debug --target gua-godot`.
+          files: ${{ steps.package.outputs.asset }}
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ consumer changes:
 
 - Inspector changes build the Tauri Inspector on Windows and attach the bundle
   outputs to a GitHub Release tagged as `inspector-<short-sha>`.
+- Godot GDScript addon changes build `gua-godot` on Windows and attach a zipped
+  `addons/gua` plugin, including the built GDExtension DLLs, to a GitHub Release
+  tagged as `godot-plugin-<short-sha>`.
 - MCP changes build and publish `gui-mcp` to npm as
   `0.0.0-main.<run-number>.<short-sha>` with the `latest` dist-tag.
 
@@ -255,6 +258,26 @@ game process starts an Inspector bridge on `ws://127.0.0.1:8765`, which Gua
 Inspector can connect to while the game is open. The addon includes `plugin.cfg`
 only for standard Godot addon packaging; Gua's runtime API is provided by
 `gua.gdextension`, not by an editor MCP.
+
+For game scripts, instantiate the GDScript adapter through an explicit preload
+instead of relying on `class_name` registration order:
+
+```gdscript
+const GuaAutoAdapterScript := preload("res://addons/gua/gua_auto_adapter.gd")
+
+var ui := GuaAutoAdapterScript.new()
+```
+
+The adapter resolves the native `GuaContext` class through `ClassDB` on first
+use and verifies that required methods such as `consume_click_request` exist
+before dispatching Inspector click requests. If that check fails, rebuild
+`gua-godot`; the stale vendored DLL is the problem, not the game script.
+
+Run the GDScript smoke check with:
+
+```powershell
+C:\Users\testk\.local\bin\Godot_v4.7-stable_win64_console.exe --headless --path examples/godot-gdscript --script res://scripts/gua_smoke.gd
+```
 
 ## Repository Layout
 

--- a/examples/godot-gdscript/README.md
+++ b/examples/godot-gdscript/README.md
@@ -12,6 +12,24 @@ cmake --build --preset windows-msvc-debug --target gua-godot
 Then open this directory in the Godot 4.7 editor. The extension exposes
 `GuaContext` to GDScript through `addons/gua/gua.gdextension`, and
 `addons/gua/gua_auto_adapter.gd` provides the standard-Control auto collector.
+Game scripts should instantiate the adapter from an explicit preload instead of
+depending on Godot's global `class_name` registration order:
+
+```gdscript
+const GuaAutoAdapterScript := preload("res://addons/gua/gua_auto_adapter.gd")
+
+var ui := GuaAutoAdapterScript.new()
+```
+
+The adapter resolves the native `GuaContext` class through `ClassDB` when it is
+first used. If the GDExtension is not loaded, or if the vendored DLL is stale and
+does not expose a required method such as `consume_click_request`, the adapter
+prints an actionable error and stops before Godot raises a generic invalid-call
+error. Rebuild the vendored DLL with:
+
+```powershell
+cmake --build --preset windows-msvc-debug --target gua-godot
+```
 
 Run the project from Godot. The sample starts the Inspector bridge inside the
 running game process on:
@@ -29,3 +47,9 @@ The sample attaches `GuaAutoAdapter` to the root Godot `Control`; the adapter
 collects standard labels and buttons into the semantic UI tree, publishes
 snapshots, observes button clicks, and dispatches Inspector `click_node` requests
 through the normal Godot button signal.
+
+For a headless smoke check of the load-order-safe path:
+
+```powershell
+C:\Users\testk\.local\bin\Godot_v4.7-stable_win64_console.exe --headless --path examples/godot-gdscript --script res://scripts/gua_smoke.gd
+```

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -2,19 +2,40 @@ class_name GuaAutoAdapter
 extends RefCounted
 
 const META_ID := "gua_id"
+const CONTEXT_CLASS := "GuaContext"
+const GDEXTENSION_RESOURCE := "res://addons/gua/gua.gdextension"
+const REBUILD_COMMAND := "cmake --build --preset windows-msvc-debug --target gua-godot"
+const REQUIRED_CONTEXT_METHODS := [
+	"begin_frame",
+	"register_node",
+	"end_frame",
+	"get_ui_tree_json",
+	"enqueue_click",
+	"consume_click_request",
+	"emit_click",
+	"poll_event",
+	"start_inspector_bridge",
+	"inspector_bridge_url",
+]
 
-var context := GuaContext.new()
+var context: Object
 var root: Control
 var buttons_by_id: Dictionary = {}
 var connected_buttons: Dictionary = {}
 var suppressed_clicks: Dictionary = {}
+var gdextension_resource: Resource
+var unavailable := false
 
 
 func attach(root_control: Control) -> void:
 	root = root_control
+	_ensure_context()
 
 
 func update(screen: String) -> void:
+	if not _ensure_context():
+		return
+
 	if root == null:
 		push_error("GuaAutoAdapter.update called before attach.")
 		return
@@ -27,15 +48,93 @@ func update(screen: String) -> void:
 
 
 func start_inspector_bridge(port: int = 8765) -> bool:
+	if not _ensure_context():
+		return false
+
 	return context.start_inspector_bridge(port)
 
 
 func inspector_bridge_url() -> String:
+	if not _ensure_context():
+		return ""
+
 	return context.inspector_bridge_url()
 
 
 func get_ui_tree_json() -> String:
+	if not _ensure_context():
+		return ""
+
 	return context.get_ui_tree_json()
+
+
+func enqueue_click(id: String) -> bool:
+	if not _ensure_context():
+		return false
+
+	return context.enqueue_click(id)
+
+
+func poll_event() -> Dictionary:
+	if not _ensure_context():
+		return {}
+
+	return context.poll_event()
+
+
+func _ensure_context() -> bool:
+	if context != null:
+		return not unavailable
+	if unavailable:
+		return false
+
+	if gdextension_resource == null:
+		gdextension_resource = load(GDEXTENSION_RESOURCE)
+		if gdextension_resource == null:
+			_mark_unavailable(
+				"Failed to load %s. Ensure the Gua addon files are installed and rebuild the Godot GDExtension DLL with: %s"
+				% [GDEXTENSION_RESOURCE, REBUILD_COMMAND]
+			)
+			return false
+
+	if not ClassDB.class_exists(CONTEXT_CLASS) or not ClassDB.can_instantiate(CONTEXT_CLASS):
+		_mark_unavailable(
+			"%s is not available. Ensure addons/gua/gua.gdextension is enabled and rebuild the Godot GDExtension DLL with: %s"
+			% [CONTEXT_CLASS, REBUILD_COMMAND]
+		)
+		return false
+
+	context = ClassDB.instantiate(CONTEXT_CLASS)
+	if context == null:
+		_mark_unavailable(
+			"Failed to instantiate %s. Ensure addons/gua/gua.gdextension loaded successfully and rebuild with: %s"
+			% [CONTEXT_CLASS, REBUILD_COMMAND]
+		)
+		return false
+
+	var missing_methods := _missing_context_methods(context)
+	if not missing_methods.is_empty():
+		_mark_unavailable(
+			"%s is missing required method '%s'. The vendored gua_godot Windows debug DLL is stale. Rebuild it with: %s"
+			% [CONTEXT_CLASS, missing_methods[0], REBUILD_COMMAND]
+		)
+		return false
+
+	return true
+
+
+func _missing_context_methods(candidate: Object) -> Array:
+	var missing_methods := []
+	for method in REQUIRED_CONTEXT_METHODS:
+		if not candidate.has_method(method):
+			missing_methods.append(method)
+	return missing_methods
+
+
+func _mark_unavailable(message: String) -> void:
+	unavailable = true
+	context = null
+	push_error(message)
 
 
 func _collect_control(control: Control) -> void:

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -1,0 +1,75 @@
+extends SceneTree
+
+const GuaAutoAdapterScript := preload("res://addons/gua/gua_auto_adapter.gd")
+
+var pressed_count := 0
+
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	var screen := Control.new()
+	screen.name = "screen"
+	screen.size = Vector2(1280, 720)
+	root.add_child(screen)
+
+	var button := Button.new()
+	button.name = "start"
+	button.text = "Start Game"
+	button.position = Vector2(512, 312)
+	button.size = Vector2(256, 56)
+	button.pressed.connect(_on_start_pressed)
+	screen.add_child(button)
+
+	await process_frame
+
+	var ui := GuaAutoAdapterScript.new()
+	var missing_methods := ui._missing_context_methods(RefCounted.new())
+	if not missing_methods.has("consume_click_request"):
+		_fail("Gua smoke did not detect missing consume_click_request on an incompatible context.")
+		return
+
+	ui.attach(screen)
+	ui.update("title")
+
+	var tree_json := ui.get_ui_tree_json()
+	if not tree_json.contains("\"start\"") or not tree_json.contains("\"button\""):
+		_fail("Gua smoke did not publish the start button in the UI tree: %s" % tree_json)
+		return
+
+	if not ui.enqueue_click("start"):
+		_fail("Gua smoke failed to enqueue click request for start.")
+		return
+
+	ui.update("title")
+
+	var click_seen := false
+	for _attempt in range(8):
+		var event := ui.poll_event()
+		if event.is_empty():
+			break
+		if event.get("type", "") == "click" and event.get("node_id", "") == "start":
+			click_seen = true
+			break
+
+	if not click_seen:
+		_fail("Gua smoke did not observe click event for start.")
+		return
+
+	if pressed_count != 1:
+		_fail("Gua smoke expected one Button.pressed signal, got %d." % pressed_count)
+		return
+
+	print("Gua GDScript smoke passed.")
+	quit(0)
+
+
+func _on_start_pressed() -> void:
+	pressed_count += 1
+
+
+func _fail(message: String) -> void:
+	push_error(message)
+	quit(1)

--- a/examples/godot-gdscript/scripts/main.gd
+++ b/examples/godot-gdscript/scripts/main.gd
@@ -1,9 +1,11 @@
 extends Control
 
+const GuaAutoAdapterScript := preload("res://addons/gua/gua_auto_adapter.gd")
+
 @export var start_inspector_bridge_on_ready := true
 @export var inspector_bridge_port := 8765
 
-var ui := GuaAutoAdapter.new()
+var ui := GuaAutoAdapterScript.new()
 var loading := false
 var title_label: Label
 var start_button: Button

--- a/native/gua-godot/README.md
+++ b/native/gua-godot/README.md
@@ -21,5 +21,19 @@ and the shared WebSocket bridge. A GDScript runtime can call
 `start_inspector_bridge(8765)` on `GuaContext` so Gua Inspector can connect to
 the running Godot game at `ws://127.0.0.1:8765`.
 
+The GDScript addon should be loaded from scripts with an explicit preload:
+
+```gdscript
+const GuaAutoAdapterScript := preload("res://addons/gua/gua_auto_adapter.gd")
+
+var ui := GuaAutoAdapterScript.new()
+```
+
+`gua_auto_adapter.gd` resolves the native `GuaContext` class through `ClassDB`
+instead of calling `GuaContext.new()` at script load time. It also checks the
+required GDExtension method surface before dispatching click requests. If a game
+reports that `consume_click_request` does not exist, the vendored DLL is stale;
+rebuild this target and use the DLL emitted into `examples/godot-gdscript/addons/gua/bin`.
+
 The GDExtension is intentionally thin. It does not reimplement Gua runtime
 behavior and does not turn Gua into a Godot UI framework or editor MCP.


### PR DESCRIPTION
## Summary
- `gua_auto_adapter.gd` を `preload` 前提の初期化に切り替え、`ClassDB` 経由で `GuaContext` を解決するようにした
- 必須メソッドの存在確認を追加し、古い vendored DLL による不明瞭な実行時エラーを先に検出するようにした
- Godot GDScript 向けの headless smoke テストを追加した
- `gua-godot` の Windows debug ビルドを ZIP 化して GitHub Release に添付する workflow を追加した
- README とサンプル README に利用手順と検証手順を追記した

## Testing
- `examples/godot-gdscript/scripts/gua_smoke.gd` による headless smoke チェックを追加
- `gua-godot` の Windows debug ビルドと release パッケージング手順を workflow に追加
- Not run (not requested)