### PR TITLE
#22 click 以外の semantic UI action request/event を標準化する

### DIFF
--- a/bindings/dotnet/src/Gua.Core/GuaAction.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaAction.cs
@@ -1,0 +1,45 @@
+namespace Gua.Core;
+
+public enum GuaActionType
+{
+    Click = 1,
+    Focus = 2,
+    SetValue = 3,
+    SetChecked = 4,
+    Select = 5,
+    Scroll = 6,
+    PressKey = 7,
+}
+
+public enum GuaActionError
+{
+    None = 0,
+    InvalidArgument = -1,
+    NodeNotFound = -2,
+    Hidden = -3,
+    Disabled = -4,
+    Unsupported = -5,
+    InvalidValue = -6,
+}
+
+public readonly record struct GuaActionRequest(
+    GuaActionType Action,
+    string? NodeId = null,
+    string? Value = null,
+    float DeltaX = 0,
+    float DeltaY = 0,
+    bool BoolValue = false,
+    string? Key = null,
+    uint Modifiers = 0,
+    bool Sensitive = false,
+    int ScrollUnit = 0,
+    ulong RequestId = 0);
+
+public readonly record struct GuaActionEvent(
+    ulong RequestId,
+    GuaActionType Action,
+    bool Succeeded,
+    GuaActionError Error,
+    string NodeId,
+    string Value,
+    bool Sensitive);

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Gua.Core;
 
 public sealed class GuaContext : IGuaContext, IDisposable
@@ -232,6 +234,133 @@ public sealed class GuaContext : IGuaContext, IDisposable
     {
         ThrowIfDisposed();
         return Native.gua_enqueue_click(_handle, id) != 0;
+    }
+
+    public GuaActionError EnqueueAction(GuaActionRequest request, out ulong requestId)
+    {
+        ThrowIfDisposed();
+        var nodeId = Marshal.StringToCoTaskMemUTF8(request.NodeId);
+        var value = Marshal.StringToCoTaskMemUTF8(request.Value);
+        var key = Marshal.StringToCoTaskMemUTF8(request.Key);
+        try
+        {
+            var descriptor = new Native.GuaNativeActionRequestDescriptor
+            {
+                StructSize = (uint)Marshal.SizeOf<Native.GuaNativeActionRequestDescriptor>(),
+                Action = (int)request.Action,
+                NodeId = nodeId,
+                Value = value,
+                DeltaX = request.DeltaX,
+                DeltaY = request.DeltaY,
+                BoolValue = request.BoolValue ? 1 : 0,
+                Key = key,
+                Modifiers = request.Modifiers,
+                Sensitive = request.Sensitive ? 1 : 0,
+                ScrollUnit = request.ScrollUnit,
+            };
+            var result = Native.gua_enqueue_action(_handle, in descriptor, out requestId);
+            return result == 1 ? GuaActionError.None : (GuaActionError)result;
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(nodeId);
+            Marshal.FreeCoTaskMem(value);
+            Marshal.FreeCoTaskMem(key);
+        }
+    }
+
+    public bool TryPollActionEvent(out GuaActionEvent e)
+    {
+        return TryPollActionEventCore(null, out e);
+    }
+
+    public bool TryPollActionEvent(ulong requestId, out GuaActionEvent e)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(requestId);
+        return TryPollActionEventCore(requestId, out e);
+    }
+
+    private bool TryPollActionEventCore(ulong? requestId, out GuaActionEvent e)
+    {
+        ThrowIfDisposed();
+        unsafe
+        {
+            Native.GuaNativeEventV2 nativeEvent = new()
+            {
+                StructSize = (uint)sizeof(Native.GuaNativeEventV2),
+            };
+            var found = requestId.HasValue
+                ? Native.gua_poll_event_v2_for_request(_handle, requestId.Value, &nativeEvent)
+                : Native.gua_poll_event_v2(_handle, &nativeEvent);
+            if (found == 0)
+            {
+                e = default;
+                return false;
+            }
+            e = new GuaActionEvent(
+                nativeEvent.RequestId,
+                (GuaActionType)nativeEvent.Action,
+                nativeEvent.Status == 1,
+                (GuaActionError)nativeEvent.ErrorCode,
+                Marshal.PtrToStringUTF8((nint)nativeEvent.NodeId) ?? string.Empty,
+                Marshal.PtrToStringUTF8((nint)nativeEvent.Value) ?? string.Empty,
+                nativeEvent.Sensitive != 0);
+            return true;
+        }
+    }
+
+    public bool TryConsumeAction(GuaActionType action, string? nodeId, out GuaActionRequest request)
+    {
+        ThrowIfDisposed();
+        unsafe
+        {
+            Native.GuaNativeActionRequest nativeRequest = new() { StructSize = (uint)sizeof(Native.GuaNativeActionRequest) };
+            if (Native.gua_consume_action_request(_handle, (int)action, nodeId, &nativeRequest) == 0)
+            {
+                request = default;
+                return false;
+            }
+            request = new GuaActionRequest(
+                (GuaActionType)nativeRequest.Action,
+                Marshal.PtrToStringUTF8((nint)nativeRequest.NodeId),
+                Marshal.PtrToStringUTF8((nint)nativeRequest.Value),
+                nativeRequest.DeltaX,
+                nativeRequest.DeltaY,
+                nativeRequest.BoolValue != 0,
+                Marshal.PtrToStringUTF8((nint)nativeRequest.Key),
+                nativeRequest.Modifiers,
+                nativeRequest.Sensitive != 0,
+                nativeRequest.ScrollUnit,
+                nativeRequest.RequestId);
+            return true;
+        }
+    }
+
+    public bool EmitActionResult(GuaActionEvent e)
+    {
+        ThrowIfDisposed();
+        var nodeId = Marshal.StringToCoTaskMemUTF8(e.NodeId);
+        var value = Marshal.StringToCoTaskMemUTF8(e.Value);
+        try
+        {
+            var result = new Native.GuaNativeActionResult
+            {
+                StructSize = (uint)Marshal.SizeOf<Native.GuaNativeActionResult>(),
+                RequestId = e.RequestId,
+                Action = (int)e.Action,
+                Status = e.Succeeded ? 1 : 2,
+                ErrorCode = (int)e.Error,
+                NodeId = nodeId,
+                Value = value,
+                Sensitive = e.Sensitive ? 1 : 0,
+            };
+            return Native.gua_emit_action_result(_handle, in result) != 0;
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(nodeId);
+            Marshal.FreeCoTaskMem(value);
+        }
     }
 
     public bool ConsumeClickRequest(string id)

--- a/bindings/dotnet/src/Gua.Core/IGuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/IGuaContext.cs
@@ -14,5 +14,11 @@ public interface IGuaContext
 
     bool EnqueueClick(string id);
 
+    GuaActionError EnqueueAction(GuaActionRequest request, out ulong requestId);
+
+    bool TryPollActionEvent(out GuaActionEvent e);
+
+    bool TryPollActionEvent(ulong requestId, out GuaActionEvent e);
+
     bool TryPollEvent(out GuaEvent e);
 }

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -16,6 +16,65 @@ internal static partial class Native
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    internal struct GuaNativeActionRequestDescriptor
+    {
+        public uint StructSize;
+        public int Action;
+        public nint NodeId;
+        public nint Value;
+        public float DeltaX;
+        public float DeltaY;
+        public int BoolValue;
+        public nint Key;
+        public uint Modifiers;
+        public int Sensitive;
+        public int ScrollUnit;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct GuaNativeEventV2
+    {
+        public uint StructSize;
+        public ulong RequestId;
+        public int Action;
+        public int Status;
+        public int ErrorCode;
+        public fixed byte NodeId[128];
+        public fixed byte Value[256];
+        public int Sensitive;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct GuaNativeActionRequest
+    {
+        public uint StructSize;
+        public ulong RequestId;
+        public int Action;
+        public fixed byte NodeId[128];
+        public fixed byte Value[256];
+        public float DeltaX;
+        public float DeltaY;
+        public int BoolValue;
+        public fixed byte Key[64];
+        public uint Modifiers;
+        public int Sensitive;
+        public int ScrollUnit;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GuaNativeActionResult
+    {
+        public uint StructSize;
+        public ulong RequestId;
+        public int Action;
+        public int Status;
+        public int ErrorCode;
+        public nint NodeId;
+        public nint Value;
+        public int Sensitive;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     internal struct GuaNativeNodeDescriptorV2
     {
         public uint StructSize;
@@ -214,4 +273,19 @@ internal static partial class Native
 
     [LibraryImport("gua")]
     internal static unsafe partial int gua_poll_event(nint context, GuaNativeEvent* outEvent);
+
+    [LibraryImport("gua")]
+    internal static partial int gua_enqueue_action(nint context, in GuaNativeActionRequestDescriptor descriptor, out ulong requestId);
+
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_poll_event_v2(nint context, GuaNativeEventV2* outEvent);
+
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_poll_event_v2_for_request(nint context, ulong requestId, GuaNativeEventV2* outEvent);
+
+    [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
+    internal static unsafe partial int gua_consume_action_request(nint context, int action, string? nodeId, GuaNativeActionRequest* outRequest);
+
+    [LibraryImport("gua")]
+    internal static partial int gua_emit_action_result(nint context, in GuaNativeActionResult result);
 }

--- a/bindings/dotnet/src/Gua.Core/README.md
+++ b/bindings/dotnet/src/Gua.Core/README.md
@@ -12,6 +12,12 @@ runtimes/win-x64/native/gua.dll
 normal package restore/build. `GUA_NATIVE_DIR` remains available when you want to
 override the packaged runtime with a locally built one.
 
+Semantic operations use `EnqueueAction` and return a `requestId`. The host adapter
+consumes the request, performs the real UI operation, then calls
+`EmitActionResult`; tests observe completion with `TryPollActionEvent`. Supported
+v1 actions are focus, set value, set checked, select, scroll, and key press.
+Click remains available through the original API and shares the same queue.
+
 At runtime the resolver checks:
 
 1. `GUA_NATIVE_DIR`

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -69,6 +69,76 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
         return true;
     }
 
+    public GuaActionError EnqueueAction(GuaActionRequest request, out ulong requestId)
+    {
+        var type = request.Action switch
+        {
+            GuaActionType.Click => "click_node",
+            GuaActionType.Focus => "focus_node",
+            GuaActionType.SetValue => "set_value",
+            GuaActionType.SetChecked => "set_checked",
+            GuaActionType.Select => "select",
+            GuaActionType.Scroll => "scroll",
+            GuaActionType.PressKey => "press_key",
+            _ => throw new ArgumentOutOfRangeException(nameof(request)),
+        };
+        var command = new Dictionary<string, object?>
+        {
+            ["type"] = type,
+            ["deltaX"] = request.DeltaX,
+            ["deltaY"] = request.DeltaY,
+            ["checked"] = request.BoolValue,
+            ["modifiers"] = request.Modifiers,
+            ["sensitive"] = request.Sensitive,
+            ["scrollUnit"] = request.ScrollUnit,
+        };
+        if (request.NodeId is not null) command["nodeId"] = request.NodeId;
+        if (request.Value is not null) command["value"] = request.Value;
+        if (request.Key is not null) command["key"] = request.Key;
+        try
+        {
+            var result = Request<ActionRequestResult>(command);
+            requestId = result.RequestId;
+            return GuaActionError.None;
+        }
+        catch (InvalidOperationException error)
+        {
+            requestId = 0;
+            if (error.Message.Contains("node_not_found", StringComparison.Ordinal)) return GuaActionError.NodeNotFound;
+            if (error.Message.Contains("hidden", StringComparison.Ordinal)) return GuaActionError.Hidden;
+            if (error.Message.Contains("disabled", StringComparison.Ordinal)) return GuaActionError.Disabled;
+            if (error.Message.Contains("unsupported", StringComparison.Ordinal)) return GuaActionError.Unsupported;
+            if (error.Message.Contains("invalid_value", StringComparison.Ordinal)) return GuaActionError.InvalidValue;
+            return GuaActionError.InvalidArgument;
+        }
+    }
+
+    public bool TryPollActionEvent(out GuaActionEvent e)
+    {
+        return TryPollActionEventCore(null, out e);
+    }
+
+    public bool TryPollActionEvent(ulong requestId, out GuaActionEvent e)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(requestId);
+        return TryPollActionEventCore(requestId, out e);
+    }
+
+    private bool TryPollActionEventCore(ulong? requestId, out GuaActionEvent e)
+    {
+        var result = Request<ActionEventResult?>(requestId.HasValue
+            ? new { type = "poll_events", requestId = requestId.Value }
+            : new { type = "poll_events" }, allowNullResult: true);
+        if (result is null)
+        {
+            e = default;
+            return false;
+        }
+        e = new GuaActionEvent(result.RequestId, (GuaActionType)result.Action, result.Succeeded,
+            (GuaActionError)result.Error, result.NodeId, result.Value, result.Sensitive);
+        return true;
+    }
+
     public bool TryPollEvent(out GuaEvent e)
     {
         e = default;
@@ -280,4 +350,8 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
     {
         PropertyNameCaseInsensitive = true,
     };
+
+    private sealed record ActionRequestResult(ulong RequestId);
+    private sealed record ActionEventResult(
+        ulong RequestId, int Action, bool Succeeded, int Error, string NodeId, string Value, bool Sensitive);
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -371,6 +371,40 @@ public sealed class GuaNodeExpectation
         return this;
     }
 
+    public ulong Focus() => Enqueue(new GuaActionRequest(GuaActionType.Focus, _id), "focus");
+
+    public ulong SetValue(string value, bool sensitive = false) =>
+        Enqueue(new GuaActionRequest(GuaActionType.SetValue, _id, Value: value, Sensitive: sensitive), "set_value");
+
+    public ulong SetChecked(bool value) =>
+        Enqueue(new GuaActionRequest(GuaActionType.SetChecked, _id, BoolValue: value), "set_checked");
+
+    public ulong Select(string value) =>
+        Enqueue(new GuaActionRequest(GuaActionType.Select, _id, Value: value), "select");
+
+    public ulong Scroll(float deltaX, float deltaY, int unit = 0) =>
+        Enqueue(new GuaActionRequest(GuaActionType.Scroll, _id, DeltaX: deltaX, DeltaY: deltaY, ScrollUnit: unit), "scroll");
+
+    public ulong PressKey(string key, uint modifiers = 0) =>
+        Enqueue(new GuaActionRequest(GuaActionType.PressKey, _id, Key: key, Modifiers: modifiers), "press_key");
+
+    public GuaNodeExpectation WaitForAction(ulong requestId, TimeSpan? timeout = null)
+    {
+        var deadline = Stopwatch.GetTimestamp() + (long)((timeout ?? TimeSpan.FromSeconds(1)).TotalSeconds * Stopwatch.Frequency);
+        do
+        {
+            if (_context.TryPollActionEvent(requestId, out var e))
+            {
+                if (!e.Succeeded) GuaAssertions.Fail($"Gua action {e.Action} failed for {_description}: {e.Error}.");
+                return this;
+            }
+            Thread.Sleep(10);
+        }
+        while (Stopwatch.GetTimestamp() < deadline);
+        GuaAssertions.Fail($"Timed out waiting for action request {requestId} on Gua node {_description}.");
+        return this;
+    }
+
     public GuaNodeExpectation WaitFor(TimeSpan? timeout = null)
     {
         return WaitUntil(node => node is not null, "exist", timeout);
@@ -430,5 +464,15 @@ public sealed class GuaNodeExpectation
         }
 
         return snapshot;
+    }
+
+    private ulong Enqueue(GuaActionRequest request, string action)
+    {
+        ToBeVisible();
+        ToBeEnabled();
+        ToHaveAction(action);
+        var error = _context.EnqueueAction(request, out var requestId);
+        if (error != GuaActionError.None) GuaAssertions.Fail($"Failed to enqueue {action} for Gua node {_description}: {error}.");
+        return requestId;
     }
 }

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -51,3 +51,7 @@ GuaAssertions.GetById(ui, "start").ToBeVisible();
 
 See `examples/dotnet-nunit` for a complete NUnit project with multiple `[Test]`
 methods in one file.
+Node expectations expose `Focus`, `SetValue`, `SetChecked`, `Select`, `Scroll`,
+and `PressKey`. These methods enqueue requests and return a request ID;
+`WaitForAction` waits for the adapter's correlated observed result rather than
+treating enqueue acceptance as completion.

--- a/examples/dotnet-nunit/TitleScreenTests.cs
+++ b/examples/dotnet-nunit/TitleScreenTests.cs
@@ -105,6 +105,41 @@ public sealed class TitleScreenTests
             .ToBeDisabled();
     }
 
+    [Test]
+    public void GenericActionCorrelatesRequestAndRedactsSensitiveValue()
+    {
+        using var ui = new GuaContext();
+        ui.BeginFrame("form");
+        ui.RegisterNode(new GuaNodeDescriptor(
+            "name", "textbox", "Name", new GuaBounds(0, 0, 100, 20), Value: string.Empty));
+        ui.RegisterNode(new GuaNodeDescriptor("remember", "checkbox", "Remember", new GuaBounds(0, 20, 100, 20), Checked: false));
+        ui.RegisterNode(new GuaNodeDescriptor("difficulty", "combobox", "Difficulty", new GuaBounds(0, 40, 100, 20), Value: "Easy"));
+        ui.RegisterNode(new GuaNodeDescriptor("content", "scrollarea", "Content", new GuaBounds(0, 60, 100, 100)));
+        ui.EndFrame();
+
+        var name = GuaAssertions.GetById(ui, "name");
+        var requestId = name.SetValue("secret-marker", sensitive: true);
+        Assert.That(name.Focus(), Is.GreaterThan(requestId));
+        Assert.That(name.PressKey("A"), Is.GreaterThan(requestId));
+        Assert.That(GuaAssertions.GetById(ui, "remember").SetChecked(true), Is.GreaterThan(requestId));
+        Assert.That(GuaAssertions.GetById(ui, "difficulty").Select("Hard"), Is.GreaterThan(requestId));
+        Assert.That(GuaAssertions.GetById(ui, "content").Scroll(1, 2), Is.GreaterThan(requestId));
+        Assert.That(ui.TryConsumeAction(GuaActionType.SetValue, "name", out var request), Is.True);
+        Assert.That(request.RequestId, Is.EqualTo(requestId));
+        Assert.That(request.Value, Is.EqualTo("secret-marker"));
+
+        Assert.That(ui.EmitActionResult(new GuaActionEvent(
+            requestId, GuaActionType.SetValue, true, GuaActionError.None, "name", request.Value!, true)), Is.True);
+        Assert.That(ui.TryPollActionEvent(out var observed), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(observed.RequestId, Is.EqualTo(requestId));
+            Assert.That(observed.Succeeded, Is.True);
+            Assert.That(observed.Sensitive, Is.True);
+            Assert.That(observed.Value, Is.Empty);
+        });
+    }
+
     private static void RenderTitle(GuaTestHost host, bool loading)
     {
         host.Frame(loading ? "loading" : "title", frame =>
@@ -133,6 +168,9 @@ public sealed class TitleScreenTests
         public string FindNodeByRole(string role, string? name = null) => "legacy";
         public string FindNodeByText(string text) => "legacy";
         public bool EnqueueClick(string id) => true;
+        public GuaActionError EnqueueAction(GuaActionRequest request, out ulong requestId) { requestId = 1; return GuaActionError.None; }
+        public bool TryPollActionEvent(out GuaActionEvent e) { e = default; return false; }
+        public bool TryPollActionEvent(ulong requestId, out GuaActionEvent e) { e = default; return false; }
         public bool TryPollEvent(out GuaEvent e) { e = default; return false; }
     }
 }

--- a/examples/godot-gdscript/README.md
+++ b/examples/godot-gdscript/README.md
@@ -44,9 +44,11 @@ because another process already owns the port or the native extension was not
 rebuilt.
 
 The sample attaches `GuaAutoAdapter` to the root Godot `Control`; the adapter
-collects standard labels and buttons into the semantic UI tree, publishes
-snapshots, observes button clicks, and dispatches Inspector `click_node` requests
-through the normal Godot button signal.
+collects standard controls into the semantic UI tree and dispatches semantic
+actions through the real controls. The v1 matrix covers focus, `LineEdit` /
+`TextEdit` / slider values, checkbox state, `OptionButton` / `ItemList` /
+`TabContainer` selection, `ScrollContainer`, and key input. Every requested host
+operation emits an observed result carrying the same `requestId`.
 
 For a headless smoke check of the load-order-safe path:
 

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -2,6 +2,7 @@ class_name GuaAutoAdapter
 extends RefCounted
 
 const META_ID := "gua_id"
+const META_SENSITIVE := "gua_sensitive"
 const CONTEXT_CLASS := "GuaContext"
 const GDEXTENSION_RESOURCE := "res://addons/gua/gua.gdextension"
 const REBUILD_COMMAND := "cmake --build --preset windows-msvc-debug --target gua-godot"
@@ -15,6 +16,10 @@ const REQUIRED_CONTEXT_METHODS := [
 	"consume_click_request",
 	"emit_click",
 	"poll_event",
+	"enqueue_action",
+	"consume_action_request",
+	"emit_action_result",
+	"poll_event_v2",
 	"start_inspector_bridge",
 	"inspector_bridge_url",
 ]
@@ -22,6 +27,7 @@ const REQUIRED_CONTEXT_METHODS := [
 var context: Object
 var root: Control
 var buttons_by_id: Dictionary = {}
+var controls_by_id: Dictionary = {}
 var connected_buttons: Dictionary = {}
 var suppressed_clicks: Dictionary = {}
 var gdextension_resource: Resource
@@ -43,9 +49,11 @@ func update(screen: String) -> void:
 
 	context.begin_frame(screen)
 	buttons_by_id.clear()
+	controls_by_id.clear()
 	_collect_control(root, "")
 	context.end_frame()
 	_dispatch_click_requests()
+	_dispatch_action_requests()
 
 
 func start_inspector_bridge(port: int = 8765) -> bool:
@@ -81,6 +89,18 @@ func poll_event() -> Dictionary:
 		return {}
 
 	return context.poll_event()
+
+
+func enqueue_action(request: Dictionary) -> Dictionary:
+	if not _ensure_context():
+		return {"error_code": -1, "request_id": 0}
+	return context.enqueue_action(request)
+
+
+func poll_event_v2() -> Dictionary:
+	if not _ensure_context():
+		return {}
+	return context.poll_event_v2()
 
 
 func _ensure_context() -> bool:
@@ -162,6 +182,7 @@ func _collect_control(control: Control, parent_id: String) -> void:
 	if control is CheckBox:
 		descriptor["checked"] = (control as CheckBox).button_pressed
 	context.register_node_v2(descriptor)
+	controls_by_id[id] = control
 
 	if control is BaseButton:
 		buttons_by_id[id] = control
@@ -220,6 +241,106 @@ func _dispatch_click_requests() -> void:
 			button.emit_signal("pressed")
 
 
+func _dispatch_action_requests() -> void:
+	for id in controls_by_id.keys():
+		var control := controls_by_id[id] as Control
+		for action in ["focus", "set_value", "set_checked", "select", "scroll", "press_key"]:
+			while true:
+				var request: Dictionary = context.consume_action_request(action, id)
+				if request.is_empty():
+					break
+				var error_code := _apply_action(control, action, request)
+				context.emit_action_result({
+					"request_id": request.get("request_id", 0),
+					"action": action,
+					"node_id": id,
+					"succeeded": error_code == 0,
+					"error_code": error_code,
+					"value": request.get("value", ""),
+					"sensitive": request.get("sensitive", false),
+				})
+	while true:
+		var request: Dictionary = context.consume_action_request("press_key", "")
+		if request.is_empty():
+			break
+		var focused := root.get_viewport().gui_get_focus_owner()
+		var error_code := _apply_action(focused, "press_key", request) if focused is Control else -2
+		context.emit_action_result({
+			"request_id": request.get("request_id", 0), "action": "press_key", "node_id": "",
+			"succeeded": error_code == 0, "error_code": error_code,
+		})
+
+
+func _apply_action(control: Control, action: String, request: Dictionary) -> int:
+	if not control.is_visible_in_tree():
+		return -3
+	if not _control_enabled(control):
+		return -4
+	match action:
+		"focus":
+			control.grab_focus()
+		"set_value":
+			var value = request.get("value", "")
+			if request.get("sensitive", false):
+				control.set_meta(META_SENSITIVE, true)
+			if control is LineEdit:
+				(control as LineEdit).text = value
+			elif control is TextEdit:
+				(control as TextEdit).text = value
+			elif control is Range and str(value).is_valid_float():
+				(control as Range).value = float(value)
+			else:
+				return -6
+		"set_checked":
+			if control is BaseButton:
+				(control as BaseButton).button_pressed = request.get("bool_value", false)
+			else:
+				return -5
+		"select":
+			if not _select_value(control, str(request.get("value", ""))):
+				return -6
+		"scroll":
+			if control is ScrollContainer:
+				var scroll := control as ScrollContainer
+				scroll.scroll_horizontal += int(request.get("delta_x", 0.0))
+				scroll.scroll_vertical += int(request.get("delta_y", 0.0))
+			else:
+				return -5
+		"press_key":
+			var event := InputEventKey.new()
+			event.keycode = OS.find_keycode_from_string(str(request.get("key", "")))
+			event.pressed = true
+			control.gui_input.emit(event)
+		_:
+			return -5
+	return 0
+
+
+func _select_value(control: Control, value: String) -> bool:
+	if control is OptionButton:
+		var option := control as OptionButton
+		for index in range(option.item_count):
+			var semantic_value := str(option.get_item_metadata(index)) if option.get_item_metadata(index) != null else option.get_item_text(index)
+			if semantic_value == value:
+				option.select(index)
+				option.item_selected.emit(index)
+				return true
+	if control is ItemList:
+		var item_list := control as ItemList
+		for index in range(item_list.item_count):
+			if item_list.get_item_text(index) == value:
+				item_list.select(index)
+				item_list.item_selected.emit(index)
+				return true
+	if control is TabContainer:
+		var tabs := control as TabContainer
+		for index in range(tabs.get_tab_count()):
+			if tabs.get_tab_title(index) == value:
+				tabs.current_tab = index
+				return true
+	return false
+
+
 func _connect_button(button: BaseButton, id: String) -> void:
 	var instance_id := button.get_instance_id()
 	if connected_buttons.has(instance_id):
@@ -261,10 +382,14 @@ func _control_role(control: Control) -> String:
 		return "textbox"
 	if control is Slider:
 		return "slider"
+	if control is ScrollContainer:
+		return "scrollarea"
 	return "panel"
 
 
 func _control_label(control: Control) -> String:
+	if control.has_meta(META_SENSITIVE) and control.get_meta(META_SENSITIVE):
+		return control.name
 	if control is OptionButton:
 		return control.name
 	if control is BaseButton:
@@ -279,6 +404,8 @@ func _control_label(control: Control) -> String:
 
 
 func _control_text(control: Control) -> Variant:
+	if control.has_meta(META_SENSITIVE) and control.get_meta(META_SENSITIVE):
+		return null
 	if control is BaseButton:
 		return (control as BaseButton).text
 	if control is Label:
@@ -291,6 +418,8 @@ func _control_text(control: Control) -> Variant:
 
 
 func _control_value(control: Control) -> Variant:
+	if control.has_meta(META_SENSITIVE) and control.get_meta(META_SENSITIVE):
+		return null
 	if control is OptionButton:
 		var option := control as OptionButton
 		return option.get_item_text(option.selected) if option.selected >= 0 else ""

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -33,6 +33,14 @@ func _run() -> void:
 	line_edit.name = "name"
 	line_edit.text = "Gua"
 	screen.add_child(line_edit)
+	var text_edit := TextEdit.new()
+	text_edit.name = "notes"
+	text_edit.text = "Old"
+	screen.add_child(text_edit)
+	var slider := HSlider.new()
+	slider.name = "volume"
+	slider.value = 10
+	screen.add_child(slider)
 
 	var option := OptionButton.new()
 	option.name = "difficulty"
@@ -58,6 +66,12 @@ func _run() -> void:
 	tabs.add_child(audio_tab)
 	tabs.current_tab = 1
 	screen.add_child(tabs)
+	var scroll := ScrollContainer.new()
+	scroll.name = "scroll"
+	var scroll_content := Control.new()
+	scroll_content.custom_minimum_size = Vector2(1000, 1000)
+	scroll.add_child(scroll_content)
+	screen.add_child(scroll)
 
 	await process_frame
 
@@ -131,6 +145,46 @@ func _run() -> void:
 
 	if pressed_count != 1:
 		_fail("Gua smoke expected one Button.pressed signal, got %d." % pressed_count)
+		return
+	var action_checkbox := CheckBox.new()
+	action_checkbox.name = "action_check"
+	screen.add_child(action_checkbox)
+	ui.update("title")
+
+	var action_cases := [
+		[{"action": "focus", "node_id": "start"}, func(): return button.has_focus()],
+		[{"action": "set_value", "node_id": "name", "value": "Codex"}, func(): return line_edit.text == "Codex"],
+		[{"action": "set_value", "node_id": "notes", "value": "New"}, func(): return text_edit.text == "New"],
+		[{"action": "set_value", "node_id": "volume", "value": "42"}, func(): return slider.value == 42],
+		[{"action": "set_checked", "node_id": "action_check", "bool_value": true}, func(): return action_checkbox.button_pressed],
+		[{"action": "select", "node_id": "difficulty", "value": "Easy"}, func(): return option.selected == 0],
+		[{"action": "select", "node_id": "servers", "value": "Osaka"}, func(): return item_list.is_selected(1)],
+		[{"action": "select", "node_id": "tabs", "value": "General"}, func(): return tabs.current_tab == 0],
+		[{"action": "scroll", "node_id": "scroll", "delta_x": 25.0, "delta_y": 30.0}, func(): return scroll.scroll_horizontal == 25 and scroll.scroll_vertical == 30],
+		[{"action": "press_key", "node_id": "name", "key": "A"}, func(): return true],
+	]
+	for action_case in action_cases:
+		var accepted: Dictionary = ui.enqueue_action(action_case[0])
+		if accepted.get("error_code", -1) != 0 or accepted.get("request_id", 0) == 0:
+			_fail("Gua smoke rejected action %s: %s" % [action_case[0], accepted])
+			return
+		ui.update("title")
+		if not action_case[1].call():
+			_fail("Gua smoke did not apply host action: %s" % action_case[0])
+			return
+		var observed := ui.poll_event_v2()
+		if observed.get("request_id", 0) != accepted.get("request_id", 0) or not observed.get("succeeded", false):
+			_fail("Gua smoke did not correlate observed action event: %s / %s" % [accepted, observed])
+			return
+	var sensitive := ui.enqueue_action({"action": "set_value", "node_id": "name", "value": "secret-marker", "sensitive": true})
+	ui.update("title")
+	var sensitive_event := ui.poll_event_v2()
+	ui.update("title")
+	if sensitive_event.get("request_id", 0) != sensitive.get("request_id", 0) or not sensitive_event.get("value", "").is_empty():
+		_fail("Gua smoke leaked a sensitive value in its observed event: %s" % sensitive_event)
+		return
+	if ui.get_ui_tree_json().contains("secret-marker"):
+		_fail("Gua smoke leaked a sensitive value in the semantic UI tree.")
 		return
 
 	print("Gua GDScript smoke passed.")

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -20,6 +20,82 @@ typedef struct gua_event_t {
     char node_id[128];
 } gua_event_t;
 
+enum {
+    GUA_ACTION_CLICK = 1,
+    GUA_ACTION_FOCUS = 2,
+    GUA_ACTION_SET_VALUE = 3,
+    GUA_ACTION_SET_CHECKED = 4,
+    GUA_ACTION_SELECT = 5,
+    GUA_ACTION_SCROLL = 6,
+    GUA_ACTION_PRESS_KEY = 7
+};
+
+enum {
+    GUA_ACTION_ACCEPTED = 1,
+    GUA_ACTION_ERROR_INVALID_ARGUMENT = -1,
+    GUA_ACTION_ERROR_NODE_NOT_FOUND = -2,
+    GUA_ACTION_ERROR_HIDDEN = -3,
+    GUA_ACTION_ERROR_DISABLED = -4,
+    GUA_ACTION_ERROR_UNSUPPORTED = -5,
+    GUA_ACTION_ERROR_INVALID_VALUE = -6
+};
+
+enum {
+    GUA_ACTION_STATUS_SUCCEEDED = 1,
+    GUA_ACTION_STATUS_FAILED = 2
+};
+
+typedef struct gua_action_request_descriptor_t {
+    uint32_t struct_size;
+    int action;
+    const char* node_id;
+    const char* value;
+    float delta_x;
+    float delta_y;
+    int bool_value;
+    const char* key;
+    uint32_t modifiers;
+    int sensitive;
+    int scroll_unit;
+} gua_action_request_descriptor_t;
+
+typedef struct gua_action_request_t {
+    uint32_t struct_size;
+    uint64_t request_id;
+    int action;
+    char node_id[128];
+    char value[256];
+    float delta_x;
+    float delta_y;
+    int bool_value;
+    char key[64];
+    uint32_t modifiers;
+    int sensitive;
+    int scroll_unit;
+} gua_action_request_t;
+
+typedef struct gua_action_result_t {
+    uint32_t struct_size;
+    uint64_t request_id;
+    int action;
+    int status;
+    int error_code;
+    const char* node_id;
+    const char* value;
+    int sensitive;
+} gua_action_result_t;
+
+typedef struct gua_event_v2_t {
+    uint32_t struct_size;
+    uint64_t request_id;
+    int action;
+    int status;
+    int error_code;
+    char node_id[128];
+    char value[256];
+    int sensitive;
+} gua_event_v2_t;
+
 typedef struct gua_node_state_t {
     int visible;
     int enabled;
@@ -121,6 +197,11 @@ int gua_enqueue_click(gua_context_t* ctx, const char* node_id);
 int gua_consume_click_request(gua_context_t* ctx, const char* node_id);
 int gua_emit_click(gua_context_t* ctx, const char* node_id);
 int gua_poll_event(gua_context_t* ctx, gua_event_t* out_event);
+int gua_enqueue_action(gua_context_t* ctx, const gua_action_request_descriptor_t* descriptor, uint64_t* out_request_id);
+int gua_consume_action_request(gua_context_t* ctx, int action, const char* node_id, gua_action_request_t* out_request);
+int gua_emit_action_result(gua_context_t* ctx, const gua_action_result_t* result);
+int gua_poll_event_v2(gua_context_t* ctx, gua_event_v2_t* out_event);
+int gua_poll_event_v2_for_request(gua_context_t* ctx, uint64_t request_id, gua_event_v2_t* out_event);
 
 #ifdef __cplusplus
 }

--- a/native/gua-core/include/gua/gua.hpp
+++ b/native/gua-core/include/gua/gua.hpp
@@ -3,6 +3,7 @@
 #include "gua/gua.h"
 
 #include <stdexcept>
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -33,6 +34,36 @@ enum class LogLevel {
 struct Event {
     EventType type = EventType::none;
     std::string node_id;
+};
+
+enum class ActionType {
+    click = GUA_ACTION_CLICK, focus = GUA_ACTION_FOCUS, set_value = GUA_ACTION_SET_VALUE,
+    set_checked = GUA_ACTION_SET_CHECKED, select = GUA_ACTION_SELECT, scroll = GUA_ACTION_SCROLL,
+    press_key = GUA_ACTION_PRESS_KEY,
+};
+
+struct ActionRequest {
+    std::uint64_t request_id = 0;
+    ActionType action = ActionType::click;
+    std::string node_id;
+    std::string value;
+    float delta_x = 0;
+    float delta_y = 0;
+    bool bool_value = false;
+    std::string key;
+    std::uint32_t modifiers = 0;
+    bool sensitive = false;
+    int scroll_unit = 0;
+};
+
+struct ActionEvent {
+    std::uint64_t request_id = 0;
+    ActionType action = ActionType::click;
+    int status = GUA_ACTION_STATUS_SUCCEEDED;
+    int error_code = 0;
+    std::string node_id;
+    std::string value;
+    bool sensitive = false;
 };
 
 struct NodeProperties {
@@ -238,6 +269,57 @@ public:
         return true;
     }
 
+    [[nodiscard]] int enqueue_action(const ActionRequest& request, std::uint64_t& request_id)
+    {
+        id_buffer_.assign(request.node_id);
+        value_buffer_.assign(request.value);
+        key_buffer_.assign(request.key);
+        const gua_action_request_descriptor_t descriptor {
+            sizeof(gua_action_request_descriptor_t), static_cast<int>(request.action),
+            id_buffer_.empty() ? nullptr : id_buffer_.c_str(), value_buffer_.empty() ? nullptr : value_buffer_.c_str(),
+            request.delta_x, request.delta_y, request.bool_value ? 1 : 0,
+            key_buffer_.empty() ? nullptr : key_buffer_.c_str(), request.modifiers, request.sensitive ? 1 : 0, request.scroll_unit
+        };
+        return gua_enqueue_action(context_, &descriptor, &request_id);
+    }
+
+    [[nodiscard]] bool consume_action(ActionType action, std::string_view node_id, ActionRequest& out)
+    {
+        id_buffer_.assign(node_id);
+        gua_action_request_t request { sizeof(gua_action_request_t) };
+        if (gua_consume_action_request(context_, static_cast<int>(action), id_buffer_.c_str(), &request) == 0) return false;
+        out = ActionRequest { request.request_id, static_cast<ActionType>(request.action), request.node_id, request.value,
+            request.delta_x, request.delta_y, request.bool_value != 0, request.key, request.modifiers, request.sensitive != 0, request.scroll_unit };
+        return true;
+    }
+
+    [[nodiscard]] bool emit_action_result(const ActionEvent& event)
+    {
+        id_buffer_.assign(event.node_id);
+        value_buffer_.assign(event.value);
+        const gua_action_result_t result { sizeof(gua_action_result_t), event.request_id, static_cast<int>(event.action),
+            event.status, event.error_code, id_buffer_.c_str(), value_buffer_.empty() ? nullptr : value_buffer_.c_str(), event.sensitive ? 1 : 0 };
+        return gua_emit_action_result(context_, &result) != 0;
+    }
+
+    [[nodiscard]] bool poll_action_event(ActionEvent& out)
+    {
+        gua_event_v2_t event { sizeof(gua_event_v2_t) };
+        if (gua_poll_event_v2(context_, &event) == 0) return false;
+        out = ActionEvent { event.request_id, static_cast<ActionType>(event.action), event.status, event.error_code,
+            event.node_id, event.value, event.sensitive != 0 };
+        return true;
+    }
+
+    [[nodiscard]] bool poll_action_event(std::uint64_t request_id, ActionEvent& out)
+    {
+        gua_event_v2_t event { sizeof(gua_event_v2_t) };
+        if (gua_poll_event_v2_for_request(context_, request_id, &event) == 0) return false;
+        out = ActionEvent { event.request_id, static_cast<ActionType>(event.action), event.status, event.error_code,
+            event.node_id, event.value, event.sensitive != 0 };
+        return true;
+    }
+
 private:
     template <typename CopyJson>
     [[nodiscard]] std::string copy_json(CopyJson copy) const
@@ -274,6 +356,7 @@ private:
     mutable std::string parent_id_buffer_;
     mutable std::string text_buffer_;
     mutable std::string value_buffer_;
+    mutable std::string key_buffer_;
     mutable std::string message_buffer_;
     std::string screenshot_buffer_;
     std::string screen_buffer_;

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <deque>
 #include <cstring>
+#include <cmath>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -31,8 +32,27 @@ struct Node {
 };
 
 struct Event {
-    int type;
+    int action;
     std::string node_id;
+    unsigned long long request_id = 0;
+    int status = GUA_ACTION_STATUS_SUCCEEDED;
+    int error_code = 0;
+    std::string value;
+    bool sensitive = false;
+};
+
+struct ActionRequest {
+    unsigned long long request_id;
+    int action;
+    std::string node_id;
+    std::string value;
+    float delta_x;
+    float delta_y;
+    int bool_value;
+    std::string key;
+    unsigned int modifiers;
+    bool sensitive;
+    int scroll_unit;
 };
 
 struct LogEntry {
@@ -104,13 +124,55 @@ int write_node_id(const std::string& node_id, char* out_node_id, int out_node_id
     return 1;
 }
 
+bool supports_action(const Node& node, int action)
+{
+    if (action == GUA_ACTION_PRESS_KEY) {
+        return node.role == "textbox";
+    }
+    if (action == GUA_ACTION_FOCUS) {
+        return node.role == "button" || node.role == "checkbox" || node.role == "radio" || node.role == "tab" ||
+            node.role == "textbox" || node.role == "slider" || node.role == "combobox" || node.role == "list";
+    }
+    if (action == GUA_ACTION_CLICK) {
+        return node.role == "button" || node.role == "checkbox" || node.role == "radio" || node.role == "tab";
+    }
+    if (action == GUA_ACTION_SET_VALUE) {
+        return node.role == "textbox" || node.role == "slider";
+    }
+    if (action == GUA_ACTION_SET_CHECKED) {
+        return node.role == "checkbox" || node.role == "radio";
+    }
+    if (action == GUA_ACTION_SELECT) {
+        return node.role == "combobox" || node.role == "list" || node.role == "listitem" || node.role == "tablist" || node.role == "tab";
+    }
+    if (action == GUA_ACTION_SCROLL) {
+        return node.role == "list" || node.role == "scrollarea";
+    }
+    return false;
+}
+
+const char* action_name(int action)
+{
+    switch (action) {
+    case GUA_ACTION_CLICK: return "click";
+    case GUA_ACTION_FOCUS: return "focus";
+    case GUA_ACTION_SET_VALUE: return "set_value";
+    case GUA_ACTION_SET_CHECKED: return "set_checked";
+    case GUA_ACTION_SELECT: return "select";
+    case GUA_ACTION_SCROLL: return "scroll";
+    case GUA_ACTION_PRESS_KEY: return "press_key";
+    default: return "";
+    }
+}
+
 } // namespace
 
 struct gua_context_t {
     mutable std::mutex mutex;
     std::string screen = "unknown";
     std::vector<Node> nodes;
-    std::deque<std::string> click_requests;
+    std::deque<ActionRequest> action_requests;
+    std::deque<ActionRequest> consumed_requests;
     std::deque<Event> events;
     std::vector<LogEntry> logs;
     Screenshot screenshot;
@@ -120,6 +182,7 @@ struct gua_context_t {
     std::string screenshot_json_cache;
     unsigned long long frame_sequence = 0;
     unsigned long long revision = 0;
+    unsigned long long next_request_id = 1;
     std::string previous_semantic_snapshot;
 };
 
@@ -195,13 +258,15 @@ std::string build_semantic_snapshot_json(const gua_context_t& ctx)
             if ((node.known_mask & GUA_NODE_KNOWN_SELECTED) != 0U) append_state("selected", node.selected);
             json += "}";
         }
-        if ((node.role == "button" || node.role == "checkbox" || node.role == "radio" || node.role == "tab") && node.enabled) {
-            json += ",\"actions\":[\"click\",\"focus\"]}";
-        } else if ((node.role == "textbox" || node.role == "slider" || node.role == "combobox") && node.enabled) {
-            json += ",\"actions\":[\"focus\",\"set_value\"]}";
-        } else {
-            json += ",\"actions\":[]}";
+        json += ",\"actions\":[";
+        bool wrote_action = false;
+        for (int action = GUA_ACTION_CLICK; action <= GUA_ACTION_PRESS_KEY; ++action) {
+            if (!node.enabled || !supports_action(node, action)) continue;
+            if (wrote_action) json += ",";
+            json += "\"" + std::string(action_name(action)) + "\"";
+            wrote_action = true;
         }
+        json += "]}";
     }
 
     json += "]}";
@@ -533,20 +598,10 @@ extern "C" int gua_find_node_by_text(gua_context_t* ctx, const char* text, char*
 
 extern "C" int gua_enqueue_click(gua_context_t* ctx, const char* node_id)
 {
-    if (ctx == nullptr || node_id == nullptr) {
-        return 0;
-    }
-
-    const std::lock_guard lock(ctx->mutex);
-    const auto found = std::any_of(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
-        return node.id == node_id && node.visible && node.enabled;
-    });
-    if (!found) {
-        return 0;
-    }
-
-    ctx->click_requests.push_back(node_id);
-    return 1;
+    const gua_action_request_descriptor_t descriptor {
+        sizeof(gua_action_request_descriptor_t), GUA_ACTION_CLICK, node_id, nullptr, 0, 0, 0, nullptr, 0, 0, 0
+    };
+    return gua_enqueue_action(ctx, &descriptor, nullptr) == GUA_ACTION_ACCEPTED ? 1 : 0;
 }
 
 extern "C" int gua_consume_click_request(gua_context_t* ctx, const char* node_id)
@@ -555,21 +610,8 @@ extern "C" int gua_consume_click_request(gua_context_t* ctx, const char* node_id
         return 0;
     }
 
-    const std::lock_guard lock(ctx->mutex);
-    const auto node_found = std::any_of(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
-        return node.id == node_id && node.visible && node.enabled;
-    });
-    if (!node_found) {
-        return 0;
-    }
-
-    const auto request = std::find(ctx->click_requests.begin(), ctx->click_requests.end(), node_id);
-    if (request == ctx->click_requests.end()) {
-        return 0;
-    }
-
-    ctx->click_requests.erase(request);
-    return 1;
+    gua_action_request_t request { sizeof(gua_action_request_t) };
+    return gua_consume_action_request(ctx, GUA_ACTION_CLICK, node_id, &request);
 }
 
 extern "C" int gua_emit_click(gua_context_t* ctx, const char* node_id)
@@ -578,9 +620,20 @@ extern "C" int gua_emit_click(gua_context_t* ctx, const char* node_id)
         return 0;
     }
 
-    const std::lock_guard lock(ctx->mutex);
-    ctx->events.push_back(Event { GUA_EVENT_CLICK, node_id });
-    return 1;
+    unsigned long long request_id = 0;
+    {
+        const std::lock_guard lock(ctx->mutex);
+        const auto consumed = std::find_if(ctx->consumed_requests.begin(), ctx->consumed_requests.end(), [&](const ActionRequest& request) {
+            return request.action == GUA_ACTION_CLICK && request.node_id == node_id;
+        });
+        if (consumed != ctx->consumed_requests.end()) {
+            request_id = consumed->request_id;
+        }
+    }
+    const gua_action_result_t result {
+        sizeof(gua_action_result_t), request_id, GUA_ACTION_CLICK, GUA_ACTION_STATUS_SUCCEEDED, 0, node_id, nullptr, 0
+    };
+    return gua_emit_action_result(ctx, &result);
 }
 
 extern "C" int gua_poll_event(gua_context_t* ctx, gua_event_t* out_event)
@@ -590,14 +643,139 @@ extern "C" int gua_poll_event(gua_context_t* ctx, gua_event_t* out_event)
     }
 
     const std::lock_guard lock(ctx->mutex);
-    if (ctx->events.empty()) {
+    const auto legacy_event = std::find_if(ctx->events.begin(), ctx->events.end(), [](const Event& event) {
+        return event.action == GUA_ACTION_CLICK || event.action == GUA_ACTION_FOCUS;
+    });
+    if (legacy_event == ctx->events.end()) {
         return 0;
     }
 
+    const Event event = *legacy_event;
+    ctx->events.erase(legacy_event);
+
+    out_event->type = event.action;
+    std::snprintf(out_event->node_id, sizeof(out_event->node_id), "%s", event.node_id.c_str());
+    return 1;
+}
+
+extern "C" int gua_enqueue_action(gua_context_t* ctx, const gua_action_request_descriptor_t* descriptor, uint64_t* out_request_id)
+{
+    if (ctx == nullptr || descriptor == nullptr || descriptor->struct_size < sizeof(gua_action_request_descriptor_t) ||
+        descriptor->action < GUA_ACTION_CLICK || descriptor->action > GUA_ACTION_PRESS_KEY) {
+        return GUA_ACTION_ERROR_INVALID_ARGUMENT;
+    }
+
+    const std::string node_id = descriptor->node_id != nullptr ? descriptor->node_id : "";
+    const std::string value = descriptor->value != nullptr ? descriptor->value : "";
+    const std::string key = descriptor->key != nullptr ? descriptor->key : "";
+    if ((descriptor->action != GUA_ACTION_PRESS_KEY && node_id.empty()) ||
+        (descriptor->action == GUA_ACTION_PRESS_KEY && key.empty()) ||
+        (descriptor->action == GUA_ACTION_SELECT && value.empty()) ||
+        (descriptor->action == GUA_ACTION_SCROLL && (!std::isfinite(descriptor->delta_x) || !std::isfinite(descriptor->delta_y)))) {
+        return GUA_ACTION_ERROR_INVALID_VALUE;
+    }
+
+    const std::lock_guard lock(ctx->mutex);
+    if (!node_id.empty()) {
+        const auto node = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& candidate) { return candidate.id == node_id; });
+        if (node == ctx->nodes.end()) return GUA_ACTION_ERROR_NODE_NOT_FOUND;
+        if (!node->visible) return GUA_ACTION_ERROR_HIDDEN;
+        if (!node->enabled) return GUA_ACTION_ERROR_DISABLED;
+        if (!supports_action(*node, descriptor->action)) return GUA_ACTION_ERROR_UNSUPPORTED;
+    }
+
+    const unsigned long long request_id = ctx->next_request_id++;
+    ctx->action_requests.push_back(ActionRequest {
+        request_id, descriptor->action, node_id, value, descriptor->delta_x, descriptor->delta_y,
+        descriptor->bool_value, key, descriptor->modifiers, descriptor->sensitive != 0, descriptor->scroll_unit
+    });
+    if (out_request_id != nullptr) *out_request_id = request_id;
+    return GUA_ACTION_ACCEPTED;
+}
+
+extern "C" int gua_consume_action_request(gua_context_t* ctx, int action, const char* node_id, gua_action_request_t* out_request)
+{
+    if (ctx == nullptr || out_request == nullptr || out_request->struct_size < sizeof(gua_action_request_t)) return 0;
+    const std::string target = node_id != nullptr ? node_id : "";
+    const std::lock_guard lock(ctx->mutex);
+    const auto request = std::find_if(ctx->action_requests.begin(), ctx->action_requests.end(), [&](const ActionRequest& candidate) {
+        return candidate.action == action && candidate.node_id == target;
+    });
+    if (request == ctx->action_requests.end()) return 0;
+    const ActionRequest value = *request;
+    ctx->action_requests.erase(request);
+    ctx->consumed_requests.push_back(value);
+    out_request->request_id = value.request_id;
+    out_request->action = value.action;
+    std::snprintf(out_request->node_id, sizeof(out_request->node_id), "%s", value.node_id.c_str());
+    std::snprintf(out_request->value, sizeof(out_request->value), "%s", value.value.c_str());
+    out_request->delta_x = value.delta_x;
+    out_request->delta_y = value.delta_y;
+    out_request->bool_value = value.bool_value;
+    std::snprintf(out_request->key, sizeof(out_request->key), "%s", value.key.c_str());
+    out_request->modifiers = value.modifiers;
+    out_request->sensitive = value.sensitive ? 1 : 0;
+    out_request->scroll_unit = value.scroll_unit;
+    return 1;
+}
+
+extern "C" int gua_emit_action_result(gua_context_t* ctx, const gua_action_result_t* result)
+{
+    if (ctx == nullptr || result == nullptr || result->struct_size < sizeof(gua_action_result_t) ||
+        result->action < GUA_ACTION_CLICK || result->action > GUA_ACTION_PRESS_KEY) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    auto consumed = ctx->consumed_requests.end();
+    if (result->request_id != 0) {
+        consumed = std::find_if(ctx->consumed_requests.begin(), ctx->consumed_requests.end(), [&](const ActionRequest& request) {
+            return request.request_id == result->request_id && request.action == result->action &&
+                request.node_id == (result->node_id != nullptr ? result->node_id : "");
+        });
+        if (consumed == ctx->consumed_requests.end()) return 0;
+    }
+    ctx->events.push_back(Event {
+        result->action,
+        result->node_id != nullptr ? result->node_id : "",
+        result->request_id,
+        result->status,
+        result->error_code,
+        result->sensitive != 0 ? "" : (result->value != nullptr ? result->value : ""),
+        result->sensitive != 0,
+    });
+    if (consumed != ctx->consumed_requests.end()) ctx->consumed_requests.erase(consumed);
+    return 1;
+}
+
+extern "C" int gua_poll_event_v2(gua_context_t* ctx, gua_event_v2_t* out_event)
+{
+    if (ctx == nullptr || out_event == nullptr || out_event->struct_size < sizeof(gua_event_v2_t)) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    if (ctx->events.empty()) return 0;
     const Event event = ctx->events.front();
     ctx->events.pop_front();
-
-    out_event->type = event.type;
+    out_event->request_id = event.request_id;
+    out_event->action = event.action;
+    out_event->status = event.status;
+    out_event->error_code = event.error_code;
     std::snprintf(out_event->node_id, sizeof(out_event->node_id), "%s", event.node_id.c_str());
+    std::snprintf(out_event->value, sizeof(out_event->value), "%s", event.value.c_str());
+    out_event->sensitive = event.sensitive ? 1 : 0;
+    return 1;
+}
+
+extern "C" int gua_poll_event_v2_for_request(gua_context_t* ctx, uint64_t request_id, gua_event_v2_t* out_event)
+{
+    if (ctx == nullptr || request_id == 0 || out_event == nullptr || out_event->struct_size < sizeof(gua_event_v2_t)) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    const auto found = std::find_if(ctx->events.begin(), ctx->events.end(), [&](const Event& event) { return event.request_id == request_id; });
+    if (found == ctx->events.end()) return 0;
+    const Event event = *found;
+    ctx->events.erase(found);
+    out_event->request_id = event.request_id;
+    out_event->action = event.action;
+    out_event->status = event.status;
+    out_event->error_code = event.error_code;
+    std::snprintf(out_event->node_id, sizeof(out_event->node_id), "%s", event.node_id.c_str());
+    std::snprintf(out_event->value, sizeof(out_event->value), "%s", event.value.c_str());
+    out_event->sensitive = event.sensitive ? 1 : 0;
     return 1;
 }

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cstring>
 #include <string>
+#include <cstdint>
 
 namespace {
 
@@ -75,6 +76,69 @@ int main()
     gua_node_state_t legacy {};
     assert(gua_get_node_state(context, "legacy", &legacy) == 1);
     assert(legacy.visible == 1 && legacy.enabled == 1);
+
+    gua_begin_frame(context, "actions");
+    gua_register_node(context, "hidden", "button", "Hidden", { 0, 0, 1, 1 }, 0, 1);
+    gua_register_node(context, "disabled", "button", "Disabled", { 0, 0, 1, 1 }, 1, 0);
+    const gua_node_descriptor_v2_t textbox {
+        sizeof(gua_node_descriptor_v2_t), GUA_NODE_KNOWN_VALUE, "name", nullptr, "textbox", "Name", nullptr, "",
+        { 0, 0, 100, 20 }, 1, 1, 0, 0, 0, 0, 0
+    };
+    assert(gua_register_node_v2(context, &textbox) == 1);
+    register_checkbox(context, false);
+    gua_register_node(context, "difficulty", "combobox", "Difficulty", { 0, 0, 100, 20 }, 1, 1);
+    gua_register_node(context, "content", "scrollarea", "Content", { 0, 0, 100, 100 }, 1, 1);
+    gua_end_frame(context);
+
+    const gua_action_request_descriptor_t hidden_click { sizeof(gua_action_request_descriptor_t), GUA_ACTION_CLICK, "hidden" };
+    const gua_action_request_descriptor_t disabled_click { sizeof(gua_action_request_descriptor_t), GUA_ACTION_CLICK, "disabled" };
+    const gua_action_request_descriptor_t unsupported { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SELECT, "name", "x" };
+    const gua_action_request_descriptor_t missing { sizeof(gua_action_request_descriptor_t), GUA_ACTION_CLICK, "missing" };
+    const gua_action_request_descriptor_t invalid_value { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SELECT, "remember", "" };
+    assert(gua_enqueue_action(context, &hidden_click, nullptr) == GUA_ACTION_ERROR_HIDDEN);
+    assert(gua_enqueue_action(context, &disabled_click, nullptr) == GUA_ACTION_ERROR_DISABLED);
+    assert(gua_enqueue_action(context, &unsupported, nullptr) == GUA_ACTION_ERROR_UNSUPPORTED);
+    assert(gua_enqueue_action(context, &missing, nullptr) == GUA_ACTION_ERROR_NODE_NOT_FOUND);
+    assert(gua_enqueue_action(context, &invalid_value, nullptr) == GUA_ACTION_ERROR_INVALID_VALUE);
+
+    const gua_action_request_descriptor_t focus { sizeof(gua_action_request_descriptor_t), GUA_ACTION_FOCUS, "name" };
+    const gua_action_request_descriptor_t checked { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SET_CHECKED, "remember", nullptr, 0, 0, 1 };
+    const gua_action_request_descriptor_t select { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SELECT, "difficulty", "hard" };
+    const gua_action_request_descriptor_t scroll { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SCROLL, "content", nullptr, 2, 3 };
+    const gua_action_request_descriptor_t key { sizeof(gua_action_request_descriptor_t), GUA_ACTION_PRESS_KEY, "name", nullptr, 0, 0, 0, "A" };
+    std::uint64_t action_ids[5] {};
+    assert(gua_enqueue_action(context, &focus, &action_ids[0]) == GUA_ACTION_ACCEPTED);
+    assert(gua_enqueue_action(context, &checked, &action_ids[1]) == GUA_ACTION_ACCEPTED);
+    assert(gua_enqueue_action(context, &select, &action_ids[2]) == GUA_ACTION_ACCEPTED);
+    assert(gua_enqueue_action(context, &scroll, &action_ids[3]) == GUA_ACTION_ACCEPTED);
+    assert(gua_enqueue_action(context, &key, &action_ids[4]) == GUA_ACTION_ACCEPTED);
+    for (std::size_t i = 1; i < 5; ++i) assert(action_ids[i] > action_ids[i - 1]);
+
+    const gua_action_request_descriptor_t secret { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SET_VALUE, "name", "secret-marker", 0, 0, 0, nullptr, 0, 1 };
+    std::uint64_t request_id = 0;
+    assert(gua_enqueue_action(context, &secret, &request_id) == GUA_ACTION_ACCEPTED);
+    assert(request_id > 0);
+    gua_action_request_t consumed { sizeof(gua_action_request_t) };
+    assert(gua_consume_action_request(context, GUA_ACTION_SET_VALUE, "name", &consumed) == 1);
+    assert(consumed.request_id == request_id);
+    assert(std::strcmp(consumed.value, "secret-marker") == 0);
+    const gua_action_result_t result { sizeof(gua_action_result_t), request_id, GUA_ACTION_SET_VALUE,
+        GUA_ACTION_STATUS_SUCCEEDED, 0, "name", "secret-marker", 1 };
+    assert(gua_emit_action_result(context, &result) == 1);
+    assert(gua_enqueue_click(context, "remember") == 1);
+    assert(gua_consume_click_request(context, "remember") == 1);
+    assert(gua_emit_click(context, "remember") == 1);
+    gua_event_t legacy_event {};
+    assert(gua_poll_event(context, &legacy_event) == 1);
+    assert(legacy_event.type == GUA_EVENT_CLICK);
+
+    gua_event_v2_t event { sizeof(gua_event_v2_t) };
+    assert(gua_poll_event_v2_for_request(context, request_id, &event) == 1);
+    assert(event.request_id == request_id);
+    assert(event.action == GUA_ACTION_SET_VALUE);
+    assert(event.status == GUA_ACTION_STATUS_SUCCEEDED);
+    assert(event.sensitive == 1);
+    assert(std::strlen(event.value) == 0);
 
     gua_destroy_context(context);
     return 0;

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -32,6 +32,10 @@ public:
     bool consume_click_request(const String& node_id);
     bool emit_click(const String& node_id);
     Dictionary poll_event();
+    Dictionary enqueue_action(const Dictionary& request);
+    Dictionary consume_action_request(const String& action, const String& node_id);
+    bool emit_action_result(const Dictionary& result);
+    Dictionary poll_event_v2();
     bool start_inspector_bridge(int port = 8765);
     void stop_inspector_bridge();
     bool inspector_bridge_running() const;

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -21,6 +21,32 @@ const char* event_type_name(int type)
     }
 }
 
+int action_type(const godot::String& name)
+{
+    if (name == "click") return GUA_ACTION_CLICK;
+    if (name == "focus") return GUA_ACTION_FOCUS;
+    if (name == "set_value") return GUA_ACTION_SET_VALUE;
+    if (name == "set_checked") return GUA_ACTION_SET_CHECKED;
+    if (name == "select") return GUA_ACTION_SELECT;
+    if (name == "scroll") return GUA_ACTION_SCROLL;
+    if (name == "press_key") return GUA_ACTION_PRESS_KEY;
+    return 0;
+}
+
+const char* action_name(int action)
+{
+    switch (action) {
+    case GUA_ACTION_CLICK: return "click";
+    case GUA_ACTION_FOCUS: return "focus";
+    case GUA_ACTION_SET_VALUE: return "set_value";
+    case GUA_ACTION_SET_CHECKED: return "set_checked";
+    case GUA_ACTION_SELECT: return "select";
+    case GUA_ACTION_SCROLL: return "scroll";
+    case GUA_ACTION_PRESS_KEY: return "press_key";
+    default: return "none";
+    }
+}
+
 godot::String copy_runtime_json(gua_runtime_t* runtime, int (*copy_json)(gua_runtime_t*, char*, int))
 {
     int required_size = copy_json(runtime, nullptr, 0);
@@ -189,6 +215,80 @@ Dictionary GuaContext::poll_event()
     return result;
 }
 
+Dictionary GuaContext::enqueue_action(const Dictionary& source)
+{
+    const String action = source.get("action", String());
+    const String node_id = source.get("node_id", String());
+    const String value = source.get("value", String());
+    const String key = source.get("key", String());
+    const CharString node_utf8 = node_id.utf8();
+    const CharString value_utf8 = value.utf8();
+    const CharString key_utf8 = key.utf8();
+    const gua_action_request_descriptor_t request {
+        sizeof(gua_action_request_descriptor_t), action_type(action), node_id.is_empty() ? nullptr : node_utf8.get_data(),
+        value.is_empty() ? nullptr : value_utf8.get_data(), source.get("delta_x", 0.0), source.get("delta_y", 0.0),
+        source.get("bool_value", false) ? 1 : 0, key.is_empty() ? nullptr : key_utf8.get_data(),
+        static_cast<uint32_t>(static_cast<int64_t>(source.get("modifiers", 0))), source.get("sensitive", false) ? 1 : 0,
+        source.get("scroll_unit", 0)
+    };
+    uint64_t request_id = 0;
+    const int code = gua_runtime_enqueue_action(runtime_, &request, &request_id);
+    Dictionary result;
+    result["error_code"] = code == GUA_ACTION_ACCEPTED ? 0 : code;
+    result["request_id"] = request_id;
+    return result;
+}
+
+Dictionary GuaContext::consume_action_request(const String& action, const String& node_id)
+{
+    const CharString node_utf8 = node_id.utf8();
+    gua_action_request_t request { sizeof(gua_action_request_t) };
+    if (gua_runtime_consume_action_request(runtime_, action_type(action), node_utf8.get_data(), &request) == 0) return Dictionary();
+    Dictionary result;
+    result["request_id"] = request.request_id;
+    result["action"] = action_name(request.action);
+    result["node_id"] = String::utf8(request.node_id);
+    result["value"] = String::utf8(request.value);
+    result["delta_x"] = request.delta_x;
+    result["delta_y"] = request.delta_y;
+    result["bool_value"] = request.bool_value != 0;
+    result["key"] = String::utf8(request.key);
+    result["modifiers"] = request.modifiers;
+    result["sensitive"] = request.sensitive != 0;
+    result["scroll_unit"] = request.scroll_unit;
+    return result;
+}
+
+bool GuaContext::emit_action_result(const Dictionary& source)
+{
+    const String node_id = source.get("node_id", String());
+    const String value = source.get("value", String());
+    const CharString node_utf8 = node_id.utf8();
+    const CharString value_utf8 = value.utf8();
+    const gua_action_result_t result {
+        sizeof(gua_action_result_t), source.get("request_id", 0), action_type(source.get("action", String())),
+        source.get("succeeded", true) ? GUA_ACTION_STATUS_SUCCEEDED : GUA_ACTION_STATUS_FAILED,
+        source.get("error_code", 0), node_utf8.get_data(), value.is_empty() ? nullptr : value_utf8.get_data(),
+        source.get("sensitive", false) ? 1 : 0
+    };
+    return gua_runtime_emit_action_result(runtime_, &result) != 0;
+}
+
+Dictionary GuaContext::poll_event_v2()
+{
+    gua_event_v2_t event { sizeof(gua_event_v2_t) };
+    if (gua_runtime_poll_event_v2(runtime_, &event) == 0) return Dictionary();
+    Dictionary result;
+    result["request_id"] = event.request_id;
+    result["action"] = action_name(event.action);
+    result["succeeded"] = event.status == GUA_ACTION_STATUS_SUCCEEDED;
+    result["error_code"] = event.error_code;
+    result["node_id"] = String::utf8(event.node_id);
+    result["value"] = String::utf8(event.value);
+    result["sensitive"] = event.sensitive != 0;
+    return result;
+}
+
 bool GuaContext::start_inspector_bridge(int port)
 {
     return gua_runtime_start_inspector_bridge(runtime_, port) != 0;
@@ -229,6 +329,10 @@ void GuaContext::_bind_methods()
     ClassDB::bind_method(D_METHOD("consume_click_request", "node_id"), &GuaContext::consume_click_request);
     ClassDB::bind_method(D_METHOD("emit_click", "node_id"), &GuaContext::emit_click);
     ClassDB::bind_method(D_METHOD("poll_event"), &GuaContext::poll_event);
+    ClassDB::bind_method(D_METHOD("enqueue_action", "request"), &GuaContext::enqueue_action);
+    ClassDB::bind_method(D_METHOD("consume_action_request", "action", "node_id"), &GuaContext::consume_action_request);
+    ClassDB::bind_method(D_METHOD("emit_action_result", "result"), &GuaContext::emit_action_result);
+    ClassDB::bind_method(D_METHOD("poll_event_v2"), &GuaContext::poll_event_v2);
     ClassDB::bind_method(D_METHOD("start_inspector_bridge", "port"), &GuaContext::start_inspector_bridge, DEFVAL(8765));
     ClassDB::bind_method(D_METHOD("stop_inspector_bridge"), &GuaContext::stop_inspector_bridge);
     ClassDB::bind_method(D_METHOD("inspector_bridge_running"), &GuaContext::inspector_bridge_running);

--- a/native/gua-imgui/include/gua/imgui_adapter.hpp
+++ b/native/gua-imgui/include/gua/imgui_adapter.hpp
@@ -7,6 +7,11 @@
 
 #include <string>
 #include <string_view>
+#include <array>
+#include <vector>
+#include <cstring>
+#include <algorithm>
+#include <cstdio>
 
 namespace gua::imgui {
 
@@ -74,6 +79,9 @@ inline bool button(Context& context, std::string_view label)
     const std::string label_buffer(label);
     const std::string id = semantic_id_from_label(label);
     const std::string visible_label_buffer = visible_label(label);
+    ActionRequest focus_request;
+    const bool requested_focus = context.consume_action(ActionType::focus, id, focus_request);
+    if (requested_focus) ImGui::SetKeyboardFocusHere();
     const bool clicked = ImGui::Button(label_buffer.c_str());
     const ImVec2 min = ImGui::GetItemRectMin();
     const ImVec2 max = ImGui::GetItemRectMax();
@@ -91,6 +99,7 @@ inline bool button(Context& context, std::string_view label)
         NodeProperties { .text = visible_label_buffer, .focused = focused, .hovered = hovered, .pressed = pressed },
         visible,
         enabled);
+    if (requested_focus) (void)context.emit_action_result(ActionEvent { focus_request.request_id, ActionType::focus, GUA_ACTION_STATUS_SUCCEEDED, 0, id });
 
     const bool requested = context.consume_click_request(id);
     if ((clicked || requested) && visible && enabled) {
@@ -106,7 +115,10 @@ inline bool button(Context& context, std::string_view id, std::string_view label
     const std::string id_buffer(id);
     const std::string label_buffer(label);
     const std::string visible_label_buffer = visible_label(label);
+    ActionRequest focus_request;
+    const bool requested_focus = context.consume_action(ActionType::focus, id, focus_request);
     ImGui::PushID(id_buffer.c_str());
+    if (requested_focus) ImGui::SetKeyboardFocusHere();
     const bool clicked = ImGui::Button(label_buffer.c_str());
     const ImVec2 min = ImGui::GetItemRectMin();
     const ImVec2 max = ImGui::GetItemRectMax();
@@ -125,6 +137,7 @@ inline bool button(Context& context, std::string_view id, std::string_view label
         NodeProperties { .text = visible_label_buffer, .focused = focused, .hovered = hovered, .pressed = pressed },
         visible,
         enabled);
+    if (requested_focus) (void)context.emit_action_result(ActionEvent { focus_request.request_id, ActionType::focus, GUA_ACTION_STATUS_SUCCEEDED, 0, std::string(id) });
 
     const bool requested = context.consume_click_request(id);
     if ((clicked || requested) && visible && enabled) {
@@ -151,6 +164,99 @@ inline void text(Context& context, std::string_view label)
         NodeProperties { .text = visible_label_buffer },
         ImGui::IsItemVisible(),
         false);
+}
+
+inline bool input_text(Context& context, std::string_view label, std::string& value, bool sensitive = false)
+{
+    const std::string id = semantic_id_from_label(label);
+    ActionRequest request;
+    ActionRequest focus_request;
+    const bool requested_focus = context.consume_action(ActionType::focus, id, focus_request);
+    if (requested_focus) ImGui::SetKeyboardFocusHere();
+    while (context.consume_action(ActionType::set_value, id, request)) {
+        value = request.value;
+        (void)context.emit_action_result(ActionEvent { request.request_id, ActionType::set_value, GUA_ACTION_STATUS_SUCCEEDED, 0, id, value, sensitive || request.sensitive });
+    }
+    while (context.consume_action(ActionType::press_key, id, request)) {
+        bool success = true;
+        if (request.key == "Backspace") {
+            if (!value.empty()) value.pop_back();
+        } else if (request.key.size() == 1) {
+            value += request.key;
+        } else {
+            success = false;
+        }
+        (void)context.emit_action_result(ActionEvent { request.request_id, ActionType::press_key,
+            success ? GUA_ACTION_STATUS_SUCCEEDED : GUA_ACTION_STATUS_FAILED,
+            success ? 0 : GUA_ACTION_ERROR_INVALID_VALUE, id, "", sensitive });
+    }
+    std::array<char, 512> buffer {};
+    std::snprintf(buffer.data(), buffer.size(), "%s", value.c_str());
+    const std::string label_buffer(label);
+    const bool changed = ImGui::InputText(label_buffer.c_str(), buffer.data(), buffer.size());
+    if (changed) {
+        value = buffer.data();
+        (void)context.emit_action_result(ActionEvent { 0, ActionType::set_value, GUA_ACTION_STATUS_SUCCEEDED, 0, id, value, sensitive });
+    }
+    const ImVec2 min = ImGui::GetItemRectMin();
+    const ImVec2 max = ImGui::GetItemRectMax();
+    context.node_v2(id, "textbox", visible_label(label), Rect { min.x, min.y, max.x - min.x, max.y - min.y },
+        NodeProperties { .text = sensitive ? std::optional<std::string_view>() : std::optional<std::string_view>(value),
+            .value = sensitive ? std::optional<std::string_view>() : std::optional<std::string_view>(value), .focused = ImGui::IsItemFocused() },
+        ImGui::IsItemVisible(), true);
+    if (requested_focus) (void)context.emit_action_result(ActionEvent { focus_request.request_id, ActionType::focus, GUA_ACTION_STATUS_SUCCEEDED, 0, id });
+    return changed;
+}
+
+inline bool checkbox(Context& context, std::string_view label, bool& checked)
+{
+    const std::string id = semantic_id_from_label(label);
+    ActionRequest request;
+    ActionRequest focus_request;
+    const bool requested_focus = context.consume_action(ActionType::focus, id, focus_request);
+    if (requested_focus) ImGui::SetKeyboardFocusHere();
+    while (context.consume_action(ActionType::set_checked, id, request)) {
+        checked = request.bool_value;
+        (void)context.emit_action_result(ActionEvent { request.request_id, ActionType::set_checked, GUA_ACTION_STATUS_SUCCEEDED, 0, id, checked ? "true" : "false" });
+    }
+    const std::string label_buffer(label);
+    const bool changed = ImGui::Checkbox(label_buffer.c_str(), &checked);
+    if (changed) (void)context.emit_action_result(ActionEvent { 0, ActionType::set_checked, GUA_ACTION_STATUS_SUCCEEDED, 0, id, checked ? "true" : "false" });
+    const ImVec2 min = ImGui::GetItemRectMin();
+    const ImVec2 max = ImGui::GetItemRectMax();
+    context.node_v2(id, "checkbox", visible_label(label), Rect { min.x, min.y, max.x - min.x, max.y - min.y },
+        NodeProperties { .focused = ImGui::IsItemFocused(), .checked = checked }, ImGui::IsItemVisible(), true);
+    if (requested_focus) (void)context.emit_action_result(ActionEvent { focus_request.request_id, ActionType::focus, GUA_ACTION_STATUS_SUCCEEDED, 0, id });
+    return changed;
+}
+
+inline bool combo(Context& context, std::string_view label, int& selected, const std::vector<std::string>& items)
+{
+    const std::string id = semantic_id_from_label(label);
+    ActionRequest request;
+    ActionRequest focus_request;
+    const bool requested_focus = context.consume_action(ActionType::focus, id, focus_request);
+    if (requested_focus) ImGui::SetKeyboardFocusHere();
+    while (context.consume_action(ActionType::select, id, request)) {
+        const auto found = std::find(items.begin(), items.end(), request.value);
+        const bool success = found != items.end();
+        if (success) selected = static_cast<int>(std::distance(items.begin(), found));
+        (void)context.emit_action_result(ActionEvent { request.request_id, ActionType::select,
+            success ? GUA_ACTION_STATUS_SUCCEEDED : GUA_ACTION_STATUS_FAILED,
+            success ? 0 : GUA_ACTION_ERROR_INVALID_VALUE, id, success ? request.value : "" });
+    }
+    std::vector<const char*> pointers;
+    for (const auto& item : items) pointers.push_back(item.c_str());
+    const std::string label_buffer(label);
+    const bool changed = ImGui::Combo(label_buffer.c_str(), &selected, pointers.data(), static_cast<int>(pointers.size()));
+    const std::string value = selected >= 0 && selected < static_cast<int>(items.size()) ? items[static_cast<std::size_t>(selected)] : "";
+    if (changed) (void)context.emit_action_result(ActionEvent { 0, ActionType::select, GUA_ACTION_STATUS_SUCCEEDED, 0, id, value });
+    const ImVec2 min = ImGui::GetItemRectMin();
+    const ImVec2 max = ImGui::GetItemRectMax();
+    context.node_v2(id, "combobox", visible_label(label), Rect { min.x, min.y, max.x - min.x, max.y - min.y },
+        NodeProperties { .value = value, .focused = ImGui::IsItemFocused() }, ImGui::IsItemVisible(), true);
+    if (requested_focus) (void)context.emit_action_result(ActionEvent { focus_request.request_id, ActionType::focus, GUA_ACTION_STATUS_SUCCEEDED, 0, id });
+    return changed;
 }
 
 } // namespace gua::imgui
@@ -184,6 +290,21 @@ inline bool Button(gua::Context& context, std::string_view label)
 inline void Text(gua::Context& context, std::string_view label)
 {
     gua::imgui::text(context, label);
+}
+
+inline bool InputText(gua::Context& context, std::string_view label, std::string& value, bool sensitive = false)
+{
+    return gua::imgui::input_text(context, label, value, sensitive);
+}
+
+inline bool Checkbox(gua::Context& context, std::string_view label, bool& checked)
+{
+    return gua::imgui::checkbox(context, label, checked);
+}
+
+inline bool Combo(gua::Context& context, std::string_view label, int& selected, const std::vector<std::string>& items)
+{
+    return gua::imgui::combo(context, label, selected, items);
 }
 
 } // namespace GuaImGui

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -44,6 +44,11 @@ int gua_runtime_enqueue_click(gua_runtime_t* runtime, const char* node_id);
 int gua_runtime_consume_click_request(gua_runtime_t* runtime, const char* node_id);
 int gua_runtime_emit_click(gua_runtime_t* runtime, const char* node_id);
 int gua_runtime_poll_event(gua_runtime_t* runtime, gua_event_t* out_event);
+int gua_runtime_enqueue_action(gua_runtime_t* runtime, const gua_action_request_descriptor_t* descriptor, uint64_t* out_request_id);
+int gua_runtime_consume_action_request(gua_runtime_t* runtime, int action, const char* node_id, gua_action_request_t* out_request);
+int gua_runtime_emit_action_result(gua_runtime_t* runtime, const gua_action_result_t* result);
+int gua_runtime_poll_event_v2(gua_runtime_t* runtime, gua_event_v2_t* out_event);
+int gua_runtime_poll_event_v2_for_request(gua_runtime_t* runtime, uint64_t request_id, gua_event_v2_t* out_event);
 
 int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int port);
 void gua_runtime_stop_inspector_bridge(gua_runtime_t* runtime);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -307,6 +307,51 @@ extern "C" int gua_runtime_poll_event(gua_runtime_t* runtime, gua_event_t* out_e
     return gua_poll_event(runtime->context, out_event);
 }
 
+std::string escape_json(std::string_view value)
+{
+    std::string escaped;
+    for (char ch : value) {
+        if (ch == '\\' || ch == '"') escaped.push_back('\\');
+        escaped.push_back(ch);
+    }
+    return escaped;
+}
+
+extern "C" int gua_runtime_enqueue_action(gua_runtime_t* runtime, const gua_action_request_descriptor_t* descriptor, uint64_t* out_request_id)
+{
+    if (!valid_runtime(runtime)) return GUA_ACTION_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_enqueue_action(runtime->context, descriptor, out_request_id);
+}
+
+extern "C" int gua_runtime_consume_action_request(gua_runtime_t* runtime, int action, const char* node_id, gua_action_request_t* out_request)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_consume_action_request(runtime->context, action, node_id, out_request);
+}
+
+extern "C" int gua_runtime_emit_action_result(gua_runtime_t* runtime, const gua_action_result_t* result)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_emit_action_result(runtime->context, result);
+}
+
+extern "C" int gua_runtime_poll_event_v2(gua_runtime_t* runtime, gua_event_v2_t* out_event)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_poll_event_v2(runtime->context, out_event);
+}
+
+extern "C" int gua_runtime_poll_event_v2_for_request(gua_runtime_t* runtime, uint64_t request_id, gua_event_v2_t* out_event)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_poll_event_v2_for_request(runtime->context, request_id, out_event);
+}
+
 extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int port)
 {
     if (!valid_runtime(runtime) || port <= 0 || port > 65535) {
@@ -350,6 +395,43 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
             const std::string message = "press_key(" + key_string + ")";
             gua_add_log(runtime->context, GUA_LOG_INFO, message.c_str());
             return !key.empty();
+        },
+        .enqueue_action = [runtime](const gua::ws::ActionCommand& command) -> long long {
+            int action = 0;
+            if (command.type == "click_node") action = GUA_ACTION_CLICK;
+            else if (command.type == "focus_node") action = GUA_ACTION_FOCUS;
+            else if (command.type == "set_value") action = GUA_ACTION_SET_VALUE;
+            else if (command.type == "set_checked") action = GUA_ACTION_SET_CHECKED;
+            else if (command.type == "select") action = GUA_ACTION_SELECT;
+            else if (command.type == "scroll") action = GUA_ACTION_SCROLL;
+            else if (command.type == "press_key") action = GUA_ACTION_PRESS_KEY;
+            const gua_action_request_descriptor_t descriptor {
+                sizeof(gua_action_request_descriptor_t), action,
+                command.node_id.empty() ? nullptr : command.node_id.c_str(),
+                command.value.empty() ? nullptr : command.value.c_str(),
+                command.delta_x, command.delta_y, command.bool_value ? 1 : 0,
+                command.key.empty() ? nullptr : command.key.c_str(), command.modifiers,
+                command.sensitive ? 1 : 0, command.scroll_unit
+            };
+            std::uint64_t request_id = 0;
+            const std::lock_guard lock(runtime->context_mutex);
+            const int result = gua_enqueue_action(runtime->context, &descriptor, &request_id);
+            return result == GUA_ACTION_ACCEPTED ? static_cast<long long>(request_id) : static_cast<long long>(result);
+        },
+        .poll_action_event_json = [runtime](unsigned long long request_id) {
+            gua_event_v2_t event { sizeof(gua_event_v2_t) };
+            const std::lock_guard lock(runtime->context_mutex);
+            const int found = request_id == 0
+                ? gua_poll_event_v2(runtime->context, &event)
+                : gua_poll_event_v2_for_request(runtime->context, request_id, &event);
+            if (found == 0) return std::string("null");
+            return std::string("{\"requestId\":") + std::to_string(event.request_id) +
+                ",\"action\":" + std::to_string(event.action) +
+                ",\"succeeded\":" + (event.status == GUA_ACTION_STATUS_SUCCEEDED ? "true" : "false") +
+                ",\"error\":" + std::to_string(event.error_code) +
+                ",\"nodeId\":\"" + escape_json(event.node_id) + "\"" +
+                ",\"value\":\"" + escape_json(event.value) + "\"" +
+                ",\"sensitive\":" + (event.sensitive != 0 ? "true" : "false") + "}";
         },
     };
 

--- a/native/gua-testing/include/gua/testing.hpp
+++ b/native/gua-testing/include/gua/testing.hpp
@@ -3,6 +3,7 @@
 #include "gua/gua.h"
 
 #include <chrono>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -52,6 +53,37 @@ public:
         }
     }
 
+    [[nodiscard]] std::uint64_t focus() const { return enqueue(GUA_ACTION_FOCUS); }
+    [[nodiscard]] std::uint64_t set_value(std::string_view value, bool sensitive = false) const { return enqueue(GUA_ACTION_SET_VALUE, value, false, sensitive); }
+    [[nodiscard]] std::uint64_t set_checked(bool value) const { return enqueue(GUA_ACTION_SET_CHECKED, {}, value); }
+    [[nodiscard]] std::uint64_t select(std::string_view value) const { return enqueue(GUA_ACTION_SELECT, value); }
+    [[nodiscard]] std::uint64_t scroll(float dx, float dy, int unit = 0) const
+    {
+        gua_action_request_descriptor_t descriptor { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SCROLL, id_.c_str(), nullptr, dx, dy, 0, nullptr, 0, 0, unit };
+        return enqueue_descriptor(descriptor);
+    }
+
+    [[nodiscard]] std::uint64_t press_key(std::string_view key, std::uint32_t modifiers = 0) const
+    {
+        std::string key_buffer(key);
+        gua_action_request_descriptor_t descriptor { sizeof(gua_action_request_descriptor_t), GUA_ACTION_PRESS_KEY, id_.c_str(), nullptr, 0, 0, 0, key_buffer.c_str(), modifiers, 0, 0 };
+        return enqueue_descriptor(descriptor);
+    }
+
+    void wait_for_completion(std::uint64_t request_id, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000)) const
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        do {
+            gua_event_v2_t event { sizeof(gua_event_v2_t) };
+            if (gua_poll_event_v2_for_request(context_, request_id, &event) != 0) {
+                if (event.status == GUA_ACTION_STATUS_FAILED) throw std::runtime_error("Gua action failed for node: " + id_);
+                return;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        } while (std::chrono::steady_clock::now() < deadline);
+        throw std::runtime_error("Timed out waiting for Gua action completion: " + id_);
+    }
+
     void wait_for(std::chrono::milliseconds timeout = std::chrono::milliseconds(1000)) const
     {
         const auto deadline = std::chrono::steady_clock::now() + timeout;
@@ -68,6 +100,22 @@ public:
     }
 
 private:
+    [[nodiscard]] std::uint64_t enqueue(int action, std::string_view value = {}, bool bool_value = false, bool sensitive = false) const
+    {
+        std::string value_buffer(value);
+        gua_action_request_descriptor_t descriptor { sizeof(gua_action_request_descriptor_t), action, id_.c_str(),
+            value_buffer.empty() ? nullptr : value_buffer.c_str(), 0, 0, bool_value ? 1 : 0, nullptr, 0, sensitive ? 1 : 0, 0 };
+        return enqueue_descriptor(descriptor);
+    }
+
+    [[nodiscard]] std::uint64_t enqueue_descriptor(const gua_action_request_descriptor_t& descriptor) const
+    {
+        std::uint64_t request_id = 0;
+        const int result = gua_enqueue_action(context_, &descriptor, &request_id);
+        if (result != GUA_ACTION_ACCEPTED) throw std::runtime_error("Failed to enqueue Gua action (" + std::to_string(result) + ") for node: " + id_);
+        return request_id;
+    }
+
     gua_node_state_t read_state() const
     {
         gua_node_state_t state {};

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -7,6 +7,19 @@
 
 namespace gua::ws {
 
+struct ActionCommand {
+    std::string type;
+    std::string node_id;
+    std::string value;
+    float delta_x = 0;
+    float delta_y = 0;
+    bool bool_value = false;
+    std::string key;
+    unsigned int modifiers = 0;
+    bool sensitive = false;
+    int scroll_unit = 0;
+};
+
 struct BridgeHandlers {
     std::function<std::string()> get_ui_tree_json;
     std::function<std::string()> get_logs_json;
@@ -14,6 +27,8 @@ struct BridgeHandlers {
     std::function<bool(std::string_view node_id)> click_node;
     std::function<bool(std::string_view node_id)> focus_node;
     std::function<bool(std::string_view key)> press_key;
+    std::function<long long(const ActionCommand& command)> enqueue_action;
+    std::function<std::string(unsigned long long request_id)> poll_action_event_json;
 };
 
 struct BridgeOptions {

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <cctype>
 #include <cstring>
 #include <future>
 #include <iostream>
@@ -29,6 +30,14 @@ struct Command {
     std::string type;
     std::string node_id;
     std::string key;
+    std::string value;
+    float delta_x = 0;
+    float delta_y = 0;
+    bool bool_value = false;
+    unsigned int modifiers = 0;
+    bool sensitive = false;
+    int scroll_unit = 0;
+    unsigned long long request_id = 0;
 };
 
 struct ClientConnection {
@@ -462,6 +471,47 @@ std::optional<int> json_int_field(std::string_view json, std::string_view field)
     return std::stoi(std::string(json.substr(start, end - start)));
 }
 
+std::optional<unsigned long long> json_uint64_field(std::string_view json, std::string_view field)
+{
+    const std::string key = "\"" + std::string(field) + "\"";
+    const std::size_t key_position = json.find(key);
+    if (key_position == std::string_view::npos) return std::nullopt;
+    const std::size_t colon = json.find(':', key_position + key.size());
+    if (colon == std::string_view::npos) return std::nullopt;
+    std::size_t start = json.find_first_not_of(" \t", colon + 1U);
+    if (start == std::string_view::npos) return std::nullopt;
+    std::size_t end = start;
+    while (end < json.size() && std::isdigit(static_cast<unsigned char>(json[end]))) ++end;
+    if (end == start) return std::nullopt;
+    return std::stoull(std::string(json.substr(start, end - start)));
+}
+
+std::optional<double> json_number_field(std::string_view json, std::string_view field)
+{
+    const std::string key = "\"" + std::string(field) + "\"";
+    const std::size_t key_position = json.find(key);
+    if (key_position == std::string_view::npos) return std::nullopt;
+    const std::size_t colon = json.find(':', key_position + key.size());
+    if (colon == std::string_view::npos) return std::nullopt;
+    std::size_t start = json.find_first_not_of(" \t", colon + 1U);
+    if (start == std::string_view::npos) return std::nullopt;
+    std::size_t end = start;
+    while (end < json.size() && (std::isdigit(static_cast<unsigned char>(json[end])) || json[end] == '-' || json[end] == '+' || json[end] == '.' || json[end] == 'e' || json[end] == 'E')) ++end;
+    if (end == start) return std::nullopt;
+    return std::stod(std::string(json.substr(start, end - start)));
+}
+
+bool json_bool_field(std::string_view json, std::string_view field, bool fallback = false)
+{
+    const std::string key = "\"" + std::string(field) + "\"";
+    const std::size_t key_position = json.find(key);
+    if (key_position == std::string_view::npos) return fallback;
+    const std::size_t colon = json.find(':', key_position + key.size());
+    if (colon == std::string_view::npos) return fallback;
+    const std::size_t start = json.find_first_not_of(" \t", colon + 1U);
+    return start != std::string_view::npos && json.substr(start, 4) == "true";
+}
+
 Command parse_command(std::string_view json)
 {
     Command command;
@@ -469,6 +519,14 @@ Command parse_command(std::string_view json)
     command.type = json_string_field(json, "type").value_or("");
     command.node_id = json_string_field(json, "nodeId").value_or("");
     command.key = json_string_field(json, "key").value_or("");
+    command.value = json_string_field(json, "value").value_or("");
+    command.delta_x = static_cast<float>(json_number_field(json, "deltaX").value_or(0));
+    command.delta_y = static_cast<float>(json_number_field(json, "deltaY").value_or(0));
+    command.bool_value = json_bool_field(json, "checked");
+    command.modifiers = static_cast<unsigned int>(json_int_field(json, "modifiers").value_or(0));
+    command.sensitive = json_bool_field(json, "sensitive");
+    command.scroll_unit = json_int_field(json, "scrollUnit").value_or(0);
+    command.request_id = json_uint64_field(json, "requestId").value_or(0);
     return command;
 }
 
@@ -485,6 +543,19 @@ std::string ok_null_response(int id)
 std::string error_response(int id, std::string_view message)
 {
     return "{\"id\":" + std::to_string(id) + ",\"ok\":false,\"error\":\"" + escape_json(message) + "\"}";
+}
+
+std::string_view action_error_name(long long code)
+{
+    switch (code) {
+    case -1: return "invalid_argument";
+    case -2: return "node_not_found";
+    case -3: return "hidden";
+    case -4: return "disabled";
+    case -5: return "unsupported";
+    case -6: return "invalid_value";
+    default: return "unknown";
+    }
 }
 
 Socket create_listen_socket(unsigned short port)
@@ -723,6 +794,20 @@ private:
             }
             if (command.type == "get_screenshot") {
                 return ok_response(command.id, handlers_.get_screenshot_json());
+            }
+            if (command.type == "poll_events") {
+                return handlers_.poll_action_event_json
+                    ? ok_response(command.id, handlers_.poll_action_event_json(command.request_id))
+                    : error_response(command.id, "poll_events is not supported by this bridge");
+            }
+            if (handlers_.enqueue_action && (command.type == "click_node" || command.type == "focus_node" || command.type == "press_key" ||
+                command.type == "set_value" || command.type == "set_checked" || command.type == "select" || command.type == "scroll")) {
+                const long long request_id = handlers_.enqueue_action(gua::ws::ActionCommand {
+                    command.type, command.node_id, command.value, command.delta_x, command.delta_y, command.bool_value,
+                    command.key, command.modifiers, command.sensitive, command.scroll_unit });
+                return request_id > 0
+                    ? ok_response(command.id, "{\"requestId\":" + std::to_string(request_id) + "}")
+                    : error_response(command.id, "Gua action rejected: " + std::string(action_error_name(request_id)));
             }
             if (command.type == "click_node") {
                 return handlers_.click_node(command.node_id)

--- a/protocol/fixtures/action-request-v1.json
+++ b/protocol/fixtures/action-request-v1.json
@@ -1,0 +1,7 @@
+{
+  "type": "set_value",
+  "nodeId": "player-name",
+  "value": "Ada",
+  "sensitive": false,
+  "requestId": 42
+}

--- a/protocol/fixtures/action-result-v1.json
+++ b/protocol/fixtures/action-result-v1.json
@@ -1,0 +1,9 @@
+{
+  "type": "set_value",
+  "timestampMs": 1234,
+  "requestId": 42,
+  "status": "succeeded",
+  "nodeId": "player-name",
+  "value": "Ada",
+  "sensitive": false
+}

--- a/protocol/schema/commands.schema.json
+++ b/protocol/schema/commands.schema.json
@@ -6,6 +6,10 @@
     { "$ref": "#/$defs/getUiTree" },
     { "$ref": "#/$defs/nodeCommand" },
     { "$ref": "#/$defs/pressKey" },
+    { "$ref": "#/$defs/valueAction" },
+    { "$ref": "#/$defs/checkedAction" },
+    { "$ref": "#/$defs/selectAction" },
+    { "$ref": "#/$defs/scrollAction" },
     { "$ref": "#/$defs/textInput" },
     { "$ref": "#/$defs/moveGamepad" },
     { "$ref": "#/$defs/simpleCommand" }
@@ -28,7 +32,8 @@
           "enum": ["get_node", "click_node", "focus_node", "wait_for_node"]
         },
         "nodeId": { "type": "string", "minLength": 1 },
-        "timeoutMs": { "type": "integer", "minimum": 0 }
+        "timeoutMs": { "type": "integer", "minimum": 0 },
+        "requestId": { "type": "integer", "minimum": 1 }
       }
     },
     "pressKey": {
@@ -37,7 +42,57 @@
       "additionalProperties": false,
       "properties": {
         "type": { "const": "press_key" },
-        "key": { "type": "string", "minLength": 1 }
+        "key": { "type": "string", "minLength": 1 },
+        "nodeId": { "type": "string", "minLength": 1 },
+        "modifiers": { "type": "integer", "minimum": 0 },
+        "requestId": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "valueAction": {
+      "type": "object",
+      "required": ["type", "nodeId", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "set_value" },
+        "nodeId": { "type": "string", "minLength": 1 },
+        "value": { "type": "string" },
+        "sensitive": { "type": "boolean", "default": false },
+        "requestId": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "checkedAction": {
+      "type": "object",
+      "required": ["type", "nodeId", "checked"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "set_checked" },
+        "nodeId": { "type": "string", "minLength": 1 },
+        "checked": { "type": "boolean" },
+        "requestId": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "selectAction": {
+      "type": "object",
+      "required": ["type", "nodeId", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "select" },
+        "nodeId": { "type": "string", "minLength": 1 },
+        "value": { "type": "string", "minLength": 1 },
+        "requestId": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "scrollAction": {
+      "type": "object",
+      "required": ["type", "nodeId", "deltaX", "deltaY"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "scroll" },
+        "nodeId": { "type": "string", "minLength": 1 },
+        "deltaX": { "type": "number" },
+        "deltaY": { "type": "number" },
+        "scrollUnit": { "type": "integer", "enum": [0, 1] },
+        "requestId": { "type": "integer", "minimum": 1 }
       }
     },
     "textInput": {

--- a/protocol/schema/events.schema.json
+++ b/protocol/schema/events.schema.json
@@ -8,7 +8,7 @@
   "properties": {
     "type": {
       "type": "string",
-      "enum": ["click", "focus", "key", "text", "gamepad"]
+      "enum": ["click", "focus", "set_value", "set_checked", "select", "scroll", "press_key", "key", "text", "gamepad"]
     },
     "timestampMs": {
       "type": "integer",
@@ -18,6 +18,13 @@
       "type": "string",
       "minLength": 1
     },
+    "requestId": { "type": "integer", "minimum": 0 },
+    "status": { "type": "string", "enum": ["succeeded", "failed"] },
+    "error": { "type": "string", "enum": ["node_not_found", "hidden", "disabled", "unsupported", "invalid_value"] },
+    "sensitive": { "type": "boolean", "default": false },
+    "checked": { "type": "boolean" },
+    "deltaX": { "type": "number" },
+    "deltaY": { "type": "number" },
     "key": {
       "type": "string",
       "minLength": 1
@@ -29,9 +36,20 @@
       "type": "string"
     },
     "value": {
-      "type": "number",
-      "minimum": -1,
-      "maximum": 1
+      "oneOf": [
+        { "type": "string" },
+        { "type": "number", "minimum": -1, "maximum": 1 }
+      ]
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "type": { "enum": ["click", "focus", "set_value", "set_checked", "select", "scroll", "press_key"] } } },
+      "then": { "required": ["requestId", "status"] }
+    },
+    {
+      "if": { "properties": { "sensitive": { "const": true } }, "required": ["sensitive"] },
+      "then": { "properties": { "value": { "type": "string", "maxLength": 0 } } }
+    }
+  ]
 }

--- a/protocol/schema/ui-tree.schema.json
+++ b/protocol/schema/ui-tree.schema.json
@@ -58,7 +58,8 @@
             "menuitem",
             "combobox",
             "tablist",
-            "tab"
+            "tab",
+            "scrollarea"
           ]
         },
         "label": { "type": "string" },
@@ -85,7 +86,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["click", "focus", "press", "text_input", "set_value"]
+            "enum": ["click", "focus", "set_value", "set_checked", "select", "scroll", "press_key"]
           },
           "uniqueItems": true
         }

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -58,6 +58,7 @@ and later engine adapters own the engine-specific reflection details.
 | Godot `OptionButton` | `combobox` | parentId, value, focused |
 | Godot `ItemList` | `list` + `listitem` children | stable derived child id, parentId, text, selected |
 | Godot `TabContainer` | `tablist` + `tab` children | stable derived child id, parentId, text, selected |
+| Godot `ScrollContainer` | `scrollarea` | bounds, visible, enabled, scroll action |
 
 The legacy `gua_register_node` and `gua_get_node_state` C exports remain valid.
 New integrations use `gua_node_descriptor_v2_t` / `gua_node_state_v2_t`, whose
@@ -89,6 +90,18 @@ Initial command types:
 - `click_node`
 - `focus_node`
 - `press_key`
+- `set_value`
+- `set_checked`
+- `select`
+- `scroll`
+
+### Semantic action lifecycle (v1)
+
+Semantic actions follow `enqueue -> consume -> host action -> observed event`. Enqueue acceptance only records a request; it is never completion. Each accepted request receives a monotonically increasing `requestId`, and the adapter must copy that ID into its success or failure event after attempting the host operation.
+
+The v1 action names map directly to the additive C ABI action enum: `click`, `focus`, `set_value`, `set_checked`, `select`, `scroll`, and `press_key`. Enqueue validation distinguishes `node_not_found`, `hidden`, `disabled`, `unsupported`, and `invalid_value`. Existing click functions remain compatibility wrappers over the generic queue.
+
+`sensitive=true` permits the adapter to receive the requested value, but event values, logs, diagnostics, and recordings must use an empty or redacted representation. `scrollUnit=0` means host pixels and `scrollUnit=1` means semantic lines. A key request may omit `nodeId` to target the host's current focus; when a node is provided it must expose `press_key`.
 - `text_input`
 - `move_gamepad`
 - `wait_for_node`


### PR DESCRIPTION
## 対応 Issue

- #22

## 実装内容

- `focus` / `set_value` / `set_checked` / `select` / `scroll` / `press_key` の protocol schema と fixture を追加
- 一意な `requestId`、enqueue error、adapter consume、observed success/failure event を扱う additive C ABI / runtime v2 API を追加
- 既存 click API を generic queue の互換 wrapper として維持
- C++ wrapper / testing helper と .NET P/Invoke / testing helper / remote context を同じ contract に同期
- WebSocket bridge で action enqueue と requestId 指定 event polling を透過
- ImGui の `InputText` / `Checkbox` / `Combo` facade と focus/key handling を追加
- Godot adapter-owned reflection で LineEdit、TextEdit、CheckBox、OptionButton、ItemList、TabContainer、ScrollContainer、key input を実 control へ適用
- sensitive value を event、semantic tree、label/text/value へ再公開しない処理を追加
- `scrollarea` role と対応 action 一覧を UI tree schema に同期

## Architecture 判断

- protocol を source of truth とし、C ABI は既存 symbol/struct を変更せず additive API のみ追加しました。
- enqueue acceptance と操作完了を分離し、adapter が host operation 後に同じ requestId を emit します。
- requestId 指定 poll を用意し、ある操作の完了待ちが無関係 event を drain しないようにしました。
- .NET は別 runtime を持たず P/Invoke、ImGui/Godot は game code の手動再記述ではなく adapter/facade-owned reflection を維持しています。
- legacy `gua_poll_event` は click/focus のみを扱い、v2 action event を誤って旧 enum として返さない互換動作にしました。

## Action matrix

| Action | Core/C++/.NET | WebSocket | Godot | ImGui |
|---|---|---|---|---|
| focus | ✅ | ✅ | Control.grab_focus | facade focus |
| set_value | ✅ | ✅ | LineEdit/TextEdit/Range | InputText |
| set_checked | ✅ | ✅ | BaseButton toggle | Checkbox |
| select | ✅ | ✅ | OptionButton/ItemList/TabContainer | Combo |
| scroll | ✅ | ✅ | ScrollContainer | 対応 node を未公開 |
| press_key | ✅ | ✅ | focused/target Control | InputText |

## 検証

- `cmake --preset windows-msvc-debug` — 成功
- `cmake --build --preset windows-msvc-debug -- /m:1` — 成功（core/runtime/bridge/Godot/ImGui/native sample）
- `ctest --test-dir build\windows-msvc-debug -C Debug --output-on-failure` — 1/1 成功
- `dotnet build bindings\dotnet\src\Gua.Testing\Gua.Testing.csproj --configuration Release --no-restore` — 成功、警告0
- `dotnet build bindings\dotnet\src\Gua.Testing.Godot\Gua.Testing.Godot.csproj --configuration Release --no-restore` — 成功、警告0
- `dotnet test examples\dotnet-nunit\GuaDotNetNUnitSample.csproj --configuration Release --no-build` — 5/5 成功
- `bun run check` — inspector / MCP / bridge 全成功
- Godot 4.7 headless smoke — 成功（6操作、全対象 control、requestId 相関、sensitive 非露出）
- `uvx check-jsonschema` — commands/events/ui-tree fixture 3件成功
- `git diff --check` — 成功

## 互換性

- 既存 click enqueue/consume/emit と legacy event ABI は維持しています。
- main の PR #26（Issue #21）を基点としており、最新 `origin/main` を取り込み済みです。

## 未対応事項

- gamepad、double click、long press、drag & drop、IME composition、coordinate click は Issue 範囲外です。
- diagnostics/recording 本体は #20/#25、reset は #24、selector は #23 に残しています。
- ImGui の scrollable semantic facade は本 Issue で node を新設せず、既存 facade の対象操作に限定しています。