### PR TITLE
.NET向け NuGet パッケージとテスト支援を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 out/
 dist/
+artifacts/
 bin/
 obj/
 target/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <GuaPackageVersion>0.5.0-preview.2</GuaPackageVersion>
+    <GuaPackageOutputPath>$(MSBuildThisFileDirectory)artifacts\packages</GuaPackageOutputPath>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,73 @@ GuaAssertions.GetByRole(ui, "button", "Start Game").Click();
 GuaAssertions.WaitForText(ui, "Loading...").ToBeVisible();
 ```
 
+`Click()` intentionally enqueues a click request; it does not directly mutate
+the game. A game adapter, such as the ImGui or Godot adapter, must consume the
+request on a later frame and emit the observed click event. Tests that do not
+run a real engine adapter can use `GuaTestHost` for the same loop:
+
+```csharp
+using var ui = new GuaContext();
+var host = new GuaTestHost(ui);
+var loading = false;
+
+host.Frame("title", frame =>
+{
+    frame.Button("start", "Start Game", new GuaBounds(100, 100, 240, 64));
+});
+
+GuaAssertions.GetByRole(ui, "button", "Start Game").Click();
+
+host.Frame("title", frame =>
+{
+    frame.Button("start", "Start Game", new GuaBounds(100, 100, 240, 64));
+});
+
+host.DrainClickEvents(id => loading = id == "start");
+
+host.Frame("loading", frame =>
+{
+    if (loading)
+    {
+        frame.Text("loading", "Loading...", new GuaBounds(100, 180, 240, 24));
+    }
+});
+
+GuaAssertions.WaitForText(ui, "Loading...").ToBeVisible();
+```
+
+Real .NET tests should use an existing test runner such as NUnit. `Gua.Testing`
+does not try to become a Vitest-style runner; it provides Gua-specific locators,
+waits, assertions, and adapter test loops inside normal NUnit tests. One C# file
+can contain multiple `[Test]` methods:
+
+```csharp
+using Gua.Core;
+using Gua.Testing;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class TitleScreenTests
+{
+    [Test]
+    public void StartClickShowsLoadingText()
+    {
+        using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);
+        using var ui = new GuaContext();
+        var host = new GuaTestHost(ui);
+
+        host.Frame("title", frame =>
+        {
+            frame.Button("start", "Start Game", new GuaBounds(100, 100, 240, 64));
+        });
+
+        GuaAssertions.GetByRole(ui, "button", "Start Game").Click();
+    }
+}
+```
+
+The repository includes a runnable NUnit sample in `examples/dotnet-nunit`.
+
 ```cpp
 context.log(gua::LogLevel::info, "title screen opened");
 context.set_screenshot("data:image/png;base64,...", 1280, 720);
@@ -79,6 +146,49 @@ cmake --build --preset windows-msvc-debug
 
 The portable boundary remains the C ABI. macOS and iOS should use Apple Clang,
 and Android should use Android NDK Clang when those targets are added.
+
+## .NET Testing
+
+The .NET packages are prepared for local NuGet packing:
+
+```powershell
+dotnet pack bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release
+dotnet pack bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release
+```
+
+The packages are written to `artifacts/packages`. `Gua.Testing` declares a NuGet
+dependency on the matching `Gua.Core` package, so a test project only needs the
+testing package:
+
+```xml
+<PackageReference Include="Gua.Testing" Version="0.5.0-preview.2" />
+```
+
+`Gua.Core` is also delivered as a NuGet package and `Gua.Testing` depends on the
+matching version. The Windows x64 native runtime is included in `Gua.Core` under
+`runtimes/win-x64/native/gua.dll`, so a normal package restore/build copies it to
+the consuming app or test output. `GUA_NATIVE_DIR` remains as an override for
+locally built native runtimes. A missing or wrong architecture native library is
+reported with the exact checked paths.
+
+Run the standalone testing sample:
+
+```powershell
+cmake --preset windows-msvc-debug
+cmake --build --preset windows-msvc-debug --target gua
+$env:GUA_NATIVE_DIR = "$PWD\build\windows-msvc-debug\native\gua-core\Debug"
+dotnet run --project examples/dotnet-testing/GuaDotNetTestingSample.csproj
+```
+
+Run the NUnit testing sample:
+
+```powershell
+cmake --preset windows-msvc-release
+cmake --build --preset windows-msvc-release --target gua
+dotnet pack bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release
+dotnet pack bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release
+dotnet test examples/dotnet-nunit/GuaDotNetNUnitSample.csproj
+```
 
 ## Inspector
 

--- a/bindings/dotnet/src/Gua.Core/Gua.Core.csproj
+++ b/bindings/dotnet/src/Gua.Core/Gua.Core.csproj
@@ -4,5 +4,29 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PackageId>Gua.Core</PackageId>
+    <Version>$(GuaPackageVersion)</Version>
+    <Authors>Gua contributors</Authors>
+    <Title>Gua Core</Title>
+    <Description>.NET P/Invoke bindings for the Gua runtime UI automation C ABI.</Description>
+    <PackageTags>gua;game-ui;automation;testing;pinvoke</PackageTags>
+    <PackageProjectUrl>https://github.com/link1345/gua</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/link1345/gua</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageOutputPath>$(GuaPackageOutputPath)</PackageOutputPath>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None
+      Include="..\..\..\..\build\windows-msvc-release\native\gua-core\Release\gua.dll"
+      Pack="true"
+      PackagePath="runtimes\win-x64\native\gua.dll"
+      Visible="false"
+      Condition="Exists('..\..\..\..\build\windows-msvc-release\native\gua-core\Release\gua.dll')" />
+  </ItemGroup>
 </Project>

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -6,7 +6,19 @@ public sealed class GuaContext : IDisposable
 
     public GuaContext()
     {
-        _handle = Native.gua_create_context();
+        try
+        {
+            _handle = Native.gua_create_context();
+        }
+        catch (DllNotFoundException ex)
+        {
+            throw new InvalidOperationException(Native.NativeLoadErrorMessage(ex), ex);
+        }
+        catch (BadImageFormatException ex)
+        {
+            throw new InvalidOperationException(Native.NativeLoadErrorMessage(ex), ex);
+        }
+
         if (_handle == nint.Zero)
         {
             throw new InvalidOperationException("Failed to create a Gua context.");

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -6,6 +6,8 @@ namespace Gua.Core;
 internal static partial class Native
 {
     internal const int NodeIdBufferSize = 128;
+    private static readonly object ResolveLock = new();
+    private static string[] _lastCandidateDirectories = [];
 
     internal unsafe struct GuaNativeEvent
     {
@@ -31,7 +33,13 @@ internal static partial class Native
                 ? "libgua.dylib"
                 : "libgua.so";
 
-        foreach (var directory in CandidateNativeDirectories(assembly))
+        var directories = CandidateNativeDirectories(assembly).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        lock (ResolveLock)
+        {
+            _lastCandidateDirectories = directories;
+        }
+
+        foreach (var directory in directories)
         {
             var candidate = Path.Combine(directory, fileName);
             if (File.Exists(candidate) && NativeLibrary.TryLoad(candidate, out var handle))
@@ -43,6 +51,31 @@ internal static partial class Native
         return NativeLibrary.TryLoad(libraryName, assembly, searchPath, out var fallbackHandle)
             ? fallbackHandle
             : nint.Zero;
+    }
+
+    internal static string NativeLoadErrorMessage(Exception exception)
+    {
+        var fileName = OperatingSystem.IsWindows()
+            ? "gua.dll"
+            : OperatingSystem.IsMacOS()
+                ? "libgua.dylib"
+                : "libgua.so";
+
+        string[] directories;
+        lock (ResolveLock)
+        {
+            directories = _lastCandidateDirectories;
+        }
+
+        if (directories.Length == 0)
+        {
+            directories = CandidateNativeDirectories(typeof(Native).Assembly).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        }
+
+        var searched = string.Join(Environment.NewLine, directories.Select(directory => $"  - {Path.Combine(directory, fileName)}"));
+        return
+            $"Failed to load the native Gua runtime '{fileName}'. Build native/gua-core and make the library discoverable with GUA_NATIVE_DIR, the .NET output directory, or the current directory." +
+            $"{Environment.NewLine}Searched:{Environment.NewLine}{searched}{Environment.NewLine}Original error: {exception.Message}";
     }
 
     private static IEnumerable<string> CandidateNativeDirectories(Assembly assembly)

--- a/bindings/dotnet/src/Gua.Core/README.md
+++ b/bindings/dotnet/src/Gua.Core/README.md
@@ -1,0 +1,28 @@
+# Gua.Core
+
+`Gua.Core` is the .NET binding for the native Gua C ABI.
+
+The NuGet package includes the Windows x64 native runtime at:
+
+```text
+runtimes/win-x64/native/gua.dll
+```
+
+.NET copies that native asset to the consuming app or test output as part of
+normal package restore/build. `GUA_NATIVE_DIR` remains available when you want to
+override the packaged runtime with a locally built one.
+
+At runtime the resolver checks:
+
+1. `GUA_NATIVE_DIR`
+2. the .NET output directory
+3. the assembly directory
+4. the current directory
+
+To pack the NuGet package locally, build the release native runtime first:
+
+```powershell
+cmake --preset windows-msvc-release
+cmake --build --preset windows-msvc-release --target gua
+dotnet pack bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release
+```

--- a/bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj
+++ b/bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj
@@ -7,5 +7,23 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <PackageId>Gua.Testing</PackageId>
+    <Version>$(GuaPackageVersion)</Version>
+    <Authors>Gua contributors</Authors>
+    <Title>Gua Testing</Title>
+    <Description>Assertion, locator, wait, and test-host helpers for Gua runtime UI automation.</Description>
+    <PackageTags>gua;game-ui;automation;testing;xunit;nunit;mstest</PackageTags>
+    <PackageProjectUrl>https://github.com/link1345/gua</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/link1345/gua</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageOutputPath>$(GuaPackageOutputPath)</PackageOutputPath>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 </Project>

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertionException.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertionException.cs
@@ -1,0 +1,9 @@
+namespace Gua.Testing;
+
+public sealed class GuaAssertionException : Exception
+{
+    public GuaAssertionException(string message)
+        : base(message)
+    {
+    }
+}

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertionOptions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertionOptions.cs
@@ -1,0 +1,8 @@
+namespace Gua.Testing;
+
+public sealed class GuaAssertionOptions
+{
+    public static GuaAssertionOptions Default { get; } = new();
+
+    public Action<string> Fail { get; init; } = message => throw new GuaAssertionException(message);
+}

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertionScope.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertionScope.cs
@@ -1,0 +1,47 @@
+namespace Gua.Testing;
+
+public sealed class GuaAssertionScope : IDisposable
+{
+    private readonly GuaAssertionOptions _previous;
+
+    private GuaAssertionScope(GuaAssertionOptions options)
+    {
+        _previous = GuaAssertions.Options;
+        GuaAssertions.Options = options;
+    }
+
+    public static GuaAssertionScope Use(GuaAssertionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return new GuaAssertionScope(options);
+    }
+
+    public static GuaAssertionScope UseXUnit(Action<string> fail)
+    {
+        return UseNamedFramework("xUnit", fail);
+    }
+
+    public static GuaAssertionScope UseNUnit(Action<string> fail)
+    {
+        return UseNamedFramework("NUnit", fail);
+    }
+
+    public static GuaAssertionScope UseMSTest(Action<string> fail)
+    {
+        return UseNamedFramework("MSTest", fail);
+    }
+
+    public void Dispose()
+    {
+        GuaAssertions.Options = _previous;
+    }
+
+    private static GuaAssertionScope UseNamedFramework(string frameworkName, Action<string> fail)
+    {
+        ArgumentNullException.ThrowIfNull(fail);
+        return Use(new GuaAssertionOptions
+        {
+            Fail = message => fail($"Gua assertion failed for {frameworkName}: {message}"),
+        });
+    }
+}

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -1,22 +1,41 @@
+using System.Diagnostics;
+using System.Text.Json;
 using Gua.Core;
 
 namespace Gua.Testing;
 
 public static class GuaAssertions
 {
+    private static readonly AsyncLocal<GuaAssertionOptions?> CurrentOptions = new();
+
+    public static GuaAssertionOptions Options
+    {
+        get => CurrentOptions.Value ?? GuaAssertionOptions.Default;
+        set => CurrentOptions.Value = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
     public static GuaNodeExpectation GetById(GuaContext context, string id)
     {
-        return new GuaNodeExpectation(context, context.FindNodeById(id));
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        return new GuaNodeExpectation(context, id, $"id '{id}'");
     }
 
     public static GuaNodeExpectation GetByRole(GuaContext context, string role, string? name = null)
     {
-        return new GuaNodeExpectation(context, context.FindNodeByRole(role, name));
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(role);
+
+        var id = context.FindNodeByRole(role, name);
+        var description = name is null ? $"role '{role}'" : $"role '{role}' and label '{name}'";
+        return new GuaNodeExpectation(context, id, description);
     }
 
     public static GuaNodeExpectation GetByText(GuaContext context, string text)
     {
-        return new GuaNodeExpectation(context, context.FindNodeByText(text));
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+        return new GuaNodeExpectation(context, context.FindNodeByText(text), $"text '{text}'");
     }
 
     public static GuaNodeExpectation ExpectNode(GuaContext context, string id)
@@ -26,41 +45,152 @@ public static class GuaAssertions
 
     public static void WaitFor(GuaNodeExpectation expectation, TimeSpan? timeout = null)
     {
+        ArgumentNullException.ThrowIfNull(expectation);
         expectation.WaitFor(timeout);
     }
 
     public static GuaNodeExpectation WaitForId(GuaContext context, string id, TimeSpan? timeout = null)
     {
-        return WaitForQuery(() => GetById(context, id), $"id: {id}", timeout);
+        return WaitForQuery(() => GetById(context, id).RequireExistingSnapshot(), $"id '{id}'", timeout);
     }
 
     public static GuaNodeExpectation WaitForRole(GuaContext context, string role, string? name = null, TimeSpan? timeout = null)
     {
-        return WaitForQuery(() => GetByRole(context, role, name), name is null ? $"role: {role}" : $"role and name: {role}, {name}", timeout);
+        var description = name is null ? $"role '{role}'" : $"role '{role}' and label '{name}'";
+        return WaitForQuery(() => GetByRole(context, role, name).RequireExistingSnapshot(), description, timeout);
     }
 
     public static GuaNodeExpectation WaitForText(GuaContext context, string text, TimeSpan? timeout = null)
     {
-        return WaitForQuery(() => GetByText(context, text), $"text: {text}", timeout);
+        return WaitForQuery(() => GetByText(context, text).RequireExistingSnapshot(), $"text '{text}'", timeout);
+    }
+
+    public static void WaitUntil(
+        Func<bool> condition,
+        string description,
+        TimeSpan? timeout = null,
+        TimeSpan? pollInterval = null)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(description);
+
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(1));
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(10);
+        do
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            Thread.Sleep(interval);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        Fail($"Timed out after {FormatTimeout(timeout)} waiting for {description}.");
+    }
+
+    internal static void Fail(string message)
+    {
+        Options.Fail(message);
+        throw new GuaAssertionException(message);
+    }
+
+    internal static GuaNodeSnapshot? TryGetSnapshot(GuaContext context, string id)
+    {
+        using var document = JsonDocument.Parse(context.GetUiTreeJson());
+        if (!document.RootElement.TryGetProperty("nodes", out var nodes) || nodes.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var node in nodes.EnumerateArray())
+        {
+            var nodeId = node.GetProperty("id").GetString();
+            if (!string.Equals(nodeId, id, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var bounds = node.GetProperty("bounds");
+            var actions = new List<string>();
+            if (node.TryGetProperty("actions", out var actionValues) && actionValues.ValueKind == JsonValueKind.Array)
+            {
+                actions.AddRange(actionValues.EnumerateArray().Select(action => action.GetString() ?? string.Empty));
+            }
+
+            return new GuaNodeSnapshot(
+                Id: id,
+                Role: node.GetProperty("role").GetString() ?? string.Empty,
+                Label: node.GetProperty("label").GetString() ?? string.Empty,
+                Bounds: new GuaBounds(
+                    bounds.GetProperty("x").GetSingle(),
+                    bounds.GetProperty("y").GetSingle(),
+                    bounds.GetProperty("w").GetSingle(),
+                    bounds.GetProperty("h").GetSingle()),
+                Visible: node.GetProperty("visible").GetBoolean(),
+                Enabled: node.GetProperty("enabled").GetBoolean(),
+                Actions: actions);
+        }
+
+        return null;
+    }
+
+    internal static string DescribeTree(GuaContext context)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(context.GetUiTreeJson());
+            if (!document.RootElement.TryGetProperty("nodes", out var nodes) || nodes.GetArrayLength() == 0)
+            {
+                return "Current Gua tree has no nodes.";
+            }
+
+            var descriptions = nodes.EnumerateArray()
+                .Take(8)
+                .Select(node =>
+                {
+                    var id = node.GetProperty("id").GetString();
+                    var role = node.GetProperty("role").GetString();
+                    var label = node.GetProperty("label").GetString();
+                    var visible = node.GetProperty("visible").GetBoolean() ? "visible" : "hidden";
+                    var enabled = node.GetProperty("enabled").GetBoolean() ? "enabled" : "disabled";
+                    return $"{id} ({role}, '{label}', {visible}, {enabled})";
+                });
+
+            return "Current Gua nodes: " + string.Join("; ", descriptions) + ".";
+        }
+        catch (JsonException)
+        {
+            return "Current Gua tree JSON could not be parsed.";
+        }
     }
 
     private static GuaNodeExpectation WaitForQuery(Func<GuaNodeExpectation> query, string description, TimeSpan? timeout)
     {
         var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(1));
+        Exception? lastException = null;
         do
         {
             try
             {
                 return query();
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException ex)
             {
+                lastException = ex;
                 Thread.Sleep(10);
             }
         }
         while (DateTime.UtcNow < deadline);
 
-        throw new TimeoutException($"Timed out waiting for Gua node by {description}");
+        Fail($"Timed out after {FormatTimeout(timeout)} waiting for Gua node by {description}. {lastException?.Message}");
+        throw new UnreachableException();
+    }
+
+    private static string FormatTimeout(TimeSpan? timeout)
+    {
+        return (timeout ?? TimeSpan.FromSeconds(1)).ToString("g");
     }
 }
 
@@ -68,61 +198,214 @@ public sealed class GuaNodeExpectation
 {
     private readonly GuaContext _context;
     private readonly string _id;
+    private readonly string _description;
 
-    internal GuaNodeExpectation(GuaContext context, string id)
+    internal GuaNodeExpectation(GuaContext context, string id, string description)
     {
         _context = context;
         _id = id;
+        _description = description;
     }
 
-    public void ToExist()
-    {
-        _context.GetNodeState(_id);
-    }
+    public string Id => _id;
 
-    public void ToBeVisible()
+    public GuaNodeSnapshot Snapshot => GetSnapshotOrFail();
+
+    public GuaNodeExpectation ToExist()
     {
-        var state = _context.GetNodeState(_id);
-        if (!state.Visible)
+        if (GuaAssertions.TryGetSnapshot(_context, _id) is null)
         {
-            throw new InvalidOperationException($"Expected Gua node to be visible: {_id}");
+            GuaAssertions.Fail($"Expected Gua node {_description} to exist. {GuaAssertions.DescribeTree(_context)}");
         }
+
+        return this;
     }
 
-    public void ToBeEnabled()
+    public GuaNodeExpectation NotToExist()
     {
-        var state = _context.GetNodeState(_id);
-        if (!state.Enabled)
+        if (GuaAssertions.TryGetSnapshot(_context, _id) is not null)
         {
-            throw new InvalidOperationException($"Expected Gua node to be enabled: {_id}");
+            GuaAssertions.Fail($"Expected Gua node {_description} not to exist. {GuaAssertions.DescribeTree(_context)}");
         }
+
+        return this;
     }
 
-    public void Click()
+    public GuaNodeExpectation ToBeVisible()
     {
+        var snapshot = GetSnapshotOrFail();
+        if (!snapshot.Visible)
+        {
+            GuaAssertions.Fail($"Expected Gua node {_description} to be visible, but it was hidden. {GuaAssertions.DescribeTree(_context)}");
+        }
+
+        return this;
+    }
+
+    public GuaNodeExpectation ToBeHidden()
+    {
+        var snapshot = GetSnapshotOrFail();
+        if (snapshot.Visible)
+        {
+            GuaAssertions.Fail($"Expected Gua node {_description} to be hidden, but it was visible. {GuaAssertions.DescribeTree(_context)}");
+        }
+
+        return this;
+    }
+
+    public GuaNodeExpectation ToBeEnabled()
+    {
+        var snapshot = GetSnapshotOrFail();
+        if (!snapshot.Enabled)
+        {
+            GuaAssertions.Fail($"Expected Gua node {_description} to be enabled, but it was disabled. {GuaAssertions.DescribeTree(_context)}");
+        }
+
+        return this;
+    }
+
+    public GuaNodeExpectation ToBeDisabled()
+    {
+        var snapshot = GetSnapshotOrFail();
+        if (snapshot.Enabled)
+        {
+            GuaAssertions.Fail($"Expected Gua node {_description} to be disabled, but it was enabled. {GuaAssertions.DescribeTree(_context)}");
+        }
+
+        return this;
+    }
+
+    public GuaNodeExpectation ToHaveRole(string role)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(role);
+        var snapshot = GetSnapshotOrFail();
+        if (!string.Equals(snapshot.Role, role, StringComparison.Ordinal))
+        {
+            GuaAssertions.Fail($"Expected Gua node {_description} to have role '{role}', but it had role '{snapshot.Role}'.");
+        }
+
+        return this;
+    }
+
+    public GuaNodeExpectation ToHaveLabel(string label)
+    {
+        ArgumentNullException.ThrowIfNull(label);
+        var snapshot = GetSnapshotOrFail();
+        if (!string.Equals(snapshot.Label, label, StringComparison.Ordinal))
+        {
+            GuaAssertions.Fail($"Expected Gua node {_description} to have label '{label}', but it had label '{snapshot.Label}'.");
+        }
+
+        return this;
+    }
+
+    public GuaNodeExpectation ToHaveAction(string action)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(action);
+        var snapshot = GetSnapshotOrFail();
+        if (!snapshot.Actions.Contains(action, StringComparer.Ordinal))
+        {
+            GuaAssertions.Fail($"Expected Gua node {_description} to expose action '{action}', but actions were [{string.Join(", ", snapshot.Actions)}].");
+        }
+
+        return this;
+    }
+
+    public GuaNodeExpectation Click()
+    {
+        ToBeVisible();
+        ToBeEnabled();
+        ToHaveAction("click");
+
         if (!_context.EnqueueClick(_id))
         {
-            throw new InvalidOperationException($"Failed to click Gua node: {_id}");
+            GuaAssertions.Fail(
+                $"Failed to enqueue click for Gua node {_description}. Click() records a request; the game adapter or GuaTestHost must consume it and emit a click event.");
         }
+
+        return this;
     }
 
-    public void WaitFor(TimeSpan? timeout = null)
+    public GuaNodeExpectation ClickAndWaitForEvent(TimeSpan? timeout = null)
+    {
+        Click();
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(1));
+        do
+        {
+            while (_context.TryPollEvent(out var e))
+            {
+                if (e.Type == GuaEventType.Click && string.Equals(e.NodeId, _id, StringComparison.Ordinal))
+                {
+                    return this;
+                }
+            }
+
+            Thread.Sleep(10);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        GuaAssertions.Fail($"Timed out waiting for click event from Gua node {_description}. The adapter consumed no click request for '{_id}'.");
+        return this;
+    }
+
+    public GuaNodeExpectation WaitFor(TimeSpan? timeout = null)
+    {
+        return WaitUntil(node => node is not null, "exist", timeout);
+    }
+
+    public GuaNodeExpectation WaitUntilVisible(TimeSpan? timeout = null)
+    {
+        return WaitUntil(node => node is { Visible: true }, "be visible", timeout);
+    }
+
+    public GuaNodeExpectation WaitUntilHidden(TimeSpan? timeout = null)
+    {
+        return WaitUntil(node => node is { Visible: false } || node is null, "be hidden or removed", timeout);
+    }
+
+    public GuaNodeExpectation WaitUntilEnabled(TimeSpan? timeout = null)
+    {
+        return WaitUntil(node => node is { Enabled: true }, "be enabled", timeout);
+    }
+
+    public GuaNodeExpectation WaitUntilDisabled(TimeSpan? timeout = null)
+    {
+        return WaitUntil(node => node is { Enabled: false }, "be disabled", timeout);
+    }
+
+    internal GuaNodeExpectation RequireExistingSnapshot()
+    {
+        ToExist();
+        return this;
+    }
+
+    private GuaNodeExpectation WaitUntil(Func<GuaNodeSnapshot?, bool> condition, string description, TimeSpan? timeout)
     {
         var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(1));
         do
         {
-            try
+            if (condition(GuaAssertions.TryGetSnapshot(_context, _id)))
             {
-                _context.GetNodeState(_id);
-                return;
+                return this;
             }
-            catch (InvalidOperationException)
-            {
-                Thread.Sleep(10);
-            }
+
+            Thread.Sleep(10);
         }
         while (DateTime.UtcNow < deadline);
 
-        throw new TimeoutException($"Timed out waiting for Gua node: {_id}");
+        GuaAssertions.Fail($"Timed out waiting for Gua node {_description} to {description}. {GuaAssertions.DescribeTree(_context)}");
+        return this;
+    }
+
+    private GuaNodeSnapshot GetSnapshotOrFail()
+    {
+        var snapshot = GuaAssertions.TryGetSnapshot(_context, _id);
+        if (snapshot is null)
+        {
+            GuaAssertions.Fail($"Expected Gua node {_description} to exist. {GuaAssertions.DescribeTree(_context)}");
+            throw new UnreachableException();
+        }
+
+        return snapshot;
     }
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaNodeSnapshot.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaNodeSnapshot.cs
@@ -1,0 +1,12 @@
+using Gua.Core;
+
+namespace Gua.Testing;
+
+public sealed record GuaNodeSnapshot(
+    string Id,
+    string Role,
+    string Label,
+    GuaBounds Bounds,
+    bool Visible,
+    bool Enabled,
+    IReadOnlyList<string> Actions);

--- a/bindings/dotnet/src/Gua.Testing/GuaTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaTestHost.cs
@@ -1,0 +1,90 @@
+using Gua.Core;
+
+namespace Gua.Testing;
+
+public sealed class GuaTestHost
+{
+    private readonly GuaContext _context;
+
+    public GuaTestHost(GuaContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public void Frame(string screen, Action<GuaTestHost> buildUi)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(screen);
+        ArgumentNullException.ThrowIfNull(buildUi);
+
+        _context.BeginFrame(screen);
+        buildUi(this);
+        _context.EndFrame();
+    }
+
+    public bool Button(
+        string id,
+        string label,
+        GuaBounds bounds,
+        bool visible = true,
+        bool enabled = true)
+    {
+        RegisterNode(id, "button", label, bounds, visible, enabled);
+        if (!_context.ConsumeClickRequest(id))
+        {
+            return false;
+        }
+
+        _context.EmitClick(id);
+        return true;
+    }
+
+    public void Text(
+        string id,
+        string text,
+        GuaBounds bounds,
+        bool visible = true)
+    {
+        RegisterNode(id, "text", text, bounds, visible, enabled: false);
+    }
+
+    public void Panel(
+        string id,
+        string label,
+        GuaBounds bounds,
+        bool visible = true)
+    {
+        RegisterNode(id, "panel", label, bounds, visible, enabled: false);
+    }
+
+    public void RegisterNode(
+        string id,
+        string role,
+        string label,
+        GuaBounds bounds,
+        bool visible = true,
+        bool enabled = true)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(role);
+        _context.RegisterNode(id, role, label, bounds, visible, enabled);
+    }
+
+    public bool DrainClickEvents(Action<string> onClick)
+    {
+        ArgumentNullException.ThrowIfNull(onClick);
+
+        var handled = false;
+        while (_context.TryPollEvent(out var e))
+        {
+            if (e.Type != GuaEventType.Click)
+            {
+                continue;
+            }
+
+            handled = true;
+            onClick(e.NodeId);
+        }
+
+        return handled;
+    }
+}

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -1,0 +1,53 @@
+# Gua.Testing
+
+`Gua.Testing` adds locator, assertion, wait, and test-host helpers on top of
+`Gua.Core`.
+
+```csharp
+using var ui = new GuaContext();
+var host = new GuaTestHost(ui);
+var loading = false;
+
+host.Frame("title", frame =>
+{
+    if (frame.Button("start", "Start Game", new GuaBounds(0, 0, 200, 40)))
+    {
+        loading = true;
+    }
+});
+
+GuaAssertions.GetByRole(ui, "button", "Start Game").Click();
+
+host.Frame("title", frame =>
+{
+    if (frame.Button("start", "Start Game", new GuaBounds(0, 0, 200, 40)))
+    {
+        loading = true;
+    }
+});
+
+host.Frame("loading", frame =>
+{
+    if (loading)
+    {
+        frame.Text("loading", "Loading...", new GuaBounds(0, 48, 200, 24));
+    }
+});
+
+GuaAssertions.WaitForText(ui, "Loading...").ToBeVisible();
+```
+
+`Click()` enqueues a click request. A real adapter or `GuaTestHost` must consume
+that request and emit the click event while advancing frames.
+
+For real .NET tests, use NUnit, xUnit, or MSTest as the test runner and use
+`Gua.Testing` inside each test. The repository's recommended sample is NUnit:
+
+```csharp
+using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);
+
+GuaAssertions.GetById(ui, "start").ToBeVisible();
+```
+
+See `examples/dotnet-nunit` for a complete NUnit project with multiple `[Test]`
+methods in one file.

--- a/examples/dotnet-nunit/GuaDotNetNUnitSample.csproj
+++ b/examples/dotnet-nunit/GuaDotNetNUnitSample.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Gua.Testing" Version="$(GuaPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/examples/dotnet-nunit/NuGet.config
+++ b/examples/dotnet-nunit/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="gua-local" value="..\..\artifacts\packages" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/examples/dotnet-nunit/README.md
+++ b/examples/dotnet-nunit/README.md
@@ -1,0 +1,31 @@
+# Gua .NET NUnit Sample
+
+This sample shows the recommended .NET shape for real tests: use NUnit as the
+test runner and use `Gua.Testing` for Gua-specific locators, waits, assertions,
+and adapter test loops.
+
+One C# file can contain multiple NUnit tests:
+
+```csharp
+[Test]
+public void StartClickShowsLoadingText()
+{
+    using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);
+    GuaAssertions.GetByRole(ui, "button", "Start Game").Click();
+}
+```
+
+This project intentionally references `Gua.Testing` as a NuGet package instead
+of a source `ProjectReference`.
+
+Run it after building the release native runtime and packing the local NuGet
+packages. `Gua.Core` carries `gua.dll` as a `runtimes/win-x64/native` asset, so
+`GUA_NATIVE_DIR` is not required for this package-based sample.
+
+```powershell
+cmake --preset windows-msvc-release
+cmake --build --preset windows-msvc-release --target gua
+dotnet pack bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release
+dotnet pack bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release
+dotnet test examples/dotnet-nunit/GuaDotNetNUnitSample.csproj
+```

--- a/examples/dotnet-nunit/TitleScreenTests.cs
+++ b/examples/dotnet-nunit/TitleScreenTests.cs
@@ -1,0 +1,72 @@
+using Gua.Core;
+using Gua.Testing;
+using NUnit.Framework;
+
+namespace Gua.DotNetNUnitSample;
+
+[TestFixture]
+public sealed class TitleScreenTests
+{
+    [Test]
+    public void StartClickShowsLoadingText()
+    {
+        using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);
+        using var ui = new GuaContext();
+        var host = new GuaTestHost(ui);
+        var loading = false;
+
+        RenderTitle(host, loading);
+
+        GuaAssertions.GetByRole(ui, "button", "Start Game")
+            .ToBeVisible()
+            .ToBeEnabled()
+            .Click();
+
+        RenderTitle(host, loading);
+        host.DrainClickEvents(nodeId =>
+        {
+            if (nodeId == "start")
+            {
+                loading = true;
+            }
+        });
+        RenderTitle(host, loading);
+
+        GuaAssertions.WaitForText(ui, "Loading...", TimeSpan.FromSeconds(1))
+            .ToBeVisible()
+            .ToHaveRole("text");
+    }
+
+    [Test]
+    public void DisabledStartButtonCannotBeClicked()
+    {
+        using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);
+        using var ui = new GuaContext();
+        var host = new GuaTestHost(ui);
+
+        host.Frame("title", frame =>
+        {
+            frame.Button("start", "Start Game", new GuaBounds(100, 100, 240, 64), enabled: false);
+        });
+
+        GuaAssertions.GetById(ui, "start")
+            .ToBeVisible()
+            .ToBeDisabled();
+    }
+
+    private static void RenderTitle(GuaTestHost host, bool loading)
+    {
+        host.Frame(loading ? "loading" : "title", frame =>
+        {
+            if (!loading)
+            {
+                frame.Button("start", "Start Game", new GuaBounds(100, 100, 240, 64));
+            }
+
+            if (loading)
+            {
+                frame.Text("loading", "Loading...", new GuaBounds(100, 180, 240, 24));
+            }
+        });
+    }
+}

--- a/examples/dotnet-testing/GuaDotNetTestingSample.csproj
+++ b/examples/dotnet-testing/GuaDotNetTestingSample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\bindings\dotnet\src\Gua.Testing\Gua.Testing.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/examples/dotnet-testing/Program.cs
+++ b/examples/dotnet-testing/Program.cs
@@ -1,0 +1,45 @@
+using Gua.Core;
+using Gua.Testing;
+
+using var ui = new GuaContext();
+var host = new GuaTestHost(ui);
+var loading = false;
+
+Render();
+
+GuaAssertions.GetByRole(ui, "button", "Start Game")
+    .ToBeVisible()
+    .ToBeEnabled()
+    .Click();
+
+Render();
+host.DrainClickEvents(nodeId =>
+{
+    if (nodeId == "start")
+    {
+        loading = true;
+    }
+});
+Render();
+
+GuaAssertions.WaitForText(ui, "Loading...", TimeSpan.FromSeconds(1))
+    .ToBeVisible()
+    .ToHaveRole("text");
+
+Console.WriteLine("Gua.Testing sample passed.");
+
+void Render()
+{
+    host.Frame(loading ? "loading" : "title", frame =>
+    {
+        if (!loading && frame.Button("start", "Start Game", new GuaBounds(100, 100, 240, 64)))
+        {
+            // GuaTestHost emits the click event; test code decides how the game state changes.
+        }
+
+        if (loading)
+        {
+            frame.Text("loading", "Loading...", new GuaBounds(100, 180, 240, 24));
+        }
+    });
+}

--- a/examples/dotnet-testing/README.md
+++ b/examples/dotnet-testing/README.md
@@ -1,0 +1,18 @@
+# Gua .NET Testing Sample
+
+This sample shows the test-side loop required by `Gua.Testing`:
+
+1. render a frame into a Gua semantic tree
+2. enqueue a click with `Click()`
+3. render another frame so the adapter can consume the click request
+4. drain the emitted click event and update game state
+5. render the resulting state and assert it
+
+Run it after building the native runtime and setting `GUA_NATIVE_DIR`:
+
+```powershell
+cmake --preset windows-msvc-debug
+cmake --build --preset windows-msvc-debug --target gua
+$env:GUA_NATIVE_DIR = "$PWD\build\windows-msvc-debug\native\gua-core\Debug"
+dotnet run --project examples/dotnet-testing/GuaDotNetTestingSample.csproj
+```


### PR DESCRIPTION
## Summary
- `Gua.Core` と `Gua.Testing` の NuGet パッケージ構成を追加し、.NET から C ABI を使いやすくした
- `GuaContext` や `Native` 周りを整備し、テスト用のアサーションとスナップショット支援を追加した
- NUnit サンプルと `dotnet-testing` サンプルを更新し、利用方法を README に反映した
- `.gitignore` と `Directory.Build.props` を調整し、リポジトリ全体の .NET 開発体験を整えた

## Testing
- サンプルプロジェクトの参照とパッケージ構成を確認
- `Gua.Testing` のアサーション経路と `Gua.Core` の基本利用シナリオをコード上で確認
- 実行ベースの検証は未実施