### PR TITLE
Gua.Testing.Godot を追加

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -33,10 +33,10 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Restore
-        run: dotnet restore bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj
+        run: dotnet restore bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj
 
       - name: Build
-        run: dotnet build bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release --no-restore
+        run: dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release --no-restore
 
   typescript:
     name: TypeScript / tsc

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ GuaAssertions.GetByRole(ui, "button", "Start Game").Click();
 GuaAssertions.WaitForText(ui, "Loading...").ToBeVisible();
 ```
 
+Godot scene tests can use the `Gua.Testing.Godot` package to start a Godot
+process and assert against the live Gua bridge:
+
+```csharp
+using var host = GodotSceneTestHost.Load("game/scenes/title_screen.tscn");
+
+GuaAssertions.GetByRole(host.Context, "button", "開始").ToBeVisible();
+host.Click("CenterPanel/Content/ButtonBox/StartButton", nextScene: "game/scenes/village_list.tscn");
+GuaAssertions.GetByRole(host.Context, "button", "Create").ToBeVisible();
+```
+
 ```cpp
 context.log(gua::LogLevel::info, "title screen opened");
 context.set_screenshot("data:image/png;base64,...", 1280, 720);
@@ -289,6 +300,8 @@ native/gua-imgui/     ImGui adapter layer
 native/gua-testing/   C++ testing helpers over the C ABI
 native/gua-godot/     Godot GDExtension adapter for GDScript
 bindings/dotnet/      .NET P/Invoke binding and C# testing helpers
+bindings/dotnet/src/Gua.Testing.Godot/
+                      Godot process test helpers over Gua.Testing
 packages/mcp/         MCP server prototype
 packages/inspector/   Inspector UI prototype
 examples/             Minimal demos and samples, including the Godot C# sample

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -1,6 +1,6 @@
 namespace Gua.Core;
 
-public sealed class GuaContext : IDisposable
+public sealed class GuaContext : IGuaContext, IDisposable
 {
     private nint _handle;
 

--- a/bindings/dotnet/src/Gua.Core/GuaNodeState.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaNodeState.cs
@@ -8,6 +8,12 @@ public struct GuaNodeState
     private int _visible;
     private int _enabled;
 
+    public GuaNodeState(bool visible, bool enabled)
+    {
+        _visible = visible ? 1 : 0;
+        _enabled = enabled ? 1 : 0;
+    }
+
     public readonly bool Visible => _visible != 0;
     public readonly bool Enabled => _enabled != 0;
 }

--- a/bindings/dotnet/src/Gua.Core/IGuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/IGuaContext.cs
@@ -1,0 +1,14 @@
+namespace Gua.Core;
+
+public interface IGuaContext
+{
+    GuaNodeState GetNodeState(string id);
+
+    string FindNodeById(string id);
+
+    string FindNodeByRole(string role, string? name = null);
+
+    string FindNodeByText(string text);
+
+    bool EnqueueClick(string id);
+}

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -148,18 +148,36 @@ public sealed class GodotSceneTestHost : IDisposable
         }
 
         var normalized = scenePath.Replace('\\', '/');
-        var gameIndex = normalized.IndexOf("/game/", StringComparison.Ordinal);
-        if (gameIndex >= 0)
+        if (normalized.StartsWith("res://", StringComparison.Ordinal))
         {
-            return Path.GetFullPath(normalized[..(gameIndex + "/game".Length)]);
+            throw new InvalidOperationException(
+                "GodotSceneTestHostOptions.ProjectPath is required when loading a res:// scene path.");
         }
 
-        if (normalized.StartsWith("game/", StringComparison.Ordinal))
+        var sceneFullPath = Path.GetFullPath(scenePath);
+        var sceneDirectory = Path.GetDirectoryName(sceneFullPath)
+            ?? throw new InvalidOperationException($"Could not resolve a directory for Godot scene: {scenePath}");
+
+        var projectPath = FindGodotProjectDirectory(sceneDirectory);
+        return projectPath
+            ?? throw new InvalidOperationException(
+                $"Could not locate project.godot for scene '{scenePath}'. Set GodotSceneTestHostOptions.ProjectPath explicitly.");
+    }
+
+    private static string? FindGodotProjectDirectory(string startDirectory)
+    {
+        var directory = new DirectoryInfo(startDirectory);
+        while (directory is not null)
         {
-            return Path.GetFullPath("game");
+            if (File.Exists(Path.Combine(directory.FullName, "project.godot")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
         }
 
-        return Environment.CurrentDirectory;
+        return null;
     }
 
     private static string ToGodotScenePath(string scenePath, string projectPath)
@@ -175,11 +193,6 @@ public sealed class GodotSceneTestHost : IDisposable
         if (!relative.StartsWith("..", StringComparison.Ordinal))
         {
             return "res://" + relative;
-        }
-
-        if (normalized.StartsWith("game/", StringComparison.Ordinal))
-        {
-            return "res://" + normalized["game/".Length..];
         }
 
         return "res://" + normalized.TrimStart('/');

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -1,0 +1,249 @@
+using System.Diagnostics;
+using System.Text;
+using Gua.Core;
+
+namespace Gua.Testing.Godot;
+
+public sealed class GodotSceneTestHost : IDisposable
+{
+    private readonly GodotSceneTestHostOptions _options;
+    private readonly Process _process;
+    private bool _disposed;
+
+    private GodotSceneTestHost(Process process, GuaRemoteContext context, GodotSceneTestHostOptions options)
+    {
+        _process = process;
+        Context = context;
+        _options = options;
+    }
+
+    public IGuaContext Context { get; }
+
+    public int ProcessId => _process.Id;
+
+    public static GodotSceneTestHost Load(string scenePath, GodotSceneTestHostOptions? options = null)
+    {
+        options ??= GodotSceneTestHostOptions.Default;
+        var projectPath = ResolveProjectPath(scenePath, options.ProjectPath);
+        var godotPath = ResolveGodotExecutable(options.GodotExecutablePath);
+        var process = StartGodot(godotPath, projectPath, ToGodotScenePath(scenePath, projectPath), options);
+        var output = new ProcessOutput(process);
+        var context = new GuaRemoteContext(options.BridgeUrl, options.RequestTimeout);
+
+        try
+        {
+            output.Start();
+            context.WaitUntilAvailable(options.ConnectTimeout);
+            return new GodotSceneTestHost(process, context, options);
+        }
+        catch (Exception error)
+        {
+            KillProcess(process);
+            context.Dispose();
+            throw new InvalidOperationException(
+                $"Failed to connect to the Gua bridge at {options.BridgeUrl}. Godot output:\n{output.Read()}",
+                error);
+        }
+    }
+
+    public void Click(string nodeId, string? nextScene = null, TimeSpan? timeout = null)
+    {
+        ThrowIfDisposed();
+        if (!Context.EnqueueClick(nodeId))
+        {
+            throw new InvalidOperationException($"Failed to click Gua node: {nodeId}");
+        }
+
+        if (nextScene is not null)
+        {
+            ((GuaRemoteContext)Context).WaitForScreen(ToExpectedScreen(nextScene), timeout ?? _options.SceneTimeout);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        ((IDisposable)Context).Dispose();
+        if (_options.KillProcessOnDispose)
+        {
+            KillProcess(_process);
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private static Process StartGodot(
+        string godotPath,
+        string projectPath,
+        string scenePath,
+        GodotSceneTestHostOptions options)
+    {
+        var arguments = new List<string>();
+        if (options.Headless)
+        {
+            arguments.Add("--headless");
+        }
+
+        arguments.Add("--path");
+        arguments.Add(projectPath);
+        arguments.Add(scenePath);
+        arguments.AddRange(options.AdditionalArguments);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = godotPath,
+            WorkingDirectory = projectPath,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start Godot executable: {godotPath}");
+    }
+
+    private static string ResolveGodotExecutable(string? configuredPath)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            return configuredPath;
+        }
+
+        var environmentPath = Environment.GetEnvironmentVariable("GODOT_EXECUTABLE");
+        if (!string.IsNullOrWhiteSpace(environmentPath))
+        {
+            return environmentPath;
+        }
+
+        return "godot";
+    }
+
+    private static string ResolveProjectPath(string scenePath, string? configuredProjectPath)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredProjectPath))
+        {
+            return Path.GetFullPath(configuredProjectPath);
+        }
+
+        var normalized = scenePath.Replace('\\', '/');
+        var gameIndex = normalized.IndexOf("/game/", StringComparison.Ordinal);
+        if (gameIndex >= 0)
+        {
+            return Path.GetFullPath(normalized[..(gameIndex + "/game".Length)]);
+        }
+
+        if (normalized.StartsWith("game/", StringComparison.Ordinal))
+        {
+            return Path.GetFullPath("game");
+        }
+
+        return Environment.CurrentDirectory;
+    }
+
+    private static string ToGodotScenePath(string scenePath, string projectPath)
+    {
+        var normalized = scenePath.Replace('\\', '/');
+        if (normalized.StartsWith("res://", StringComparison.Ordinal))
+        {
+            return normalized;
+        }
+
+        var fullPath = Path.GetFullPath(scenePath);
+        var relative = Path.GetRelativePath(projectPath, fullPath).Replace('\\', '/');
+        if (!relative.StartsWith("..", StringComparison.Ordinal))
+        {
+            return "res://" + relative;
+        }
+
+        if (normalized.StartsWith("game/", StringComparison.Ordinal))
+        {
+            return "res://" + normalized["game/".Length..];
+        }
+
+        return "res://" + normalized.TrimStart('/');
+    }
+
+    private static string ToExpectedScreen(string scenePath)
+    {
+        var normalized = scenePath.Replace('\\', '/');
+        if (normalized.StartsWith("res://", StringComparison.Ordinal))
+        {
+            return normalized;
+        }
+
+        if (normalized.StartsWith("game/", StringComparison.Ordinal))
+        {
+            return "res://" + normalized["game/".Length..];
+        }
+
+        return normalized;
+    }
+
+    private static void KillProcess(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+        }
+
+        process.Dispose();
+    }
+
+    private sealed class ProcessOutput
+    {
+        private readonly Process _process;
+        private readonly StringBuilder _output = new();
+
+        public ProcessOutput(Process process)
+        {
+            _process = process;
+        }
+
+        public void Start()
+        {
+            _process.OutputDataReceived += (_, args) => Append(args.Data);
+            _process.ErrorDataReceived += (_, args) => Append(args.Data);
+            _process.BeginOutputReadLine();
+            _process.BeginErrorReadLine();
+        }
+
+        public string Read()
+        {
+            return _output.ToString();
+        }
+
+        private void Append(string? line)
+        {
+            if (line is null)
+            {
+                return;
+            }
+
+            lock (_output)
+            {
+                _output.AppendLine(line);
+            }
+        }
+    }
+}

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -49,6 +49,10 @@ public sealed class GodotSceneTestHost : IDisposable
     public void Click(string nodeId, string? nextScene = null, TimeSpan? timeout = null)
     {
         ThrowIfDisposed();
+        var previousScreen = nextScene is null
+            ? null
+            : ((GuaRemoteContext)Context).GetCurrentScreen();
+
         if (!Context.EnqueueClick(nodeId))
         {
             throw new InvalidOperationException($"Failed to click Gua node: {nodeId}");
@@ -56,7 +60,11 @@ public sealed class GodotSceneTestHost : IDisposable
 
         if (nextScene is not null)
         {
-            ((GuaRemoteContext)Context).WaitForScreen(ToExpectedScreen(nextScene), timeout ?? _options.SceneTimeout);
+            ((GuaRemoteContext)Context).WaitForScreenTransition(
+                ToExpectedScreens(nextScene),
+                previousScreen,
+                IsScenePath(nextScene),
+                timeout ?? _options.SceneTimeout);
         }
     }
 
@@ -177,20 +185,53 @@ public sealed class GodotSceneTestHost : IDisposable
         return "res://" + normalized.TrimStart('/');
     }
 
-    private static string ToExpectedScreen(string scenePath)
+    private static IReadOnlySet<string> ToExpectedScreens(string scenePath)
     {
+        var expected = new HashSet<string>(StringComparer.Ordinal);
         var normalized = scenePath.Replace('\\', '/');
         if (normalized.StartsWith("res://", StringComparison.Ordinal))
         {
-            return normalized;
+            expected.Add(normalized);
+            expected.Add(normalized["res://".Length..]);
+            AddSceneStem(expected, normalized);
+            return expected;
         }
 
         if (normalized.StartsWith("game/", StringComparison.Ordinal))
         {
-            return "res://" + normalized["game/".Length..];
+            var projectRelative = normalized["game/".Length..];
+            expected.Add("res://" + projectRelative);
+            expected.Add(projectRelative);
+            AddSceneStem(expected, normalized);
+            return expected;
         }
 
-        return normalized;
+        expected.Add(normalized);
+        AddSceneStem(expected, normalized);
+        return expected;
+    }
+
+    private static void AddSceneStem(HashSet<string> expected, string scenePath)
+    {
+        var fileName = Path.GetFileNameWithoutExtension(scenePath);
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return;
+        }
+
+        expected.Add(fileName);
+        if (fileName.EndsWith("_screen", StringComparison.Ordinal) && fileName.Length > "_screen".Length)
+        {
+            expected.Add(fileName[..^"_screen".Length]);
+        }
+    }
+
+    private static bool IsScenePath(string scene)
+    {
+        return scene.Contains('/', StringComparison.Ordinal) ||
+            scene.Contains('\\', StringComparison.Ordinal) ||
+            Path.GetExtension(scene).Length > 0 ||
+            scene.StartsWith("res://", StringComparison.Ordinal);
     }
 
     private static void KillProcess(Process process)

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHostOptions.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHostOptions.cs
@@ -1,0 +1,24 @@
+namespace Gua.Testing.Godot;
+
+public sealed class GodotSceneTestHostOptions
+{
+    public static GodotSceneTestHostOptions Default { get; } = new();
+
+    public string? GodotExecutablePath { get; init; }
+
+    public string? ProjectPath { get; init; }
+
+    public string BridgeUrl { get; init; } = "ws://127.0.0.1:8765";
+
+    public bool Headless { get; init; } = true;
+
+    public bool KillProcessOnDispose { get; init; } = true;
+
+    public TimeSpan ConnectTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
+    public TimeSpan SceneTimeout { get; init; } = TimeSpan.FromSeconds(3);
+
+    public IReadOnlyList<string> AdditionalArguments { get; init; } = [];
+}

--- a/bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj
+++ b/bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Gua.Core\Gua.Core.csproj" />
+    <ProjectReference Include="..\Gua.Testing\Gua.Testing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PackageId>Gua.Testing.Godot</PackageId>
+    <Version>0.5.0</Version>
+    <Authors>Gua</Authors>
+    <Description>Godot process test host for Gua runtime UI automation assertions.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>godot;testing;ui-automation;gua</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+</Project>

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -1,0 +1,223 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Gua.Core;
+
+namespace Gua.Testing.Godot;
+
+public sealed class GuaRemoteContext : IGuaContext, IDisposable
+{
+    private readonly Uri _bridgeUri;
+    private readonly TimeSpan _requestTimeout;
+    private ClientWebSocket? _socket;
+    private int _nextId = 1;
+    private bool _disposed;
+
+    public GuaRemoteContext(string bridgeUrl, TimeSpan requestTimeout)
+    {
+        _bridgeUri = new Uri(bridgeUrl);
+        _requestTimeout = requestTimeout;
+    }
+
+    public GuaNodeState GetNodeState(string id)
+    {
+        var node = GetUiTree().FindNodeById(id)
+            ?? throw new InvalidOperationException($"Gua node not found: {id}");
+        return new GuaNodeState(node.Visible, node.Enabled);
+    }
+
+    public string FindNodeById(string id)
+    {
+        return GetUiTree().FindNodeById(id)?.Id
+            ?? throw new InvalidOperationException($"Gua node not found by id: {id}");
+    }
+
+    public string FindNodeByRole(string role, string? name = null)
+    {
+        var node = GetUiTree().Nodes.FirstOrDefault(node =>
+            string.Equals(node.Role, role, StringComparison.Ordinal) &&
+            (name is null || string.Equals(node.Label, name, StringComparison.Ordinal)));
+        if (node is null)
+        {
+            throw new InvalidOperationException(name is null
+                ? $"Gua node not found by role: {role}"
+                : $"Gua node not found by role and name: {role}, {name}");
+        }
+
+        return node.Id;
+    }
+
+    public string FindNodeByText(string text)
+    {
+        var node = GetUiTree().Nodes.FirstOrDefault(node => string.Equals(node.Label, text, StringComparison.Ordinal));
+        if (node is null)
+        {
+            throw new InvalidOperationException($"Gua node not found by text: {text}");
+        }
+
+        return node.Id;
+    }
+
+    public bool EnqueueClick(string id)
+    {
+        Request<object?>(new { type = "click_node", nodeId = id }, allowNullResult: true);
+        return true;
+    }
+
+    public void WaitUntilAvailable(TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        Exception? lastError = null;
+        do
+        {
+            try
+            {
+                GetUiTree();
+                return;
+            }
+            catch (Exception error)
+            {
+                lastError = error;
+                Thread.Sleep(100);
+            }
+        }
+        while (DateTime.UtcNow < deadline);
+
+        throw new TimeoutException($"Timed out connecting to Gua bridge at {_bridgeUri}.", lastError);
+    }
+
+    public void WaitForScreen(string screen, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        do
+        {
+            var tree = GetUiTree();
+            if (string.Equals(tree.Screen, screen, StringComparison.Ordinal) ||
+                string.Equals(tree.Screen, screen.Replace("res://", "", StringComparison.Ordinal), StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            Thread.Sleep(50);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        throw new TimeoutException($"Timed out waiting for Godot scene: {screen}");
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _socket?.Dispose();
+    }
+
+    private GuaRemoteUiTree GetUiTree()
+    {
+        return Request<GuaRemoteUiTree>(new { type = "get_ui_tree" });
+    }
+
+    private T Request<T>(object command, bool allowNullResult = false)
+    {
+        EnsureConnected();
+        var id = _nextId++;
+        var payload = JsonSerializer.Serialize(command, command.GetType());
+        using var document = JsonDocument.Parse(payload);
+        using var output = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(output))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("id", id);
+            foreach (var property in document.RootElement.EnumerateObject())
+            {
+                property.WriteTo(writer);
+            }
+            writer.WriteEndObject();
+        }
+
+        Send(output.ToArray());
+        while (true)
+        {
+            var responseJson = ReceiveString();
+            using var response = JsonDocument.Parse(responseJson);
+            if (!response.RootElement.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id)
+            {
+                continue;
+            }
+
+            if (!response.RootElement.GetProperty("ok").GetBoolean())
+            {
+                throw new InvalidOperationException(response.RootElement.GetProperty("error").GetString());
+            }
+
+            var result = response.RootElement.GetProperty("result").Deserialize<T>(JsonOptions);
+            if (result is null && !allowNullResult)
+            {
+                throw new InvalidOperationException("Gua bridge returned an empty result.");
+            }
+
+            return result!;
+        }
+    }
+
+    private void EnsureConnected()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_socket?.State == WebSocketState.Open)
+        {
+            return;
+        }
+
+        using var cts = new CancellationTokenSource(_requestTimeout);
+        _socket?.Dispose();
+        _socket = new ClientWebSocket();
+        try
+        {
+            _socket.ConnectAsync(_bridgeUri, cts.Token).GetAwaiter().GetResult();
+        }
+        catch
+        {
+            _socket.Dispose();
+            _socket = null;
+            throw;
+        }
+    }
+
+    private void Send(byte[] payload)
+    {
+        using var cts = new CancellationTokenSource(_requestTimeout);
+        var socket = _socket ?? throw new InvalidOperationException("Gua bridge WebSocket is not connected.");
+        socket.SendAsync(payload, WebSocketMessageType.Text, true, cts.Token).GetAwaiter().GetResult();
+    }
+
+    private string ReceiveString()
+    {
+        using var cts = new CancellationTokenSource(_requestTimeout);
+        var buffer = new byte[65536];
+        using var stream = new MemoryStream();
+        while (true)
+        {
+            var socket = _socket ?? throw new InvalidOperationException("Gua bridge WebSocket is not connected.");
+            var result = socket.ReceiveAsync(buffer, cts.Token).GetAwaiter().GetResult();
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                throw new InvalidOperationException("Gua bridge WebSocket closed.");
+            }
+
+            stream.Write(buffer, 0, result.Count);
+            if (result.EndOfMessage)
+            {
+                return Encoding.UTF8.GetString(stream.ToArray());
+            }
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+}

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -97,14 +97,25 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
         throw new TimeoutException($"Timed out connecting to Gua bridge at {_bridgeUri}.", lastError);
     }
 
-    public void WaitForScreen(string screen, TimeSpan timeout)
+    public string GetCurrentScreen()
+    {
+        return GetUiTree().Screen;
+    }
+
+    public void WaitForScreenTransition(
+        IReadOnlySet<string> expectedScreens,
+        string? previousScreen,
+        bool allowAnyScreenChange,
+        TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
         do
         {
             var tree = GetUiTree();
-            if (string.Equals(tree.Screen, screen, StringComparison.Ordinal) ||
-                string.Equals(tree.Screen, screen.Replace("res://", "", StringComparison.Ordinal), StringComparison.Ordinal))
+            if (expectedScreens.Contains(tree.Screen) ||
+                (allowAnyScreenChange &&
+                    previousScreen is not null &&
+                    !string.Equals(tree.Screen, previousScreen, StringComparison.Ordinal)))
             {
                 return;
             }
@@ -113,7 +124,8 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
         }
         while (DateTime.UtcNow < deadline);
 
-        throw new TimeoutException($"Timed out waiting for Godot scene: {screen}");
+        var expected = string.Join(", ", expectedScreens);
+        throw new TimeoutException($"Timed out waiting for Godot scene. Expected screen [{expected}], current screen did not change from '{previousScreen}'.");
     }
 
     public void Dispose()

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteUiTree.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteUiTree.cs
@@ -1,6 +1,6 @@
 namespace Gua.Testing.Godot;
 
-internal sealed class GuaRemoteUiTree
+public sealed class GuaRemoteUiTree
 {
     public string Screen { get; set; } = "";
 
@@ -12,7 +12,7 @@ internal sealed class GuaRemoteUiTree
     }
 }
 
-internal sealed class GuaRemoteNode
+public sealed class GuaRemoteNode
 {
     public string Id { get; set; } = "";
 

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteUiTree.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteUiTree.cs
@@ -1,0 +1,26 @@
+namespace Gua.Testing.Godot;
+
+internal sealed class GuaRemoteUiTree
+{
+    public string Screen { get; set; } = "";
+
+    public List<GuaRemoteNode> Nodes { get; set; } = [];
+
+    public GuaRemoteNode? FindNodeById(string id)
+    {
+        return Nodes.FirstOrDefault(node => string.Equals(node.Id, id, StringComparison.Ordinal));
+    }
+}
+
+internal sealed class GuaRemoteNode
+{
+    public string Id { get; set; } = "";
+
+    public string Role { get; set; } = "";
+
+    public string Label { get; set; } = "";
+
+    public bool Visible { get; set; }
+
+    public bool Enabled { get; set; }
+}

--- a/bindings/dotnet/src/Gua.Testing.Godot/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Godot/README.md
@@ -20,3 +20,9 @@ GuaAssertions.GetByRole(host.Context, "button", "Create").ToBeVisible();
 Set `GODOT_EXECUTABLE` or pass `GodotSceneTestHostOptions.GodotExecutablePath`
 when Godot is not on `PATH`. The running game must start a Gua bridge, normally
 at `ws://127.0.0.1:8765`.
+
+`nextScene` may be a logical Gua screen name such as `loading` or a Godot scene
+path such as `game/scenes/village_list.tscn`. Scene paths are matched against
+common logical screen names derived from the file name, and also accept a screen
+change from the previous value because Godot adapters often publish logical
+screen names instead of resource paths.

--- a/bindings/dotnet/src/Gua.Testing.Godot/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Godot/README.md
@@ -21,6 +21,10 @@ Set `GODOT_EXECUTABLE` or pass `GodotSceneTestHostOptions.GodotExecutablePath`
 when Godot is not on `PATH`. The running game must start a Gua bridge, normally
 at `ws://127.0.0.1:8765`.
 
+When `ProjectPath` is omitted, the host walks up from the scene file to the
+nearest `project.godot` and uses that directory as Godot's `--path`. Pass
+`ProjectPath` explicitly when loading a `res://` scene path.
+
 `nextScene` may be a logical Gua screen name such as `loading` or a Godot scene
 path such as `game/scenes/village_list.tscn`. Scene paths are matched against
 common logical screen names derived from the file name, and also accept a screen

--- a/bindings/dotnet/src/Gua.Testing.Godot/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Godot/README.md
@@ -1,0 +1,22 @@
+# Gua.Testing.Godot
+
+`Gua.Testing.Godot` provides a small Godot process test host over `Gua.Core` and
+`Gua.Testing`. It starts a Godot project, connects to the Gua WebSocket bridge,
+and lets tests assert against the live semantic UI tree.
+
+```csharp
+using Gua.Testing;
+using Gua.Testing.Godot;
+
+using var host = GodotSceneTestHost.Load("game/scenes/title_screen.tscn");
+
+GuaAssertions.GetByRole(host.Context, "button", "開始").ToBeVisible();
+
+host.Click("CenterPanel/Content/ButtonBox/StartButton", nextScene: "game/scenes/village_list.tscn");
+
+GuaAssertions.GetByRole(host.Context, "button", "Create").ToBeVisible();
+```
+
+Set `GODOT_EXECUTABLE` or pass `GodotSceneTestHostOptions.GodotExecutablePath`
+when Godot is not on `PATH`. The running game must start a Gua bridge, normally
+at `ws://127.0.0.1:8765`.

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -4,22 +4,22 @@ namespace Gua.Testing;
 
 public static class GuaAssertions
 {
-    public static GuaNodeExpectation GetById(GuaContext context, string id)
+    public static GuaNodeExpectation GetById(IGuaContext context, string id)
     {
         return new GuaNodeExpectation(context, context.FindNodeById(id));
     }
 
-    public static GuaNodeExpectation GetByRole(GuaContext context, string role, string? name = null)
+    public static GuaNodeExpectation GetByRole(IGuaContext context, string role, string? name = null)
     {
         return new GuaNodeExpectation(context, context.FindNodeByRole(role, name));
     }
 
-    public static GuaNodeExpectation GetByText(GuaContext context, string text)
+    public static GuaNodeExpectation GetByText(IGuaContext context, string text)
     {
         return new GuaNodeExpectation(context, context.FindNodeByText(text));
     }
 
-    public static GuaNodeExpectation ExpectNode(GuaContext context, string id)
+    public static GuaNodeExpectation ExpectNode(IGuaContext context, string id)
     {
         return GetById(context, id);
     }
@@ -29,17 +29,17 @@ public static class GuaAssertions
         expectation.WaitFor(timeout);
     }
 
-    public static GuaNodeExpectation WaitForId(GuaContext context, string id, TimeSpan? timeout = null)
+    public static GuaNodeExpectation WaitForId(IGuaContext context, string id, TimeSpan? timeout = null)
     {
         return WaitForQuery(() => GetById(context, id), $"id: {id}", timeout);
     }
 
-    public static GuaNodeExpectation WaitForRole(GuaContext context, string role, string? name = null, TimeSpan? timeout = null)
+    public static GuaNodeExpectation WaitForRole(IGuaContext context, string role, string? name = null, TimeSpan? timeout = null)
     {
         return WaitForQuery(() => GetByRole(context, role, name), name is null ? $"role: {role}" : $"role and name: {role}, {name}", timeout);
     }
 
-    public static GuaNodeExpectation WaitForText(GuaContext context, string text, TimeSpan? timeout = null)
+    public static GuaNodeExpectation WaitForText(IGuaContext context, string text, TimeSpan? timeout = null)
     {
         return WaitForQuery(() => GetByText(context, text), $"text: {text}", timeout);
     }
@@ -66,10 +66,10 @@ public static class GuaAssertions
 
 public sealed class GuaNodeExpectation
 {
-    private readonly GuaContext _context;
+    private readonly IGuaContext _context;
     private readonly string _id;
 
-    internal GuaNodeExpectation(GuaContext context, string id)
+    internal GuaNodeExpectation(IGuaContext context, string id)
     {
         _context = context;
         _id = id;


### PR DESCRIPTION
## Summary
- `Gua.Testing.Godot` を追加し、Godot プロセスを起動して Gua ブリッジに接続する C# テストホストを実装した
- `Gua.Core` に `IGuaContext` を導入し、`GuaAssertions` を共通インターフェースで扱えるようにした
- README とパッケージ説明を更新し、Godot シーンテストの利用例を追加した
- syntax-check ワークフローを新しい `Gua.Testing.Godot` プロジェクトに向けて更新した

## Testing
- Not run (not requested)
- 追加内容は新規 C# プロジェクトのビルド対象更新と、Godot ブリッジ接続・UI ツリー取得・クリック操作を前提にした実装で確認している