### PR TITLE
#21 Semantic UI node state model を実装する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.20)
 
 project(gua LANGUAGES C CXX)
 
+include(CTest)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -56,6 +56,58 @@ public sealed class GuaContext : IGuaContext, IDisposable
             enabled ? 1 : 0);
     }
 
+    public void RegisterNode(GuaNodeDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        ThrowIfDisposed();
+
+        var known = GuaNodeKnownState.None;
+        if (descriptor.ParentId is not null) known |= GuaNodeKnownState.ParentId;
+        if (descriptor.Text is not null) known |= GuaNodeKnownState.Text;
+        if (descriptor.Value is not null) known |= GuaNodeKnownState.Value;
+        if (descriptor.Focused.HasValue) known |= GuaNodeKnownState.Focused;
+        if (descriptor.Hovered.HasValue) known |= GuaNodeKnownState.Hovered;
+        if (descriptor.Pressed.HasValue) known |= GuaNodeKnownState.Pressed;
+        if (descriptor.Checked.HasValue) known |= GuaNodeKnownState.Checked;
+        if (descriptor.Selected.HasValue) known |= GuaNodeKnownState.Selected;
+
+        var strings = new[] { descriptor.Id, descriptor.ParentId, descriptor.Role, descriptor.Label, descriptor.Text, descriptor.Value };
+        var pointers = strings.Select(value => value is null ? nint.Zero : System.Runtime.InteropServices.Marshal.StringToCoTaskMemUTF8(value)).ToArray();
+        try
+        {
+            var native = new Native.GuaNativeNodeDescriptorV2
+            {
+                StructSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<Native.GuaNativeNodeDescriptorV2>(),
+                KnownMask = (ulong)known,
+                Id = pointers[0],
+                ParentId = pointers[1],
+                Role = pointers[2],
+                Label = pointers[3],
+                Text = pointers[4],
+                Value = pointers[5],
+                Bounds = descriptor.Bounds,
+                Visible = descriptor.Visible ? 1 : 0,
+                Enabled = descriptor.Enabled ? 1 : 0,
+                Focused = descriptor.Focused == true ? 1 : 0,
+                Hovered = descriptor.Hovered == true ? 1 : 0,
+                Pressed = descriptor.Pressed == true ? 1 : 0,
+                Checked = descriptor.Checked == true ? 1 : 0,
+                Selected = descriptor.Selected == true ? 1 : 0,
+            };
+            if (Native.gua_register_node_v2(_handle, in native) == 0)
+            {
+                throw new InvalidOperationException($"Failed to register Gua v2 node: {descriptor.Id}");
+            }
+        }
+        finally
+        {
+            foreach (var pointer in pointers.Where(pointer => pointer != nint.Zero))
+            {
+                System.Runtime.InteropServices.Marshal.FreeCoTaskMem(pointer);
+            }
+        }
+    }
+
     public string GetUiTreeJson()
     {
         ThrowIfDisposed();
@@ -94,6 +146,39 @@ public sealed class GuaContext : IGuaContext, IDisposable
             throw new InvalidOperationException($"Gua node not found: {id}");
         }
         return state;
+    }
+
+    public GuaNodeStateV2 GetNodeStateV2(string id)
+    {
+        ThrowIfDisposed();
+        unsafe
+        {
+            Native.GuaNativeNodeStateV2 state = default;
+            state.StructSize = (uint)sizeof(Native.GuaNativeNodeStateV2);
+            if (Native.gua_get_node_state_v2(_handle, id, &state) == 0)
+            {
+                throw new InvalidOperationException($"Gua node not found: {id}");
+            }
+
+            var known = (GuaNodeKnownState)state.KnownMask;
+            string? Read(byte* value, GuaNodeKnownState flag) => known.HasFlag(flag)
+                ? System.Runtime.InteropServices.Marshal.PtrToStringUTF8((nint)value) ?? string.Empty
+                : null;
+            bool? ReadBool(int value, GuaNodeKnownState flag) => known.HasFlag(flag) ? value != 0 : null;
+
+            return new GuaNodeStateV2(
+                known,
+                state.Visible != 0,
+                state.Enabled != 0,
+                Read(state.ParentId, GuaNodeKnownState.ParentId),
+                Read(state.Text, GuaNodeKnownState.Text),
+                Read(state.Value, GuaNodeKnownState.Value),
+                ReadBool(state.Focused, GuaNodeKnownState.Focused),
+                ReadBool(state.Hovered, GuaNodeKnownState.Hovered),
+                ReadBool(state.Pressed, GuaNodeKnownState.Pressed),
+                ReadBool(state.Checked, GuaNodeKnownState.Checked),
+                ReadBool(state.Selected, GuaNodeKnownState.Selected));
+        }
     }
 
     public string FindNodeById(string id)

--- a/bindings/dotnet/src/Gua.Core/GuaNodeDescriptor.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaNodeDescriptor.cs
@@ -1,0 +1,44 @@
+namespace Gua.Core;
+
+[Flags]
+public enum GuaNodeKnownState : ulong
+{
+    None = 0,
+    ParentId = 1UL << 0,
+    Text = 1UL << 1,
+    Value = 1UL << 2,
+    Focused = 1UL << 3,
+    Hovered = 1UL << 4,
+    Pressed = 1UL << 5,
+    Checked = 1UL << 6,
+    Selected = 1UL << 7,
+}
+
+public sealed record GuaNodeDescriptor(
+    string Id,
+    string Role,
+    string Label,
+    GuaBounds Bounds,
+    bool Visible = true,
+    bool Enabled = true,
+    string? ParentId = null,
+    string? Text = null,
+    string? Value = null,
+    bool? Focused = null,
+    bool? Hovered = null,
+    bool? Pressed = null,
+    bool? Checked = null,
+    bool? Selected = null);
+
+public sealed record GuaNodeStateV2(
+    GuaNodeKnownState KnownState,
+    bool Visible,
+    bool Enabled,
+    string? ParentId,
+    string? Text,
+    string? Value,
+    bool? Focused,
+    bool? Hovered,
+    bool? Pressed,
+    bool? Checked,
+    bool? Selected);

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -15,6 +15,44 @@ internal static partial class Native
         public fixed byte NodeId[NodeIdBufferSize];
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GuaNativeNodeDescriptorV2
+    {
+        public uint StructSize;
+        public ulong KnownMask;
+        public nint Id;
+        public nint ParentId;
+        public nint Role;
+        public nint Label;
+        public nint Text;
+        public nint Value;
+        public GuaBounds Bounds;
+        public int Visible;
+        public int Enabled;
+        public int Focused;
+        public int Hovered;
+        public int Pressed;
+        public int Checked;
+        public int Selected;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct GuaNativeNodeStateV2
+    {
+        public uint StructSize;
+        public ulong KnownMask;
+        public int Visible;
+        public int Enabled;
+        public int Focused;
+        public int Hovered;
+        public int Pressed;
+        public int Checked;
+        public int Selected;
+        public fixed byte ParentId[128];
+        public fixed byte Text[256];
+        public fixed byte Value[256];
+    }
+
     static Native()
     {
         NativeLibrary.SetDllImportResolver(typeof(Native).Assembly, ResolveGuaLibrary);
@@ -124,6 +162,9 @@ internal static partial class Native
         int enabled);
 
     [LibraryImport("gua")]
+    internal static partial int gua_register_node_v2(nint context, in GuaNativeNodeDescriptorV2 descriptor);
+
+    [LibraryImport("gua")]
     internal static partial nint gua_get_ui_tree_json(nint context);
 
     [LibraryImport("gua")]
@@ -149,6 +190,9 @@ internal static partial class Native
 
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int gua_get_node_state(nint context, string nodeId, out GuaNodeState state);
+
+    [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
+    internal static unsafe partial int gua_get_node_state_v2(nint context, string nodeId, GuaNativeNodeStateV2* state);
 
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static unsafe partial int gua_find_node_by_id(nint context, string nodeId, byte* outNodeId, int outNodeIdSize);

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteUiTree.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteUiTree.cs
@@ -2,6 +2,12 @@ namespace Gua.Testing.Godot;
 
 public sealed class GuaRemoteUiTree
 {
+    public int? SchemaVersion { get; set; }
+
+    public ulong? FrameSequence { get; set; }
+
+    public ulong? Revision { get; set; }
+
     public string Screen { get; set; } = "";
 
     public List<GuaRemoteNode> Nodes { get; set; } = [];
@@ -23,4 +29,21 @@ public sealed class GuaRemoteNode
     public bool Visible { get; set; }
 
     public bool Enabled { get; set; }
+
+    public string? ParentId { get; set; }
+
+    public string? Text { get; set; }
+
+    public string? Value { get; set; }
+
+    public GuaRemoteNodeState? State { get; set; }
+}
+
+public sealed class GuaRemoteNodeState
+{
+    public bool? Focused { get; set; }
+    public bool? Hovered { get; set; }
+    public bool? Pressed { get; set; }
+    public bool? Checked { get; set; }
+    public bool? Selected { get; set; }
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -119,6 +119,18 @@ public static class GuaAssertions
                 actions.AddRange(actionValues.EnumerateArray().Select(action => action.GetString() ?? string.Empty));
             }
 
+            JsonElement state = default;
+            var hasState = node.TryGetProperty("state", out state) && state.ValueKind == JsonValueKind.Object;
+            bool? OptionalBoolean(string name) => hasState && state.TryGetProperty(name, out var value)
+                ? value.GetBoolean()
+                : null;
+            string? OptionalString(string name) => node.TryGetProperty(name, out var value)
+                ? value.GetString()
+                : null;
+            ulong? OptionalRootUInt64(string name) => document.RootElement.TryGetProperty(name, out var value)
+                ? value.GetUInt64()
+                : null;
+
             return new GuaNodeSnapshot(
                 Id: id,
                 Role: node.GetProperty("role").GetString() ?? string.Empty,
@@ -130,7 +142,18 @@ public static class GuaAssertions
                     bounds.GetProperty("h").GetSingle()),
                 Visible: node.GetProperty("visible").GetBoolean(),
                 Enabled: node.GetProperty("enabled").GetBoolean(),
-                Actions: actions);
+                Actions: actions,
+                ParentId: OptionalString("parentId"),
+                Text: OptionalString("text"),
+                Value: OptionalString("value"),
+                Focused: OptionalBoolean("focused"),
+                Hovered: OptionalBoolean("hovered"),
+                Pressed: OptionalBoolean("pressed"),
+                Checked: OptionalBoolean("checked"),
+                Selected: OptionalBoolean("selected"),
+                SchemaVersion: document.RootElement.TryGetProperty("schemaVersion", out var schemaVersion) ? schemaVersion.GetInt32() : null,
+                FrameSequence: OptionalRootUInt64("frameSequence"),
+                Revision: OptionalRootUInt64("revision"));
         }
 
         return null;

--- a/bindings/dotnet/src/Gua.Testing/GuaNodeSnapshot.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaNodeSnapshot.cs
@@ -9,4 +9,15 @@ public sealed record GuaNodeSnapshot(
     GuaBounds Bounds,
     bool Visible,
     bool Enabled,
-    IReadOnlyList<string> Actions);
+    IReadOnlyList<string> Actions,
+    string? ParentId = null,
+    string? Text = null,
+    string? Value = null,
+    bool? Focused = null,
+    bool? Hovered = null,
+    bool? Pressed = null,
+    bool? Checked = null,
+    bool? Selected = null,
+    int? SchemaVersion = null,
+    ulong? FrameSequence = null,
+    ulong? Revision = null);

--- a/examples/dotnet-nunit/TitleScreenTests.cs
+++ b/examples/dotnet-nunit/TitleScreenTests.cs
@@ -8,6 +8,57 @@ namespace Gua.DotNetNUnitSample;
 public sealed class TitleScreenTests
 {
     [Test]
+    public void V2NodeStatePreservesUnknownAndStableRevision()
+    {
+        using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);
+        using var ui = new GuaContext();
+
+        void Render(bool isChecked)
+        {
+            ui.BeginFrame("settings");
+            ui.RegisterNode(new GuaNodeDescriptor(
+                "remember", "checkbox", "Remember me", new GuaBounds(10, 20, 100, 24),
+                ParentId: "form", Text: "Remember me", Focused: false, Checked: isChecked));
+            ui.EndFrame();
+        }
+
+        Render(false);
+        var first = GuaAssertions.GetById(ui, "remember").Snapshot;
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.SchemaVersion, Is.EqualTo(2));
+            Assert.That(first.FrameSequence, Is.EqualTo(1));
+            Assert.That(first.Revision, Is.EqualTo(1));
+            Assert.That(first.ParentId, Is.EqualTo("form"));
+            Assert.That(first.Checked, Is.False);
+            Assert.That(first.Selected, Is.Null);
+        });
+
+        Render(false);
+        Assert.That(GuaAssertions.GetById(ui, "remember").Snapshot.Revision, Is.EqualTo(1));
+        Render(true);
+        Assert.That(GuaAssertions.GetById(ui, "remember").Snapshot.Revision, Is.EqualTo(2));
+
+        var nativeState = ui.GetNodeStateV2("remember");
+        Assert.That(nativeState.Checked, Is.True);
+        Assert.That(nativeState.Selected, Is.Null);
+    }
+
+    [Test]
+    public void LegacySnapshotWithoutVersionMetadataRemainsReadable()
+    {
+        using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);
+        var snapshot = GuaAssertions.GetById(new LegacyContext(), "legacy").Snapshot;
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Label, Is.EqualTo("Legacy"));
+            Assert.That(snapshot.SchemaVersion, Is.Null);
+            Assert.That(snapshot.FrameSequence, Is.Null);
+            Assert.That(snapshot.Checked, Is.Null);
+        });
+    }
+
+    [Test]
     public void StartClickShowsLoadingText()
     {
         using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);
@@ -68,5 +119,20 @@ public sealed class TitleScreenTests
                 frame.Text("loading", "Loading...", new GuaBounds(100, 180, 240, 24));
             }
         });
+    }
+
+    private sealed class LegacyContext : IGuaContext
+    {
+        private const string Tree = """
+            {"screen":"legacy","nodes":[{"id":"legacy","role":"button","label":"Legacy","visible":true,"enabled":true,"bounds":{"x":0,"y":0,"w":1,"h":1},"actions":["click"]}]}
+            """;
+
+        public string GetUiTreeJson() => Tree;
+        public GuaNodeState GetNodeState(string id) => new(true, true);
+        public string FindNodeById(string id) => id == "legacy" ? id : throw new InvalidOperationException();
+        public string FindNodeByRole(string role, string? name = null) => "legacy";
+        public string FindNodeByText(string text) => "legacy";
+        public bool EnqueueClick(string id) => true;
+        public bool TryPollEvent(out GuaEvent e) { e = default; return false; }
     }
 }

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -8,6 +8,7 @@ const REBUILD_COMMAND := "cmake --build --preset windows-msvc-debug --target gua
 const REQUIRED_CONTEXT_METHODS := [
 	"begin_frame",
 	"register_node",
+	"register_node_v2",
 	"end_frame",
 	"get_ui_tree_json",
 	"enqueue_click",
@@ -42,7 +43,7 @@ func update(screen: String) -> void:
 
 	context.begin_frame(screen)
 	buttons_by_id.clear()
-	_collect_control(root)
+	_collect_control(root, "")
 	context.end_frame()
 	_dispatch_click_requests()
 
@@ -137,26 +138,74 @@ func _mark_unavailable(message: String) -> void:
 	push_error(message)
 
 
-func _collect_control(control: Control) -> void:
+func _collect_control(control: Control, parent_id: String) -> void:
 	var id := _control_id(control)
 	var role := _control_role(control)
 	var label := _control_label(control)
-	context.register_node(
-		id,
-		role,
-		label,
-		Rect2(control.global_position, control.size),
-		control.is_visible_in_tree(),
-		_control_enabled(control)
-	)
+	var descriptor := {
+		"id": id,
+		"role": role,
+		"label": label,
+		"bounds": Rect2(control.global_position, control.size),
+		"visible": control.is_visible_in_tree(),
+		"enabled": _control_enabled(control),
+		"focused": control.has_focus(),
+	}
+	if not parent_id.is_empty():
+		descriptor["parent_id"] = parent_id
+	var text := _control_text(control)
+	if text != null:
+		descriptor["text"] = text
+	var value := _control_value(control)
+	if value != null:
+		descriptor["value"] = value
+	if control is CheckBox:
+		descriptor["checked"] = (control as CheckBox).button_pressed
+	context.register_node_v2(descriptor)
 
 	if control is BaseButton:
 		buttons_by_id[id] = control
 		_connect_button(control as BaseButton, id)
+	if control is ItemList:
+		_collect_item_list_items(control as ItemList, id)
+	if control is TabContainer:
+		_collect_tab_items(control as TabContainer, id)
 
 	for child in control.get_children():
 		if child is Control:
-			_collect_control(child as Control)
+			_collect_control(child as Control, id)
+
+
+func _collect_item_list_items(item_list: ItemList, parent_id: String) -> void:
+	for index in range(item_list.item_count):
+		var label := item_list.get_item_text(index)
+		context.register_node_v2({
+			"id": "%s$item:%d" % [parent_id, index],
+			"parent_id": parent_id,
+			"role": "listitem",
+			"label": label,
+			"text": label,
+			"bounds": Rect2(item_list.global_position, item_list.size),
+			"visible": item_list.is_visible_in_tree(),
+			"enabled": not item_list.is_item_disabled(index),
+			"selected": item_list.is_selected(index),
+		})
+
+
+func _collect_tab_items(tab_container: TabContainer, parent_id: String) -> void:
+	for index in range(tab_container.get_tab_count()):
+		var label := tab_container.get_tab_title(index)
+		context.register_node_v2({
+			"id": "%s$tab:%d" % [parent_id, index],
+			"parent_id": parent_id,
+			"role": "tab",
+			"label": label,
+			"text": label,
+			"bounds": Rect2(tab_container.global_position, tab_container.size),
+			"visible": tab_container.is_visible_in_tree(),
+			"enabled": not tab_container.is_tab_disabled(index),
+			"selected": tab_container.current_tab == index,
+		})
 
 
 func _dispatch_click_requests() -> void:
@@ -196,6 +245,12 @@ func _control_id(control: Control) -> String:
 
 
 func _control_role(control: Control) -> String:
+	if control is OptionButton:
+		return "combobox"
+	if control is ItemList:
+		return "list"
+	if control is TabContainer:
+		return "tablist"
 	if control is CheckBox:
 		return "checkbox"
 	if control is BaseButton:
@@ -210,6 +265,8 @@ func _control_role(control: Control) -> String:
 
 
 func _control_label(control: Control) -> String:
+	if control is OptionButton:
+		return control.name
 	if control is BaseButton:
 		return (control as BaseButton).text
 	if control is Label:
@@ -221,6 +278,31 @@ func _control_label(control: Control) -> String:
 	return control.name
 
 
+func _control_text(control: Control) -> Variant:
+	if control is BaseButton:
+		return (control as BaseButton).text
+	if control is Label:
+		return (control as Label).text
+	if control is LineEdit:
+		return (control as LineEdit).text
+	if control is TextEdit:
+		return (control as TextEdit).text
+	return null
+
+
+func _control_value(control: Control) -> Variant:
+	if control is OptionButton:
+		var option := control as OptionButton
+		return option.get_item_text(option.selected) if option.selected >= 0 else ""
+	if control is LineEdit:
+		return (control as LineEdit).text
+	if control is TextEdit:
+		return (control as TextEdit).text
+	if control is Range:
+		return str((control as Range).value)
+	return null
+
+
 func _control_enabled(control: Control) -> bool:
 	if control is BaseButton:
 		return not (control as BaseButton).disabled
@@ -228,4 +310,10 @@ func _control_enabled(control: Control) -> bool:
 		return (control as LineEdit).editable
 	if control is TextEdit:
 		return (control as TextEdit).editable
-	return false
+	if control is ItemList:
+		return true
+	if control is TabContainer:
+		return true
+	if control is Slider:
+		return (control as Slider).editable
+	return control.mouse_filter != Control.MOUSE_FILTER_IGNORE

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -23,6 +23,42 @@ func _run() -> void:
 	button.pressed.connect(_on_start_pressed)
 	screen.add_child(button)
 
+	var checkbox := CheckBox.new()
+	checkbox.name = "remember"
+	checkbox.text = "Remember me"
+	checkbox.button_pressed = false
+	screen.add_child(checkbox)
+
+	var line_edit := LineEdit.new()
+	line_edit.name = "name"
+	line_edit.text = "Gua"
+	screen.add_child(line_edit)
+
+	var option := OptionButton.new()
+	option.name = "difficulty"
+	option.add_item("Easy")
+	option.add_item("Hard")
+	option.select(1)
+	screen.add_child(option)
+
+	var item_list := ItemList.new()
+	item_list.name = "servers"
+	item_list.add_item("Tokyo")
+	item_list.add_item("Osaka")
+	item_list.select(0)
+	screen.add_child(item_list)
+
+	var tabs := TabContainer.new()
+	tabs.name = "tabs"
+	var general_tab := Control.new()
+	general_tab.name = "General"
+	tabs.add_child(general_tab)
+	var audio_tab := Control.new()
+	audio_tab.name = "Audio"
+	tabs.add_child(audio_tab)
+	tabs.current_tab = 1
+	screen.add_child(tabs)
+
 	await process_frame
 
 	var ui := GuaAutoAdapterScript.new()
@@ -37,6 +73,41 @@ func _run() -> void:
 	var tree_json := ui.get_ui_tree_json()
 	if not tree_json.contains("\"start\"") or not tree_json.contains("\"button\""):
 		_fail("Gua smoke did not publish the start button in the UI tree: %s" % tree_json)
+		return
+	var tree = JSON.parse_string(tree_json)
+	if tree.get("schemaVersion", 0) != 2 or tree.get("frameSequence", 0) != 1:
+		_fail("Gua smoke did not publish v2 snapshot metadata: %s" % tree_json)
+		return
+	if not tree_json.contains("\"checked\":false"):
+		_fail("Gua smoke collapsed an observed false checkbox state into unknown: %s" % tree_json)
+		return
+	if not tree_json.contains("\"role\":\"combobox\"") or not tree_json.contains("\"value\":\"Hard\""):
+		_fail("Gua smoke did not publish OptionButton value state: %s" % tree_json)
+		return
+	if not tree_json.contains("servers$item:0") or not tree_json.contains("tabs$tab:1"):
+		_fail("Gua smoke did not publish stable ItemList/TabContainer semantic children: %s" % tree_json)
+		return
+
+	var first_revision = tree.get("revision", 0)
+	ui.update("title")
+	var stable_tree = JSON.parse_string(ui.get_ui_tree_json())
+	if stable_tree.get("frameSequence", 0) != 2 or stable_tree.get("revision", 0) != first_revision:
+		_fail("Gua smoke changed revision for an unchanged semantic frame: %s" % ui.get_ui_tree_json())
+		return
+
+	checkbox.visible = false
+	ui.update("title")
+	var hidden_tree = JSON.parse_string(ui.get_ui_tree_json())
+	var hidden_checkbox = _find_node(hidden_tree, "remember")
+	if hidden_checkbox == null or hidden_checkbox.get("visible", true):
+		_fail("Gua smoke removed a hidden in-tree control instead of publishing visible=false.")
+		return
+
+	screen.remove_child(checkbox)
+	checkbox.queue_free()
+	ui.update("title")
+	if _find_node(JSON.parse_string(ui.get_ui_tree_json()), "remember") != null:
+		_fail("Gua smoke retained a detached control in the semantic snapshot.")
 		return
 
 	if not ui.enqueue_click("start"):
@@ -68,6 +139,13 @@ func _run() -> void:
 
 func _on_start_pressed() -> void:
 	pressed_count += 1
+
+
+func _find_node(tree: Dictionary, id: String) -> Variant:
+	for node in tree.get("nodes", []):
+		if node.get("id", "") == id:
+			return node
+	return null
 
 
 func _fail(message: String) -> void:

--- a/native/gua-core/CMakeLists.txt
+++ b/native/gua-core/CMakeLists.txt
@@ -58,3 +58,10 @@ else()
             -Wpedantic
     )
 endif()
+
+if(BUILD_TESTING)
+    add_executable(gua-core-state-tests tests/state_model_tests.cpp)
+    target_link_libraries(gua-core-state-tests PRIVATE gua-core)
+    target_compile_features(gua-core-state-tests PRIVATE cxx_std_20)
+    add_test(NAME gua-core-state-tests COMMAND gua-core-state-tests)
+endif()

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -22,6 +24,51 @@ typedef struct gua_node_state_t {
     int visible;
     int enabled;
 } gua_node_state_t;
+
+enum {
+    GUA_NODE_KNOWN_PARENT_ID = 1ULL << 0,
+    GUA_NODE_KNOWN_TEXT = 1ULL << 1,
+    GUA_NODE_KNOWN_VALUE = 1ULL << 2,
+    GUA_NODE_KNOWN_FOCUSED = 1ULL << 3,
+    GUA_NODE_KNOWN_HOVERED = 1ULL << 4,
+    GUA_NODE_KNOWN_PRESSED = 1ULL << 5,
+    GUA_NODE_KNOWN_CHECKED = 1ULL << 6,
+    GUA_NODE_KNOWN_SELECTED = 1ULL << 7
+};
+
+typedef struct gua_node_descriptor_v2_t {
+    uint32_t struct_size;
+    uint64_t known_mask;
+    const char* id;
+    const char* parent_id;
+    const char* role;
+    const char* label;
+    const char* text;
+    const char* value;
+    gua_bounds_t bounds;
+    int visible;
+    int enabled;
+    int focused;
+    int hovered;
+    int pressed;
+    int checked;
+    int selected;
+} gua_node_descriptor_v2_t;
+
+typedef struct gua_node_state_v2_t {
+    uint32_t struct_size;
+    uint64_t known_mask;
+    int visible;
+    int enabled;
+    int focused;
+    int hovered;
+    int pressed;
+    int checked;
+    int selected;
+    char parent_id[128];
+    char text[256];
+    char value[256];
+} gua_node_state_v2_t;
 
 enum {
     GUA_LOG_TRACE = 0,
@@ -52,6 +99,7 @@ void gua_register_node(
     int visible,
     int enabled
 );
+int gua_register_node_v2(gua_context_t* ctx, const gua_node_descriptor_v2_t* descriptor);
 
 const char* gua_get_ui_tree_json(gua_context_t* ctx);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
@@ -65,6 +113,7 @@ const char* gua_get_screenshot_json(gua_context_t* ctx);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
 int gua_copy_screenshot_json(gua_context_t* ctx, char* out_json, int out_json_size);
 int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state);
+int gua_get_node_state_v2(gua_context_t* ctx, const char* node_id, gua_node_state_v2_t* out_state);
 int gua_find_node_by_id(gua_context_t* ctx, const char* node_id, char* out_node_id, int out_node_id_size);
 int gua_find_node_by_role(gua_context_t* ctx, const char* role, const char* name, char* out_node_id, int out_node_id_size);
 int gua_find_node_by_text(gua_context_t* ctx, const char* text, char* out_node_id, int out_node_id_size);

--- a/native/gua-core/include/gua/gua.hpp
+++ b/native/gua-core/include/gua/gua.hpp
@@ -3,6 +3,7 @@
 #include "gua/gua.h"
 
 #include <stdexcept>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -32,6 +33,17 @@ enum class LogLevel {
 struct Event {
     EventType type = EventType::none;
     std::string node_id;
+};
+
+struct NodeProperties {
+    std::optional<std::string_view> parent_id;
+    std::optional<std::string_view> text;
+    std::optional<std::string_view> value;
+    std::optional<bool> focused;
+    std::optional<bool> hovered;
+    std::optional<bool> pressed;
+    std::optional<bool> checked;
+    std::optional<bool> selected;
 };
 
 class Context {
@@ -103,6 +115,55 @@ public:
             gua_bounds_t { bounds.x, bounds.y, bounds.w, bounds.h },
             visible ? 1 : 0,
             enabled ? 1 : 0);
+    }
+
+    void node_v2(
+        std::string_view id,
+        std::string_view role,
+        std::string_view label,
+        Rect bounds,
+        const NodeProperties& properties = {},
+        bool visible = true,
+        bool enabled = true)
+    {
+        id_buffer_.assign(id);
+        role_buffer_.assign(role);
+        label_buffer_.assign(label);
+        parent_id_buffer_ = properties.parent_id ? std::string(*properties.parent_id) : std::string();
+        text_buffer_ = properties.text ? std::string(*properties.text) : std::string();
+        value_buffer_ = properties.value ? std::string(*properties.value) : std::string();
+
+        unsigned long long known_mask = 0;
+        if (properties.parent_id) known_mask |= GUA_NODE_KNOWN_PARENT_ID;
+        if (properties.text) known_mask |= GUA_NODE_KNOWN_TEXT;
+        if (properties.value) known_mask |= GUA_NODE_KNOWN_VALUE;
+        if (properties.focused) known_mask |= GUA_NODE_KNOWN_FOCUSED;
+        if (properties.hovered) known_mask |= GUA_NODE_KNOWN_HOVERED;
+        if (properties.pressed) known_mask |= GUA_NODE_KNOWN_PRESSED;
+        if (properties.checked) known_mask |= GUA_NODE_KNOWN_CHECKED;
+        if (properties.selected) known_mask |= GUA_NODE_KNOWN_SELECTED;
+
+        const gua_node_descriptor_v2_t descriptor {
+            sizeof(gua_node_descriptor_v2_t),
+            known_mask,
+            id_buffer_.c_str(),
+            properties.parent_id ? parent_id_buffer_.c_str() : nullptr,
+            role_buffer_.c_str(),
+            label_buffer_.c_str(),
+            properties.text ? text_buffer_.c_str() : nullptr,
+            properties.value ? value_buffer_.c_str() : nullptr,
+            gua_bounds_t { bounds.x, bounds.y, bounds.w, bounds.h },
+            visible ? 1 : 0,
+            enabled ? 1 : 0,
+            properties.focused.value_or(false) ? 1 : 0,
+            properties.hovered.value_or(false) ? 1 : 0,
+            properties.pressed.value_or(false) ? 1 : 0,
+            properties.checked.value_or(false) ? 1 : 0,
+            properties.selected.value_or(false) ? 1 : 0,
+        };
+        if (gua_register_node_v2(context_, &descriptor) == 0) {
+            throw std::runtime_error("Failed to register Gua v2 node");
+        }
     }
 
     void button(std::string_view id, std::string_view label, Rect bounds, bool visible = true, bool enabled = true)
@@ -210,6 +271,9 @@ private:
     mutable std::string id_buffer_;
     mutable std::string role_buffer_;
     mutable std::string label_buffer_;
+    mutable std::string parent_id_buffer_;
+    mutable std::string text_buffer_;
+    mutable std::string value_buffer_;
     mutable std::string message_buffer_;
     std::string screenshot_buffer_;
     std::string screen_buffer_;

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -19,6 +19,15 @@ struct Node {
     gua_bounds_t bounds;
     bool visible;
     bool enabled;
+    unsigned long long known_mask = 0;
+    std::string parent_id;
+    std::string text;
+    std::string value;
+    bool focused = false;
+    bool hovered = false;
+    bool pressed = false;
+    bool checked = false;
+    bool selected = false;
 };
 
 struct Event {
@@ -109,6 +118,9 @@ struct gua_context_t {
     std::string json_cache;
     std::string logs_json_cache;
     std::string screenshot_json_cache;
+    unsigned long long frame_sequence = 0;
+    unsigned long long revision = 0;
+    std::string previous_semantic_snapshot;
 };
 
 namespace {
@@ -122,7 +134,7 @@ int copy_json_string(const std::string& json, char* out_json, int out_json_size)
     return required_size;
 }
 
-std::string build_ui_tree_json(const gua_context_t& ctx)
+std::string build_semantic_snapshot_json(const gua_context_t& ctx)
 {
     std::string json = "{\"screen\":\"" + escape_json(ctx.screen) + "\",\"nodes\":[";
 
@@ -143,16 +155,50 @@ std::string build_ui_tree_json(const gua_context_t& ctx)
             node.bounds.h);
 
         json += "{\"id\":\"" + escape_json(node.id) + "\"";
+        if ((node.known_mask & GUA_NODE_KNOWN_PARENT_ID) != 0U) {
+            json += ",\"parentId\":\"" + escape_json(node.parent_id) + "\"";
+        }
         json += ",\"role\":\"" + escape_json(node.role) + "\"";
         json += ",\"label\":\"" + escape_json(node.label) + "\"";
+        if ((node.known_mask & GUA_NODE_KNOWN_TEXT) != 0U) {
+            json += ",\"text\":\"" + escape_json(node.text) + "\"";
+        }
+        if ((node.known_mask & GUA_NODE_KNOWN_VALUE) != 0U) {
+            json += ",\"value\":\"" + escape_json(node.value) + "\"";
+        }
         json += ",\"visible\":";
         json += node.visible ? "true" : "false";
         json += ",\"enabled\":";
         json += node.enabled ? "true" : "false";
         json += ",\"bounds\":";
         json += bounds;
-        if (node.role == "button" && node.enabled) {
+        const unsigned long long boolean_state_mask =
+            GUA_NODE_KNOWN_FOCUSED | GUA_NODE_KNOWN_HOVERED | GUA_NODE_KNOWN_PRESSED |
+            GUA_NODE_KNOWN_CHECKED | GUA_NODE_KNOWN_SELECTED;
+        if ((node.known_mask & boolean_state_mask) != 0U) {
+            json += ",\"state\":{";
+            bool wrote_state = false;
+            const auto append_state = [&](const char* name, bool value) {
+                if (wrote_state) {
+                    json += ",";
+                }
+                json += "\"";
+                json += name;
+                json += "\":";
+                json += value ? "true" : "false";
+                wrote_state = true;
+            };
+            if ((node.known_mask & GUA_NODE_KNOWN_FOCUSED) != 0U) append_state("focused", node.focused);
+            if ((node.known_mask & GUA_NODE_KNOWN_HOVERED) != 0U) append_state("hovered", node.hovered);
+            if ((node.known_mask & GUA_NODE_KNOWN_PRESSED) != 0U) append_state("pressed", node.pressed);
+            if ((node.known_mask & GUA_NODE_KNOWN_CHECKED) != 0U) append_state("checked", node.checked);
+            if ((node.known_mask & GUA_NODE_KNOWN_SELECTED) != 0U) append_state("selected", node.selected);
+            json += "}";
+        }
+        if ((node.role == "button" || node.role == "checkbox" || node.role == "radio" || node.role == "tab") && node.enabled) {
             json += ",\"actions\":[\"click\",\"focus\"]}";
+        } else if ((node.role == "textbox" || node.role == "slider" || node.role == "combobox") && node.enabled) {
+            json += ",\"actions\":[\"focus\",\"set_value\"]}";
         } else {
             json += ",\"actions\":[]}";
         }
@@ -160,6 +206,14 @@ std::string build_ui_tree_json(const gua_context_t& ctx)
 
     json += "]}";
     return json;
+}
+
+std::string build_ui_tree_json(const gua_context_t& ctx)
+{
+    std::string semantic = build_semantic_snapshot_json(ctx);
+    semantic.erase(semantic.begin());
+    return "{\"schemaVersion\":2,\"frameSequence\":" + std::to_string(ctx.frame_sequence) +
+        ",\"revision\":" + std::to_string(ctx.revision) + "," + semantic;
 }
 
 std::string build_logs_json(const gua_context_t& ctx)
@@ -225,6 +279,12 @@ extern "C" void gua_end_frame(gua_context_t* ctx)
     }
 
     const std::lock_guard lock(ctx->mutex);
+    const std::string semantic_snapshot = build_semantic_snapshot_json(*ctx);
+    ++ctx->frame_sequence;
+    if (semantic_snapshot != ctx->previous_semantic_snapshot) {
+        ++ctx->revision;
+        ctx->previous_semantic_snapshot = semantic_snapshot;
+    }
     ctx->json_cache.clear();
 }
 
@@ -250,6 +310,34 @@ extern "C" void gua_register_node(
         visible != 0,
         enabled != 0,
     });
+}
+
+extern "C" int gua_register_node_v2(gua_context_t* ctx, const gua_node_descriptor_v2_t* descriptor)
+{
+    if (ctx == nullptr || descriptor == nullptr || descriptor->struct_size < sizeof(gua_node_descriptor_v2_t) ||
+        descriptor->id == nullptr || descriptor->role == nullptr) {
+        return 0;
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    ctx->nodes.push_back(Node {
+        descriptor->id,
+        descriptor->role,
+        descriptor->label != nullptr ? descriptor->label : "",
+        descriptor->bounds,
+        descriptor->visible != 0,
+        descriptor->enabled != 0,
+        descriptor->known_mask,
+        descriptor->parent_id != nullptr ? descriptor->parent_id : "",
+        descriptor->text != nullptr ? descriptor->text : "",
+        descriptor->value != nullptr ? descriptor->value : "",
+        descriptor->focused != 0,
+        descriptor->hovered != 0,
+        descriptor->pressed != 0,
+        descriptor->checked != 0,
+        descriptor->selected != 0,
+    });
+    return 1;
 }
 
 extern "C" const char* gua_get_ui_tree_json(gua_context_t* ctx)
@@ -359,6 +447,32 @@ extern "C" int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_n
 
     out_state->visible = found->visible ? 1 : 0;
     out_state->enabled = found->enabled ? 1 : 0;
+    return 1;
+}
+
+extern "C" int gua_get_node_state_v2(gua_context_t* ctx, const char* node_id, gua_node_state_v2_t* out_state)
+{
+    if (ctx == nullptr || node_id == nullptr || out_state == nullptr || out_state->struct_size < sizeof(gua_node_state_v2_t)) {
+        return 0;
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    const auto found = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) { return node.id == node_id; });
+    if (found == ctx->nodes.end()) {
+        return 0;
+    }
+
+    out_state->known_mask = found->known_mask;
+    out_state->visible = found->visible ? 1 : 0;
+    out_state->enabled = found->enabled ? 1 : 0;
+    out_state->focused = found->focused ? 1 : 0;
+    out_state->hovered = found->hovered ? 1 : 0;
+    out_state->pressed = found->pressed ? 1 : 0;
+    out_state->checked = found->checked ? 1 : 0;
+    out_state->selected = found->selected ? 1 : 0;
+    std::snprintf(out_state->parent_id, sizeof(out_state->parent_id), "%s", found->parent_id.c_str());
+    std::snprintf(out_state->text, sizeof(out_state->text), "%s", found->text.c_str());
+    std::snprintf(out_state->value, sizeof(out_state->value), "%s", found->value.c_str());
     return 1;
 }
 

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -1,0 +1,81 @@
+#include "gua/gua.h"
+
+#include <cassert>
+#include <cstring>
+#include <string>
+
+namespace {
+
+void register_checkbox(gua_context_t* context, bool checked)
+{
+    const gua_node_descriptor_v2_t descriptor {
+        sizeof(gua_node_descriptor_v2_t),
+        GUA_NODE_KNOWN_PARENT_ID | GUA_NODE_KNOWN_TEXT | GUA_NODE_KNOWN_FOCUSED | GUA_NODE_KNOWN_CHECKED,
+        "remember",
+        "form",
+        "checkbox",
+        "Remember me",
+        "Remember me",
+        nullptr,
+        { 10.0F, 20.0F, 100.0F, 24.0F },
+        1,
+        1,
+        0,
+        0,
+        0,
+        checked ? 1 : 0,
+        0,
+    };
+    assert(gua_register_node_v2(context, &descriptor) == 1);
+}
+
+} // namespace
+
+int main()
+{
+    gua_context_t* context = gua_create_context();
+    assert(context != nullptr);
+
+    gua_begin_frame(context, "settings");
+    register_checkbox(context, false);
+    gua_end_frame(context);
+    const std::string first = gua_get_ui_tree_json(context);
+    assert(first.find("\"schemaVersion\":2") != std::string::npos);
+    assert(first.find("\"frameSequence\":1") != std::string::npos);
+    assert(first.find("\"revision\":1") != std::string::npos);
+    assert(first.find("\"parentId\":\"form\"") != std::string::npos);
+    assert(first.find("\"checked\":false") != std::string::npos);
+    assert(first.find("\"selected\"") == std::string::npos);
+
+    gua_node_state_v2_t state {};
+    state.struct_size = sizeof(state);
+    assert(gua_get_node_state_v2(context, "remember", &state) == 1);
+    assert((state.known_mask & GUA_NODE_KNOWN_CHECKED) != 0U);
+    assert(state.checked == 0);
+    assert(std::strcmp(state.parent_id, "form") == 0);
+
+    gua_begin_frame(context, "settings");
+    register_checkbox(context, false);
+    gua_end_frame(context);
+    const std::string stable = gua_get_ui_tree_json(context);
+    assert(stable.find("\"frameSequence\":2") != std::string::npos);
+    assert(stable.find("\"revision\":1") != std::string::npos);
+
+    gua_begin_frame(context, "settings");
+    register_checkbox(context, true);
+    gua_end_frame(context);
+    const std::string changed = gua_get_ui_tree_json(context);
+    assert(changed.find("\"frameSequence\":3") != std::string::npos);
+    assert(changed.find("\"revision\":2") != std::string::npos);
+    assert(changed.find("\"checked\":true") != std::string::npos);
+
+    gua_begin_frame(context, "settings");
+    gua_register_node(context, "legacy", "button", "Legacy", { 0, 0, 1, 1 }, 1, 1);
+    gua_end_frame(context);
+    gua_node_state_t legacy {};
+    assert(gua_get_node_state(context, "legacy", &legacy) == 1);
+    assert(legacy.visible == 1 && legacy.enabled == 1);
+
+    gua_destroy_context(context);
+    return 0;
+}

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -25,6 +25,7 @@ public:
         const Rect2& bounds,
         bool visible = true,
         bool enabled = true);
+    bool register_node_v2(const Dictionary& descriptor);
 
     String get_ui_tree_json() const;
     bool enqueue_click(const String& node_id);

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -98,6 +98,61 @@ void GuaContext::register_node(
         enabled ? 1 : 0);
 }
 
+bool GuaContext::register_node_v2(const Dictionary& source)
+{
+    if (!source.has("id") || !source.has("role") || !source.has("bounds")) {
+        UtilityFunctions::push_error("GuaContext.register_node_v2 requires id, role, and bounds.");
+        return false;
+    }
+
+    const String id = source["id"];
+    const String role = source["role"];
+    const String label = source.get("label", String());
+    const String parent_id = source.get("parent_id", String());
+    const String text = source.get("text", String());
+    const String value = source.get("value", String());
+    const Rect2 bounds = source["bounds"];
+    const CharString id_utf8 = id.utf8();
+    const CharString parent_id_utf8 = parent_id.utf8();
+    const CharString role_utf8 = role.utf8();
+    const CharString label_utf8 = label.utf8();
+    const CharString text_utf8 = text.utf8();
+    const CharString value_utf8 = value.utf8();
+
+    unsigned long long known_mask = 0;
+    if (source.has("parent_id")) known_mask |= GUA_NODE_KNOWN_PARENT_ID;
+    if (source.has("text")) known_mask |= GUA_NODE_KNOWN_TEXT;
+    if (source.has("value")) known_mask |= GUA_NODE_KNOWN_VALUE;
+    if (source.has("focused")) known_mask |= GUA_NODE_KNOWN_FOCUSED;
+    if (source.has("hovered")) known_mask |= GUA_NODE_KNOWN_HOVERED;
+    if (source.has("pressed")) known_mask |= GUA_NODE_KNOWN_PRESSED;
+    if (source.has("checked")) known_mask |= GUA_NODE_KNOWN_CHECKED;
+    if (source.has("selected")) known_mask |= GUA_NODE_KNOWN_SELECTED;
+
+    const gua_node_descriptor_v2_t descriptor {
+        sizeof(gua_node_descriptor_v2_t),
+        known_mask,
+        id_utf8.get_data(),
+        source.has("parent_id") ? parent_id_utf8.get_data() : nullptr,
+        role_utf8.get_data(),
+        label_utf8.get_data(),
+        source.has("text") ? text_utf8.get_data() : nullptr,
+        source.has("value") ? value_utf8.get_data() : nullptr,
+        gua_bounds_t {
+            static_cast<float>(bounds.position.x), static_cast<float>(bounds.position.y),
+            static_cast<float>(bounds.size.x), static_cast<float>(bounds.size.y),
+        },
+        source.get("visible", true) ? 1 : 0,
+        source.get("enabled", true) ? 1 : 0,
+        source.get("focused", false) ? 1 : 0,
+        source.get("hovered", false) ? 1 : 0,
+        source.get("pressed", false) ? 1 : 0,
+        source.get("checked", false) ? 1 : 0,
+        source.get("selected", false) ? 1 : 0,
+    };
+    return gua_runtime_register_node_v2(runtime_, &descriptor) != 0;
+}
+
 String GuaContext::get_ui_tree_json() const
 {
     return copy_runtime_json(runtime_, gua_runtime_copy_ui_tree_json);
@@ -168,6 +223,7 @@ void GuaContext::_bind_methods()
         &GuaContext::register_node,
         DEFVAL(true),
         DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("register_node_v2", "descriptor"), &GuaContext::register_node_v2);
     ClassDB::bind_method(D_METHOD("get_ui_tree_json"), &GuaContext::get_ui_tree_json);
     ClassDB::bind_method(D_METHOD("enqueue_click", "node_id"), &GuaContext::enqueue_click);
     ClassDB::bind_method(D_METHOD("consume_click_request", "node_id"), &GuaContext::consume_click_request);

--- a/native/gua-imgui/include/gua/imgui_adapter.hpp
+++ b/native/gua-imgui/include/gua/imgui_adapter.hpp
@@ -54,7 +54,14 @@ inline bool button(
     bool visible = true,
     bool enabled = true)
 {
-    context.button(id, label, bounds, visible, enabled);
+    context.node_v2(
+        id,
+        "button",
+        label,
+        bounds,
+        NodeProperties { .text = label, .pressed = clicked },
+        visible,
+        enabled);
     if (clicked && visible && enabled) {
         return context.emit_click(id);
     }
@@ -72,11 +79,16 @@ inline bool button(Context& context, std::string_view label)
     const ImVec2 max = ImGui::GetItemRectMax();
     const bool visible = ImGui::IsItemVisible();
     const bool enabled = true;
+    const bool focused = ImGui::IsItemFocused();
+    const bool hovered = ImGui::IsItemHovered();
+    const bool pressed = ImGui::IsItemActive();
 
-    context.button(
+    context.node_v2(
         id,
+        "button",
         visible_label_buffer,
         Rect { min.x, min.y, max.x - min.x, max.y - min.y },
+        NodeProperties { .text = visible_label_buffer, .focused = focused, .hovered = hovered, .pressed = pressed },
         visible,
         enabled);
 
@@ -100,12 +112,17 @@ inline bool button(Context& context, std::string_view id, std::string_view label
     const ImVec2 max = ImGui::GetItemRectMax();
     const bool visible = ImGui::IsItemVisible();
     const bool enabled = true;
+    const bool focused = ImGui::IsItemFocused();
+    const bool hovered = ImGui::IsItemHovered();
+    const bool pressed = ImGui::IsItemActive();
     ImGui::PopID();
 
-    context.button(
+    context.node_v2(
         id,
+        "button",
         visible_label_buffer,
         Rect { min.x, min.y, max.x - min.x, max.y - min.y },
+        NodeProperties { .text = visible_label_buffer, .focused = focused, .hovered = hovered, .pressed = pressed },
         visible,
         enabled);
 
@@ -126,11 +143,14 @@ inline void text(Context& context, std::string_view label)
     ImGui::TextUnformatted(visible_label_buffer.c_str());
     const ImVec2 min = ImGui::GetItemRectMin();
     const ImVec2 max = ImGui::GetItemRectMax();
-    context.text(
+    context.node_v2(
         id,
+        "text",
         visible_label_buffer,
         Rect { min.x, min.y, max.x - min.x, max.y - min.y },
-        ImGui::IsItemVisible());
+        NodeProperties { .text = visible_label_buffer },
+        ImGui::IsItemVisible(),
+        false);
 }
 
 } // namespace gua::imgui

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -22,6 +22,7 @@ void gua_runtime_register_node(
     int visible,
     int enabled
 );
+int gua_runtime_register_node_v2(gua_runtime_t* runtime, const gua_node_descriptor_v2_t* descriptor);
 
 const char* gua_runtime_get_ui_tree_json(gua_runtime_t* runtime);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
@@ -35,6 +36,7 @@ const char* gua_runtime_get_screenshot_json(gua_runtime_t* runtime);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
 int gua_runtime_copy_screenshot_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
 int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* node_id, gua_node_state_t* out_state);
+int gua_runtime_get_node_state_v2(gua_runtime_t* runtime, const char* node_id, gua_node_state_v2_t* out_state);
 int gua_runtime_find_node_by_id(gua_runtime_t* runtime, const char* node_id, char* out_node_id, int out_node_id_size);
 int gua_runtime_find_node_by_role(gua_runtime_t* runtime, const char* role, const char* name, char* out_node_id, int out_node_id_size);
 int gua_runtime_find_node_by_text(gua_runtime_t* runtime, const char* text, char* out_node_id, int out_node_id_size);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -125,6 +125,16 @@ extern "C" void gua_runtime_register_node(
     gua_register_node(runtime->context, id, role, label, bounds, visible, enabled);
 }
 
+extern "C" int gua_runtime_register_node_v2(gua_runtime_t* runtime, const gua_node_descriptor_v2_t* descriptor)
+{
+    if (!valid_runtime(runtime)) {
+        return 0;
+    }
+
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_register_node_v2(runtime->context, descriptor);
+}
+
 extern "C" const char* gua_runtime_get_ui_tree_json(gua_runtime_t* runtime)
 {
     if (!valid_runtime(runtime)) {
@@ -210,6 +220,16 @@ extern "C" int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* no
 
     const std::lock_guard lock(runtime->context_mutex);
     return gua_get_node_state(runtime->context, node_id, out_state);
+}
+
+extern "C" int gua_runtime_get_node_state_v2(gua_runtime_t* runtime, const char* node_id, gua_node_state_v2_t* out_state)
+{
+    if (!valid_runtime(runtime)) {
+        return 0;
+    }
+
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_get_node_state_v2(runtime->context, node_id, out_state);
 }
 
 extern "C" int gua_runtime_find_node_by_id(gua_runtime_t* runtime, const char* node_id, char* out_node_id, int out_node_id_size)

--- a/protocol/fixtures/ui-tree-v2.json
+++ b/protocol/fixtures/ui-tree-v2.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": 2,
+  "frameSequence": 12,
+  "revision": 4,
+  "screen": "settings",
+  "nodes": [
+    {
+      "id": "remember",
+      "parentId": "form",
+      "role": "checkbox",
+      "label": "Remember me",
+      "text": "Remember me",
+      "visible": true,
+      "enabled": true,
+      "bounds": { "x": 10, "y": 20, "w": 100, "h": 24 },
+      "state": { "focused": false, "checked": false },
+      "actions": ["click", "focus"]
+    },
+    {
+      "id": "difficulty",
+      "parentId": "form",
+      "role": "combobox",
+      "label": "Difficulty",
+      "value": "Hard",
+      "visible": true,
+      "enabled": true,
+      "bounds": { "x": 10, "y": 50, "w": 100, "h": 24 },
+      "actions": ["focus", "set_value"]
+    }
+  ]
+}

--- a/protocol/schema/ui-tree.schema.json
+++ b/protocol/schema/ui-tree.schema.json
@@ -3,9 +3,12 @@
   "$id": "https://gua.dev/schema/ui-tree.schema.json",
   "title": "Gua UI Tree",
   "type": "object",
-  "required": ["screen", "nodes"],
+  "required": ["schemaVersion", "frameSequence", "revision", "screen", "nodes"],
   "additionalProperties": false,
   "properties": {
+    "schemaVersion": { "const": 2 },
+    "frameSequence": { "type": "integer", "minimum": 0 },
+    "revision": { "type": "integer", "minimum": 0 },
     "screen": {
       "type": "string",
       "minLength": 1
@@ -52,10 +55,15 @@
             "screen",
             "dialog",
             "menu",
-            "menuitem"
+            "menuitem",
+            "combobox",
+            "tablist",
+            "tab"
           ]
         },
         "label": { "type": "string" },
+        "text": { "type": "string" },
+        "value": { "type": ["number", "string", "boolean", "null"] },
         "visible": { "type": "boolean" },
         "enabled": { "type": "boolean" },
         "bounds": { "$ref": "#/$defs/bounds" },
@@ -67,6 +75,7 @@
             "hovered": { "type": "boolean" },
             "pressed": { "type": "boolean" },
             "checked": { "type": "boolean" },
+            "selected": { "type": "boolean" },
             "value": {
               "type": ["number", "string", "boolean", "null"]
             }

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -9,9 +9,24 @@ A UI tree response describes one frame or snapshot of runtime UI state.
 
 - `screen`: logical screen name, such as `title` or `settings`
 - `nodes`: flat list of semantic UI nodes
+- `schemaVersion`: currently `2`
+- `frameSequence`: increments once for every completed host frame
+- `revision`: increments only when the semantic screen or node content changes
 
 Nodes are intentionally semantic. They describe role, label, state, bounds, and
 supported actions, not rendering internals.
+
+Version 2 adds `parentId`, `text`, `value`, and optional boolean state. An
+omitted property means that the adapter cannot observe that state. A present
+property whose value is `false` means that the adapter observed the state and
+it was false. Adapters must not fill unsupported state with false. Values
+crossing the initial C ABI are normalized to UTF-8 strings; the schema also
+allows native JSON scalar values for future transports.
+
+`frameSequence` and `revision` have different purposes. Rebuilding the same
+semantic tree in consecutive frames increments `frameSequence` but leaves
+`revision` unchanged. Changing the screen, node membership, hierarchy, bounds,
+text, value, state, or actions increments `revision` at `end_frame`.
 
 ## Adapter-Owned Reflection
 
@@ -20,6 +35,8 @@ or snapshot. Game code should not have to restate its visible buttons, labels,
 and controls as separate Gua calls when the adapter can observe those controls.
 
 - If a host UI element disappears, the next adapter snapshot omits its Gua node.
+- If a host UI element remains in the host tree but becomes hidden, the adapter
+  keeps the node and publishes `visible: false`.
 - If a host UI element is clicked by the user, the adapter emits a Gua event.
 - If automation requests `click_node`, the core records a pending click request.
   The adapter consumes that request when it reaches the matching host UI element
@@ -28,6 +45,26 @@ and controls as separate Gua calls when the adapter can observe those controls.
 
 This keeps the C ABI as the stable protocol boundary while letting ImGui, Godot,
 and later engine adapters own the engine-specific reflection details.
+
+### Initial adapter mapping
+
+| Host control | Gua role | Adapter-owned fields |
+| --- | --- | --- |
+| ImGui `Button` facade | `button` | text, visible, enabled, focused, hovered, pressed |
+| ImGui `Text` facade | `text` | text, visible |
+| Godot `Button` | `button` | parentId, text, visible, enabled, focused |
+| Godot `CheckBox` | `checkbox` | parentId, text, focused, checked |
+| Godot `LineEdit` / `TextEdit` | `textbox` | parentId, text, value, focused |
+| Godot `OptionButton` | `combobox` | parentId, value, focused |
+| Godot `ItemList` | `list` + `listitem` children | stable derived child id, parentId, text, selected |
+| Godot `TabContainer` | `tablist` + `tab` children | stable derived child id, parentId, text, selected |
+
+The legacy `gua_register_node` and `gua_get_node_state` C exports remain valid.
+New integrations use `gua_node_descriptor_v2_t` / `gua_node_state_v2_t`, whose
+`struct_size` protects ABI versioning and whose `known_mask` distinguishes
+unsupported properties from observed false or empty values. Readers should
+continue accepting legacy payloads that contain only `screen` and `nodes`
+during migration.
 
 ## Inspector Snapshots
 


### PR DESCRIPTION
## 対応 Issue

Closes #21

## 実装内容

- `ui-tree.schema.json` を schemaVersion 2 とし、`frameSequence` / `revision`、`parentId`、`text`、`value`、optional state、`combobox` / `tablist` / `tab` role を定義
- 既存 ABI を維持したまま、`struct_size` と `known_mask` を持つ `gua_node_descriptor_v2_t` / `gua_node_state_v2_t` と runtime 透過 API を追加
- 同一 semantic snapshot では revision を維持し、完了 frame ごとに frameSequence を増加
- C++ wrapper、.NET P/Invoke / snapshot reader、remote model を v2 に追従し、legacy JSON reader 互換を維持
- ImGui facade が text / focused / hovered / pressed を adapter-owned reflection で登録
- Godot adapter が Button、CheckBox、LineEdit/TextEdit、OptionButton、ItemList、TabContainer の role・親子・値・選択状態を自動収集
- native deterministic test、NUnit test、Godot 4.7 smoke、schema fixture を追加

## Architecture 判断

- 既存 `gua_register_node` / `gua_get_node_state` と既存 struct は変更せず、additive v2 API に分離しました。
- optional state は known mask が立つ場合だけ JSON に出し、観測済み false と未対応/取得不能を区別します。
- Godot の semantic child ID は `<parent>$item:<index>` / `<parent>$tab:<index>` とし、ゲームコードによる状態の手動再記述を要求しません。
- click 以外の action queue、selector、wait、diagnostics は後続 Issue の範囲として混ぜていません。

## テスト・検証

- `cmake --preset windows-msvc-debug` ✅
- `cmake --build --preset windows-msvc-debug` ✅
- `ctest --test-dir build\\windows-msvc-debug -C Debug --output-on-failure` ✅ 1/1
- `dotnet build bindings\\dotnet\\src\\Gua.Testing\\Gua.Testing.csproj --configuration Release --no-restore` ✅
- `dotnet build bindings\\dotnet\\src\\Gua.Testing.Godot\\Gua.Testing.Godot.csproj --configuration Release --no-restore` ✅
- ローカル pack を使用した `dotnet build/test examples\\dotnet-nunit\\GuaDotNetNUnitSample.csproj` ✅ 4/4
- `bun run check` ✅
- Godot 4.7 headless `gua_smoke.gd` ✅
- `ajv-cli` による `ui-tree-v2.json` schema validation ✅
- `git diff --check` ✅

## 互換性確認

- legacy C ABI の登録・状態取得を native test で確認
- `screen` / `nodes` のみの legacy JSON を .NET reader が引き続き読めることを NUnit test で確認
- hidden in-tree node は `visible=false` で残り、detached node は次 snapshot から消えることを Godot smoke で確認

## 未対応事項

Issue #21 の範囲内に未対応事項はありません。後続の generic action、strict selector、wait/diagnostics は各依存 Issue で扱います。