### PR TITLE
NuGet パッケージ版を 0.5.0-preview.3 に更新する

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <GuaPackageVersion>0.5.0-preview.2</GuaPackageVersion>
+    <GuaPackageVersion>0.5.0-preview.3</GuaPackageVersion>
     <GuaPackageOutputPath>$(MSBuildThisFileDirectory)artifacts\packages</GuaPackageOutputPath>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ dependency on the matching `Gua.Core` package, so a test project only needs the
 testing package:
 
 ```xml
-<PackageReference Include="Gua.Testing" Version="0.5.0-preview.2" />
+<PackageReference Include="Gua.Testing" Version="0.5.0-preview.3" />
 ```
 
 `Gua.Core` is also delivered as a NuGet package and `Gua.Testing` depends on the


### PR DESCRIPTION
## Summary
- `GuaPackageVersion` を `0.5.0-preview.3` に更新
- README の `Gua.Testing` 参照例を新しいプレリリース版に追従

## Testing
- Not run (not requested)