### PR TITLE
#23 Strict semantic selector と scope query API を追加

### DIFF
--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -228,6 +228,45 @@ public sealed class GuaContext : IGuaContext, IDisposable
         }
     }
 
+    public GuaQueryResult Query(GuaSelector selector)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ThrowIfDisposed();
+        var values = new[] { selector.Id, selector.Role, selector.Name, selector.Text, selector.ParentId };
+        var pointers = values.Select(value => value is null ? nint.Zero : System.Runtime.InteropServices.Marshal.StringToCoTaskMemUTF8(value)).ToArray();
+        try
+        {
+            var native = new Native.GuaNativeSelectorV1
+            {
+                StructSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<Native.GuaNativeSelectorV1>(),
+                Id = pointers[0], IdMatch = (int)selector.IdMatch,
+                Role = pointers[1], RoleMatch = (int)selector.RoleMatch,
+                Name = pointers[2], NameMatch = (int)selector.NameMatch,
+                Text = pointers[3], TextMatch = (int)selector.TextMatch,
+                ParentId = pointers[4], DirectChild = selector.DirectChild ? 1 : 0,
+                Visible = (int)selector.Visible, Enabled = (int)selector.Enabled,
+            };
+            unsafe
+            {
+                var required = Native.gua_query_nodes_json(_handle, in native, null, 0);
+                var buffer = new byte[required];
+                fixed (byte* pointer = buffer)
+                {
+                    Native.gua_query_nodes_json(_handle, in native, pointer, buffer.Length);
+                    var json = System.Runtime.InteropServices.Marshal.PtrToStringUTF8((nint)pointer)
+                        ?? throw new InvalidOperationException("Native Gua returned invalid selector JSON.");
+                    return System.Text.Json.JsonSerializer.Deserialize<GuaQueryResult>(json, QueryJsonOptions)
+                        ?? throw new InvalidOperationException("Native Gua returned an empty selector result.");
+                }
+            }
+        }
+        finally
+        {
+            foreach (var pointer in pointers.Where(pointer => pointer != nint.Zero))
+                System.Runtime.InteropServices.Marshal.FreeCoTaskMem(pointer);
+        }
+    }
+
     public bool EnqueueClick(string id)
     {
         ThrowIfDisposed();
@@ -344,4 +383,9 @@ public sealed class GuaContext : IGuaContext, IDisposable
         Logs,
         Screenshot,
     }
+
+    private static readonly System.Text.Json.JsonSerializerOptions QueryJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
 }

--- a/bindings/dotnet/src/Gua.Core/GuaSelector.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaSelector.cs
@@ -1,0 +1,33 @@
+namespace Gua.Core;
+
+public enum GuaMatchMode
+{
+    Exact = 0,
+    Contains = 1,
+    Regex = 2,
+}
+
+public enum GuaStateFilter
+{
+    Any = 0,
+    False = 1,
+    True = 2,
+}
+
+public sealed record GuaSelector(
+    string? Id = null,
+    GuaMatchMode IdMatch = GuaMatchMode.Exact,
+    string? Role = null,
+    GuaMatchMode RoleMatch = GuaMatchMode.Exact,
+    string? Name = null,
+    GuaMatchMode NameMatch = GuaMatchMode.Exact,
+    string? Text = null,
+    GuaMatchMode TextMatch = GuaMatchMode.Exact,
+    string? ParentId = null,
+    bool DirectChild = false,
+    GuaStateFilter Visible = GuaStateFilter.Any,
+    GuaStateFilter Enabled = GuaStateFilter.Any);
+
+public sealed record GuaNodeQueryMatch(string Id, string Role, string Label, string? ParentId);
+
+public sealed record GuaQueryResult(bool Valid, IReadOnlyList<GuaNodeQueryMatch> Matches, string? Error = null);

--- a/bindings/dotnet/src/Gua.Core/IGuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/IGuaContext.cs
@@ -12,6 +12,8 @@ public interface IGuaContext
 
     string FindNodeByText(string text);
 
+    GuaQueryResult Query(GuaSelector selector) => throw new NotSupportedException("This Gua context does not support semantic selector queries.");
+
     bool EnqueueClick(string id);
 
     bool TryPollEvent(out GuaEvent e);

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -53,6 +53,24 @@ internal static partial class Native
         public fixed byte Value[256];
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GuaNativeSelectorV1
+    {
+        public uint StructSize;
+        public nint Id;
+        public int IdMatch;
+        public nint Role;
+        public int RoleMatch;
+        public nint Name;
+        public int NameMatch;
+        public nint Text;
+        public int TextMatch;
+        public nint ParentId;
+        public int DirectChild;
+        public int Visible;
+        public int Enabled;
+    }
+
     static Native()
     {
         NativeLibrary.SetDllImportResolver(typeof(Native).Assembly, ResolveGuaLibrary);
@@ -202,6 +220,9 @@ internal static partial class Native
 
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static unsafe partial int gua_find_node_by_text(nint context, string text, byte* outNodeId, int outNodeIdSize);
+
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_query_nodes_json(nint context, in GuaNativeSelectorV1 selector, byte* outJson, int outJsonSize);
 
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int gua_enqueue_click(nint context, string nodeId);

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -63,6 +63,27 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
         return node.Id;
     }
 
+    public GuaQueryResult Query(GuaSelector selector)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        return Request<GuaQueryResult>(new
+        {
+            type = "query_nodes",
+            selectorId = selector.Id,
+            idMatch = (int)selector.IdMatch,
+            role = selector.Role,
+            roleMatch = (int)selector.RoleMatch,
+            name = selector.Name,
+            nameMatch = (int)selector.NameMatch,
+            text = selector.Text,
+            textMatch = (int)selector.TextMatch,
+            parentId = selector.ParentId,
+            directChild = selector.DirectChild ? 1 : 0,
+            visible = (int)selector.Visible,
+            enabled = (int)selector.Enabled,
+        });
+    }
+
     public bool EnqueueClick(string id)
     {
         Request<object?>(new { type = "click_node", nodeId = id }, allowNullResult: true);

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -18,7 +18,7 @@ public static class GuaAssertions
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(id);
-        return new GuaNodeExpectation(context, id, $"id '{id}'");
+        return Query(context).ById(id).Get();
     }
 
     public static GuaNodeExpectation GetByRole(IGuaContext context, string role, string? name = null)
@@ -26,16 +26,20 @@ public static class GuaAssertions
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(role);
 
-        var id = context.FindNodeByRole(role, name);
-        var description = name is null ? $"role '{role}'" : $"role '{role}' and label '{name}'";
-        return new GuaNodeExpectation(context, id, description);
+        return Query(context).ByRole(role, name).Get();
     }
 
     public static GuaNodeExpectation GetByText(IGuaContext context, string text)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(text);
-        return new GuaNodeExpectation(context, context.FindNodeByText(text), $"text '{text}'");
+        return Query(context).ByText(text).Get();
+    }
+
+    public static GuaLocatorQuery Query(IGuaContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return new GuaLocatorQuery(context);
     }
 
     public static GuaNodeExpectation ExpectNode(IGuaContext context, string id)

--- a/bindings/dotnet/src/Gua.Testing/GuaLocatorQuery.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaLocatorQuery.cs
@@ -1,0 +1,94 @@
+using Gua.Core;
+
+namespace Gua.Testing;
+
+public sealed record GuaLocatorQuery
+{
+    private readonly IGuaContext _context;
+    private readonly GuaSelector _selector;
+
+    internal GuaLocatorQuery(IGuaContext context, GuaSelector? selector = null)
+    {
+        _context = context;
+        _selector = selector ?? new GuaSelector();
+    }
+
+    public GuaLocatorQuery ById(string id, GuaMatchMode match = GuaMatchMode.Exact) => Next(_selector with { Id = id, IdMatch = match });
+    public GuaLocatorQuery ByRole(string role, string? name = null, GuaMatchMode match = GuaMatchMode.Exact) =>
+        Next(_selector with { Role = role, RoleMatch = match, Name = name, NameMatch = match });
+    public GuaLocatorQuery ByText(string text, GuaMatchMode match = GuaMatchMode.Exact) => Next(_selector with { Text = text, TextMatch = match });
+    public GuaLocatorQuery Within(string parentId, bool directChild = false) => Next(_selector with { ParentId = parentId, DirectChild = directChild });
+    public GuaLocatorQuery WhereVisible(bool visible = true) => Next(_selector with { Visible = visible ? GuaStateFilter.True : GuaStateFilter.False });
+    public GuaLocatorQuery WhereEnabled(bool enabled = true) => Next(_selector with { Enabled = enabled ? GuaStateFilter.True : GuaStateFilter.False });
+
+    public IReadOnlyList<GuaNodeExpectation> QueryAll()
+    {
+        var result = Execute();
+        return result.Matches.Select(match => new GuaNodeExpectation(_context, match.Id, Describe())).ToArray();
+    }
+
+    public GuaNodeExpectation Get()
+    {
+        var result = Execute();
+        if (result.Matches.Count == 0)
+            GuaAssertions.Fail($"Strict Gua selector matched no nodes: {Describe()}.");
+        if (result.Matches.Count > 1)
+        {
+            var candidates = string.Join("; ", result.Matches.Select(match =>
+                $"{match.Id} ({match.Role}, '{match.Label}', parentId='{match.ParentId ?? "<root>"}')"));
+            GuaAssertions.Fail($"Strict Gua selector matched {result.Matches.Count} nodes: {Describe()}. Candidates: {candidates}. Narrow the scope with Within(...) or add stable id/state filters.");
+        }
+        return new GuaNodeExpectation(_context, result.Matches[0].Id, Describe());
+    }
+
+    public GuaLocatorQuery AssertCount(int expected)
+    {
+        var actual = Execute().Matches.Count;
+        if (actual != expected)
+            GuaAssertions.Fail($"Expected selector {Describe()} to match {expected} nodes, but matched {actual}.");
+        return this;
+    }
+
+    private GuaQueryResult Execute()
+    {
+        GuaQueryResult result;
+        try
+        {
+            result = _context.Query(_selector);
+        }
+        catch (NotSupportedException) when (CanUseLegacyFallback())
+        {
+            var id = _selector.Id is not null
+                ? _context.FindNodeById(_selector.Id)
+                : _selector.Role is not null
+                    ? _context.FindNodeByRole(_selector.Role, _selector.Name)
+                    : _context.FindNodeByText(_selector.Text!);
+            result = new GuaQueryResult(true, [new GuaNodeQueryMatch(id, "legacy", "legacy", null)]);
+        }
+        if (!result.Valid)
+            GuaAssertions.Fail($"Invalid Gua selector {Describe()}: {result.Error ?? "unknown syntax error"}");
+        return result;
+    }
+
+    private bool CanUseLegacyFallback() =>
+        _selector.ParentId is null && !_selector.DirectChild &&
+        _selector.Visible == GuaStateFilter.Any && _selector.Enabled == GuaStateFilter.Any &&
+        _selector.IdMatch == GuaMatchMode.Exact && _selector.RoleMatch == GuaMatchMode.Exact &&
+        _selector.NameMatch == GuaMatchMode.Exact && _selector.TextMatch == GuaMatchMode.Exact &&
+        (_selector.Id is not null || _selector.Role is not null || _selector.Text is not null);
+
+    private GuaLocatorQuery Next(GuaSelector selector) => new(_context, selector);
+
+    private string Describe()
+    {
+        var fields = new List<string>();
+        if (_selector.Id is not null) fields.Add($"id={_selector.IdMatch}:{_selector.Id}");
+        if (_selector.Role is not null) fields.Add($"role={_selector.RoleMatch}:{_selector.Role}");
+        if (_selector.Name is not null) fields.Add($"name={_selector.NameMatch}:{_selector.Name}");
+        if (_selector.Text is not null) fields.Add($"text={_selector.TextMatch}:{_selector.Text}");
+        if (_selector.ParentId is not null) fields.Add($"scope={_selector.ParentId} ({(_selector.DirectChild ? "direct children" : "descendants")})");
+        if (_selector.Visible != GuaStateFilter.Any) fields.Add($"visible={_selector.Visible == GuaStateFilter.True}");
+        if (_selector.Enabled != GuaStateFilter.Any) fields.Add($"enabled={_selector.Enabled == GuaStateFilter.True}");
+        return "{" + string.Join(", ", fields) + "}";
+    }
+}

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -51,3 +51,23 @@ GuaAssertions.GetById(ui, "start").ToBeVisible();
 
 See `examples/dotnet-nunit` for a complete NUnit project with multiple `[Test]`
 methods in one file.
+
+Semantic locators are strict: `GetBy*` fails when zero or multiple nodes match,
+while `QueryAll()` is the explicit multi-result API. String matching is exact by
+default and can opt into ordinal contains or ECMAScript regex matching:
+
+```csharp
+var save = GuaAssertions.Query(ui)
+    .ByRole("button")
+    .ByText("^保存", GuaMatchMode.Regex)
+    .Within("settings-panel")
+    .WhereVisible()
+    .WhereEnabled()
+    .Get();
+
+GuaAssertions.Query(ui).ByRole("listitem").Within("servers").AssertCount(3);
+```
+
+`Within(parentId)` searches descendants and excludes the parent itself. Pass
+`directChild: true` to limit the query to immediate children. Local and Godot
+remote contexts send the same selector to the native evaluator.

--- a/bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Gua.Core\Gua.Core.csproj" />
+    <ProjectReference Include="..\..\src\Gua.Testing\Gua.Testing.csproj" />
+    <ProjectReference Include="..\..\src\Gua.Testing.Godot\Gua.Testing.Godot.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using Gua.Core;
+using Gua.Testing.Godot;
+using NUnit.Framework;
+
+namespace Gua.Selector.Tests;
+
+[TestFixture]
+public sealed class SelectorParityTests
+{
+    [Test]
+    public void LocalAndRemoteContextsUseTheSameNativeSelectorEvaluator()
+    {
+        var port = ReservePort();
+        var runtime = Native.gua_runtime_create();
+        Assert.That(runtime, Is.Not.EqualTo(nint.Zero));
+        try
+        {
+            Native.gua_runtime_begin_frame(runtime, "fixture");
+            Native.gua_runtime_register_node(runtime, "save-a", "button", "Save", new GuaBounds(0, 0, 1, 1), 1, 1);
+            Native.gua_runtime_register_node(runtime, "save-b", "button", "Save as", new GuaBounds(0, 0, 1, 1), 1, 1);
+            Native.gua_runtime_end_frame(runtime);
+            Assert.That(Native.gua_runtime_start_inspector_bridge(runtime, port), Is.EqualTo(1));
+
+            using var local = new GuaContext();
+            local.BeginFrame("fixture");
+            local.RegisterNode("save-a", "button", "Save", new GuaBounds(0, 0, 1, 1));
+            local.RegisterNode("save-b", "button", "Save as", new GuaBounds(0, 0, 1, 1));
+            local.EndFrame();
+
+            using var remote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            var selector = new GuaSelector(Role: "button", Name: "^Save", NameMatch: GuaMatchMode.Regex);
+            var remoteResult = remote.Query(selector);
+            var localResult = local.Query(selector);
+            Assert.That(remoteResult.Matches.Select(match => match.Id),
+                Is.EqualTo(localResult.Matches.Select(match => match.Id)));
+
+            var invalid = new GuaSelector(Text: "[", TextMatch: GuaMatchMode.Regex);
+            Assert.Multiple(() =>
+            {
+                Assert.That(local.Query(invalid).Valid, Is.False);
+                Assert.That(remote.Query(invalid).Valid, Is.False);
+            });
+        }
+        finally
+        {
+            Native.gua_runtime_stop_inspector_bridge(runtime);
+            Native.gua_runtime_destroy(runtime);
+        }
+    }
+
+    private static int ReservePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static class Native
+    {
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern nint gua_runtime_create();
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void gua_runtime_destroy(nint runtime);
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void gua_runtime_begin_frame(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string screen);
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void gua_runtime_end_frame(nint runtime);
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void gua_runtime_register_node(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string id,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string role, [MarshalAs(UnmanagedType.LPUTF8Str)] string label,
+            GuaBounds bounds, int visible, int enabled);
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int gua_runtime_start_inspector_bridge(nint runtime, int port);
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void gua_runtime_stop_inspector_bridge(nint runtime);
+    }
+}

--- a/examples/dotnet-nunit/TitleScreenTests.cs
+++ b/examples/dotnet-nunit/TitleScreenTests.cs
@@ -8,6 +8,30 @@ namespace Gua.DotNetNUnitSample;
 public sealed class TitleScreenTests
 {
     [Test]
+    public void StrictSelectorsShareNativeMatchingAndScopeRules()
+    {
+        using var ui = new GuaContext();
+        ui.BeginFrame("selectors");
+        ui.RegisterNode(new GuaNodeDescriptor("left", "panel", "Left", new GuaBounds(0, 0, 10, 10)));
+        ui.RegisterNode(new GuaNodeDescriptor("right", "panel", "Right", new GuaBounds(0, 0, 10, 10)));
+        ui.RegisterNode(new GuaNodeDescriptor("group", "panel", "Group", new GuaBounds(0, 0, 10, 10), ParentId: "left"));
+        ui.RegisterNode(new GuaNodeDescriptor("left-save", "button", "保存", new GuaBounds(0, 0, 1, 1), ParentId: "group", Text: "保存"));
+        ui.RegisterNode(new GuaNodeDescriptor("right-save", "button", "保存", new GuaBounds(0, 0, 1, 1), ParentId: "right", Text: "保存"));
+        ui.RegisterNode(new GuaNodeDescriptor("hidden", "button", "Hidden", new GuaBounds(0, 0, 1, 1), ParentId: "left", Text: "Hidden", Visible: false));
+        ui.EndFrame();
+
+        var left = GuaAssertions.Query(ui).ByText("保", GuaMatchMode.Contains).Within("left").WhereVisible().Get();
+        Assert.That(left.Snapshot.Id, Is.EqualTo("left-save"));
+        GuaAssertions.Query(ui).ByRole("button").Within("left", directChild: true).AssertCount(1);
+
+        var ambiguous = Assert.Throws<GuaAssertionException>(() => GuaAssertions.GetByText(ui, "保存"));
+        Assert.That(ambiguous!.Message, Does.Contain("left-save").And.Contain("right-save").And.Contain("Within"));
+
+        var invalid = Assert.Throws<GuaAssertionException>(() => GuaAssertions.Query(ui).ByText("[", GuaMatchMode.Regex).QueryAll());
+        Assert.That(invalid!.Message, Does.Contain("Invalid Gua selector"));
+    }
+
+    [Test]
     public void V2NodeStatePreservesUnknownAndStableRevision()
     {
         using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);

--- a/native/gua-core/CMakeLists.txt
+++ b/native/gua-core/CMakeLists.txt
@@ -64,4 +64,5 @@ if(BUILD_TESTING)
     target_link_libraries(gua-core-state-tests PRIVATE gua-core)
     target_compile_features(gua-core-state-tests PRIVATE cxx_std_20)
     add_test(NAME gua-core-state-tests COMMAND gua-core-state-tests)
+
 endif()

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -71,6 +71,34 @@ typedef struct gua_node_state_v2_t {
 } gua_node_state_v2_t;
 
 enum {
+    GUA_MATCH_EXACT = 0,
+    GUA_MATCH_CONTAINS = 1,
+    GUA_MATCH_REGEX = 2
+};
+
+enum {
+    GUA_FILTER_ANY = 0,
+    GUA_FILTER_FALSE = 1,
+    GUA_FILTER_TRUE = 2
+};
+
+typedef struct gua_selector_v1_t {
+    uint32_t struct_size;
+    const char* id;
+    int id_match;
+    const char* role;
+    int role_match;
+    const char* name;
+    int name_match;
+    const char* text;
+    int text_match;
+    const char* parent_id;
+    int direct_child;
+    int visible;
+    int enabled;
+} gua_selector_v1_t;
+
+enum {
     GUA_LOG_TRACE = 0,
     GUA_LOG_DEBUG = 1,
     GUA_LOG_INFO = 2,
@@ -117,6 +145,8 @@ int gua_get_node_state_v2(gua_context_t* ctx, const char* node_id, gua_node_stat
 int gua_find_node_by_id(gua_context_t* ctx, const char* node_id, char* out_node_id, int out_node_id_size);
 int gua_find_node_by_role(gua_context_t* ctx, const char* role, const char* name, char* out_node_id, int out_node_id_size);
 int gua_find_node_by_text(gua_context_t* ctx, const char* text, char* out_node_id, int out_node_id_size);
+/* Returns the required JSON byte size including the trailing NUL. The result contains valid, matches, and optional error fields. */
+int gua_query_nodes_json(gua_context_t* ctx, const gua_selector_v1_t* selector, char* out_json, int out_json_size);
 int gua_enqueue_click(gua_context_t* ctx, const char* node_id);
 int gua_consume_click_request(gua_context_t* ctx, const char* node_id);
 int gua_emit_click(gua_context_t* ctx, const char* node_id);

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <regex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -102,6 +103,92 @@ int write_node_id(const std::string& node_id, char* out_node_id, int out_node_id
 
     std::snprintf(out_node_id, static_cast<std::size_t>(out_node_id_size), "%s", node_id.c_str());
     return 1;
+}
+
+bool matches_text(const std::string& actual, const char* expected, int mode, std::string& error)
+{
+    if (expected == nullptr || expected[0] == '\0') {
+        return true;
+    }
+    switch (mode) {
+    case GUA_MATCH_EXACT:
+        return actual == expected;
+    case GUA_MATCH_CONTAINS:
+        return actual.find(expected) != std::string::npos;
+    case GUA_MATCH_REGEX:
+        try {
+            return std::regex_search(actual, std::regex(expected, std::regex::ECMAScript));
+        } catch (const std::regex_error& exception) {
+            error = exception.what();
+            return false;
+        }
+    default:
+        error = "unknown match mode";
+        return false;
+    }
+}
+
+bool matches_filter(bool actual, int filter, std::string& error)
+{
+    if (filter == GUA_FILTER_ANY) return true;
+    if (filter == GUA_FILTER_FALSE) return !actual;
+    if (filter == GUA_FILTER_TRUE) return actual;
+    error = "unknown state filter";
+    return false;
+}
+
+bool is_in_scope(const std::vector<Node>& nodes, const Node& node, const char* parent_id, bool direct_child)
+{
+    if (parent_id == nullptr || parent_id[0] == '\0') return true;
+    if (node.id == parent_id) return false;
+    if (direct_child) return node.parent_id == parent_id;
+
+    std::string current = node.parent_id;
+    for (std::size_t depth = 0; !current.empty() && depth <= nodes.size(); ++depth) {
+        if (current == parent_id) return true;
+        const auto parent = std::find_if(nodes.begin(), nodes.end(), [&](const Node& candidate) { return candidate.id == current; });
+        if (parent == nodes.end() || parent->parent_id == current) return false;
+        current = parent->parent_id;
+    }
+    return false;
+}
+
+std::string build_query_json(const std::vector<Node>& nodes, const gua_selector_v1_t& selector)
+{
+    std::string error;
+    std::vector<const Node*> matches;
+    for (const Node& node : nodes) {
+        if (!is_in_scope(nodes, node, selector.parent_id, selector.direct_child != 0)) continue;
+        const std::string& text = (node.known_mask & GUA_NODE_KNOWN_TEXT) != 0U ? node.text : node.label;
+        if (!matches_text(node.id, selector.id, selector.id_match, error) || !error.empty() ||
+            !matches_text(node.role, selector.role, selector.role_match, error) || !error.empty() ||
+            !matches_text(node.label, selector.name, selector.name_match, error) || !error.empty() ||
+            !matches_text(text, selector.text, selector.text_match, error) || !error.empty() ||
+            !matches_filter(node.visible, selector.visible, error) || !error.empty() ||
+            !matches_filter(node.enabled, selector.enabled, error) || !error.empty()) {
+            if (!error.empty()) break;
+            continue;
+        }
+        matches.push_back(&node);
+    }
+
+    if (!error.empty()) {
+        return "{\"valid\":false,\"error\":\"" + escape_json(error) + "\",\"matches\":[]}";
+    }
+
+    std::string json = "{\"valid\":true,\"matches\":[";
+    for (std::size_t i = 0; i < matches.size(); ++i) {
+        if (i > 0) json += ",";
+        const Node& node = *matches[i];
+        json += "{\"id\":\"" + escape_json(node.id) + "\",\"role\":\"" + escape_json(node.role) +
+            "\",\"label\":\"" + escape_json(node.label) + "\",\"parentId\":";
+        json += (node.known_mask & GUA_NODE_KNOWN_PARENT_ID) != 0U
+            ? "\"" + escape_json(node.parent_id) + "\""
+            : "null";
+        json += "}";
+    }
+    json += "]}";
+    return json;
 }
 
 } // namespace
@@ -529,6 +616,15 @@ extern "C" int gua_find_node_by_text(gua_context_t* ctx, const char* text, char*
     }
 
     return write_node_id(found->id, out_node_id, out_node_id_size);
+}
+
+extern "C" int gua_query_nodes_json(gua_context_t* ctx, const gua_selector_v1_t* selector, char* out_json, int out_json_size)
+{
+    if (ctx == nullptr || selector == nullptr || selector->struct_size < sizeof(gua_selector_v1_t)) {
+        return copy_json_string("{\"valid\":false,\"error\":\"invalid selector struct\",\"matches\":[]}", out_json, out_json_size);
+    }
+    const std::lock_guard lock(ctx->mutex);
+    return copy_json_string(build_query_json(ctx->nodes, *selector), out_json, out_json_size);
 }
 
 extern "C" int gua_enqueue_click(gua_context_t* ctx, const char* node_id)

--- a/native/gua-core/tests/selector_tests.cpp
+++ b/native/gua-core/tests/selector_tests.cpp
@@ -1,0 +1,55 @@
+#include "gua/gua.h"
+#include "gua/testing.hpp"
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void node(gua_context_t* context, const char* id, const char* parent, const char* role, const char* label, const char* text, bool visible = true)
+{
+    const gua_node_descriptor_v2_t descriptor {
+        sizeof(gua_node_descriptor_v2_t),
+        static_cast<uint64_t>((parent ? GUA_NODE_KNOWN_PARENT_ID : 0) | (text ? GUA_NODE_KNOWN_TEXT : 0)),
+        id, parent, role, label, text, nullptr, { 0, 0, 1, 1 }, visible ? 1 : 0, 1, 0, 0, 0, 0, 0,
+    };
+    assert(gua_register_node_v2(context, &descriptor) == 1);
+}
+
+}
+
+int main()
+{
+    gua_context_t* context = gua_create_context();
+    gua_begin_frame(context, "selectors");
+    node(context, "left", nullptr, "panel", "Left", nullptr);
+    node(context, "right", nullptr, "panel", "Right", nullptr);
+    node(context, "left-group", "left", "panel", "Group", nullptr);
+    node(context, "left-save", "left-group", "button", "保存", "保存");
+    node(context, "right-save", "right", "button", "保存", "保存");
+    node(context, "hidden", "left", "button", "Hidden", "Hidden", false);
+    gua_end_frame(context);
+
+    using namespace gua::testing;
+    assert(query(context).by_role("button").query_all().size() == 3);
+    assert(query(context).by_text("保存").within("left").get().id() == "left-save");
+    assert(query(context).by_text("存", match_mode::contains).within("right", true).get().id() == "right-save");
+    assert(query(context).by_name("^保.*$", match_mode::regex).within("left").where_visible().get().id() == "left-save");
+    query(context).by_role("button").within("left", true).assert_count(1);
+
+    bool ambiguous = false;
+    try { (void)get_by_text(context, "保存"); }
+    catch (const std::runtime_error& error) { ambiguous = std::string(error.what()).find("multiple") != std::string::npos; }
+    assert(ambiguous);
+
+    bool invalid_regex = false;
+    try { (void)query(context).by_text("[", match_mode::regex).query_all(); }
+    catch (const std::runtime_error& error) { invalid_regex = std::string(error.what()).find("Invalid Gua selector") != std::string::npos; }
+    assert(invalid_regex);
+
+    char legacy[128] {};
+    assert(gua_find_node_by_text(context, "保存", legacy, sizeof(legacy)) == 1);
+    assert(std::string(legacy) == "left-save");
+    gua_destroy_context(context);
+}

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -40,6 +40,7 @@ int gua_runtime_get_node_state_v2(gua_runtime_t* runtime, const char* node_id, g
 int gua_runtime_find_node_by_id(gua_runtime_t* runtime, const char* node_id, char* out_node_id, int out_node_id_size);
 int gua_runtime_find_node_by_role(gua_runtime_t* runtime, const char* role, const char* name, char* out_node_id, int out_node_id_size);
 int gua_runtime_find_node_by_text(gua_runtime_t* runtime, const char* text, char* out_node_id, int out_node_id_size);
+int gua_runtime_query_nodes_json(gua_runtime_t* runtime, const gua_selector_v1_t* selector, char* out_json, int out_json_size);
 int gua_runtime_enqueue_click(gua_runtime_t* runtime, const char* node_id);
 int gua_runtime_consume_click_request(gua_runtime_t* runtime, const char* node_id);
 int gua_runtime_emit_click(gua_runtime_t* runtime, const char* node_id);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -267,6 +267,13 @@ extern "C" int gua_runtime_find_node_by_text(gua_runtime_t* runtime, const char*
     return gua_find_node_by_text(runtime->context, text, out_node_id, out_node_id_size);
 }
 
+extern "C" int gua_runtime_query_nodes_json(gua_runtime_t* runtime, const gua_selector_v1_t* selector, char* out_json, int out_json_size)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_query_nodes_json(runtime->context, selector, out_json, out_json_size);
+}
+
 extern "C" int gua_runtime_enqueue_click(gua_runtime_t* runtime, const char* node_id)
 {
     if (!valid_runtime(runtime)) {
@@ -327,6 +334,23 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
         },
         .get_screenshot_json = [runtime] {
             return copy_screenshot_json(runtime);
+        },
+        .query_nodes_json = [runtime](const gua::ws::QuerySelector& selector) {
+            gua_selector_v1_t native {
+                sizeof(gua_selector_v1_t),
+                selector.id.empty() ? nullptr : selector.id.c_str(), selector.id_match,
+                selector.role.empty() ? nullptr : selector.role.c_str(), selector.role_match,
+                selector.name.empty() ? nullptr : selector.name.c_str(), selector.name_match,
+                selector.text.empty() ? nullptr : selector.text.c_str(), selector.text_match,
+                selector.parent_id.empty() ? nullptr : selector.parent_id.c_str(),
+                selector.direct_child ? 1 : 0, selector.visible, selector.enabled,
+            };
+            const std::lock_guard lock(runtime->context_mutex);
+            const int size = gua_query_nodes_json(runtime->context, &native, nullptr, 0);
+            std::string json(static_cast<std::size_t>(size), '\0');
+            gua_query_nodes_json(runtime->context, &native, json.data(), size);
+            json.resize(static_cast<std::size_t>(size - 1));
+            return json;
         },
         .click_node = [runtime](std::string_view node_id) {
             const std::string id(node_id);

--- a/native/gua-testing/CMakeLists.txt
+++ b/native/gua-testing/CMakeLists.txt
@@ -10,3 +10,10 @@ target_link_libraries(gua-testing
     INTERFACE
         gua::core
 )
+
+if(BUILD_TESTING)
+    add_executable(gua-core-selector-tests ../gua-core/tests/selector_tests.cpp)
+    target_link_libraries(gua-core-selector-tests PRIVATE gua-core gua-testing)
+    target_compile_features(gua-core-selector-tests PRIVATE cxx_std_20)
+    add_test(NAME gua-core-selector-tests COMMAND gua-core-selector-tests)
+endif()

--- a/native/gua-testing/include/gua/testing.hpp
+++ b/native/gua-testing/include/gua/testing.hpp
@@ -8,6 +8,7 @@
 #include <string_view>
 #include <thread>
 #include <utility>
+#include <vector>
 
 namespace gua::testing {
 
@@ -89,32 +90,97 @@ inline std::string read_node_id(char const* description, int found, const char* 
     return buffer;
 }
 
+enum class match_mode { exact = GUA_MATCH_EXACT, contains = GUA_MATCH_CONTAINS, regex = GUA_MATCH_REGEX };
+
+class Query {
+public:
+    explicit Query(gua_context_t* context) : context_(context) {}
+
+    Query by_id(std::string value, match_mode mode = match_mode::exact) const { Query copy(*this); copy.id_ = std::move(value); copy.id_match_ = mode; return copy; }
+    Query by_role(std::string value, match_mode mode = match_mode::exact) const { Query copy(*this); copy.role_ = std::move(value); copy.role_match_ = mode; return copy; }
+    Query by_name(std::string value, match_mode mode = match_mode::exact) const { Query copy(*this); copy.name_ = std::move(value); copy.name_match_ = mode; return copy; }
+    Query by_text(std::string value, match_mode mode = match_mode::exact) const { Query copy(*this); copy.text_ = std::move(value); copy.text_match_ = mode; return copy; }
+    Query within(std::string parent_id, bool direct_child = false) const { Query copy(*this); copy.parent_id_ = std::move(parent_id); copy.direct_child_ = direct_child; return copy; }
+    Query where_visible(bool value = true) const { Query copy(*this); copy.visible_ = value ? GUA_FILTER_TRUE : GUA_FILTER_FALSE; return copy; }
+    Query where_enabled(bool value = true) const { Query copy(*this); copy.enabled_ = value ? GUA_FILTER_TRUE : GUA_FILTER_FALSE; return copy; }
+
+    [[nodiscard]] std::vector<Locator> query_all() const
+    {
+        const std::string json = execute();
+        std::vector<Locator> matches;
+        std::size_t cursor = 0;
+        while ((cursor = json.find("\"id\":\"", cursor)) != std::string::npos) {
+            cursor += 6;
+            const std::size_t end = json.find('"', cursor);
+            if (end == std::string::npos) break;
+            matches.emplace_back(context_, json.substr(cursor, end - cursor));
+            cursor = end + 1;
+        }
+        return matches;
+    }
+
+    [[nodiscard]] Locator get() const
+    {
+        auto matches = query_all();
+        if (matches.empty()) throw std::runtime_error("Strict Gua selector matched no nodes: " + describe());
+        if (matches.size() > 1) throw std::runtime_error("Strict Gua selector matched multiple nodes: " + describe() + ". Narrow the scope with within() or add a stable id/state filter. " + execute());
+        return std::move(matches.front());
+    }
+
+    const Query& assert_count(std::size_t expected) const
+    {
+        const std::size_t actual = query_all().size();
+        if (actual != expected) throw std::runtime_error("Expected selector " + describe() + " to match " + std::to_string(expected) + " nodes, but matched " + std::to_string(actual));
+        return *this;
+    }
+
+private:
+    [[nodiscard]] std::string execute() const
+    {
+        gua_selector_v1_t selector {
+            sizeof(gua_selector_v1_t),
+            pointer(id_), static_cast<int>(id_match_), pointer(role_), static_cast<int>(role_match_),
+            pointer(name_), static_cast<int>(name_match_), pointer(text_), static_cast<int>(text_match_),
+            pointer(parent_id_), direct_child_ ? 1 : 0, visible_, enabled_,
+        };
+        const int required = gua_query_nodes_json(context_, &selector, nullptr, 0);
+        std::string json(static_cast<std::size_t>(required), '\0');
+        gua_query_nodes_json(context_, &selector, json.data(), required);
+        json.resize(static_cast<std::size_t>(required - 1));
+        if (json.find("\"valid\":false") != std::string::npos) throw std::runtime_error("Invalid Gua selector " + describe() + ": " + json);
+        return json;
+    }
+
+    static const char* pointer(const std::string& value) { return value.empty() ? nullptr : value.c_str(); }
+    [[nodiscard]] std::string describe() const { return "{id='" + id_ + "', role='" + role_ + "', name='" + name_ + "', text='" + text_ + "', scope='" + parent_id_ + "'}"; }
+
+    gua_context_t* context_;
+    std::string id_, role_, name_, text_, parent_id_;
+    match_mode id_match_ = match_mode::exact, role_match_ = match_mode::exact, name_match_ = match_mode::exact, text_match_ = match_mode::exact;
+    bool direct_child_ = false;
+    int visible_ = GUA_FILTER_ANY, enabled_ = GUA_FILTER_ANY;
+};
+
+inline Query query(gua_context_t* context) { return Query(context); }
+
 inline Locator get_by_id(gua_context_t* context, std::string id)
 {
-    char node_id[128] {};
-    return Locator(context, read_node_id("id", gua_find_node_by_id(context, id.c_str(), node_id, static_cast<int>(sizeof(node_id))), node_id));
+    return query(context).by_id(std::move(id)).get();
 }
 
 inline Locator get_by_role(gua_context_t* context, std::string_view role)
 {
-    char node_id[128] {};
-    std::string role_buffer(role);
-    return Locator(context, read_node_id("role", gua_find_node_by_role(context, role_buffer.c_str(), nullptr, node_id, static_cast<int>(sizeof(node_id))), node_id));
+    return query(context).by_role(std::string(role)).get();
 }
 
 inline Locator get_by_role(gua_context_t* context, std::string_view role, std::string_view name)
 {
-    char node_id[128] {};
-    std::string role_buffer(role);
-    std::string name_buffer(name);
-    return Locator(context, read_node_id("role and name", gua_find_node_by_role(context, role_buffer.c_str(), name_buffer.c_str(), node_id, static_cast<int>(sizeof(node_id))), node_id));
+    return query(context).by_role(std::string(role)).by_name(std::string(name)).get();
 }
 
 inline Locator get_by_text(gua_context_t* context, std::string_view text)
 {
-    char node_id[128] {};
-    std::string text_buffer(text);
-    return Locator(context, read_node_id("text", gua_find_node_by_text(context, text_buffer.c_str(), node_id, static_cast<int>(sizeof(node_id))), node_id));
+    return query(context).by_text(std::string(text)).get();
 }
 
 inline Locator expect_node(gua_context_t* context, std::string id)
@@ -131,10 +197,9 @@ inline Locator wait_for_id(gua_context_t* context, std::string id, std::chrono::
 {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     do {
-        char node_id[128] {};
-        if (gua_find_node_by_id(context, id.c_str(), node_id, static_cast<int>(sizeof(node_id))) != 0) {
-            return Locator(context, node_id);
-        }
+        auto matches = query(context).by_id(id).query_all();
+        if (matches.size() == 1) return std::move(matches.front());
+        if (matches.size() > 1) throw std::runtime_error("Strict Gua selector matched multiple nodes by id: " + id);
 
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     } while (std::chrono::steady_clock::now() < deadline);
@@ -147,10 +212,9 @@ inline Locator wait_for_role(gua_context_t* context, std::string_view role, std:
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     std::string role_buffer(role);
     do {
-        char node_id[128] {};
-        if (gua_find_node_by_role(context, role_buffer.c_str(), nullptr, node_id, static_cast<int>(sizeof(node_id))) != 0) {
-            return Locator(context, node_id);
-        }
+        auto matches = query(context).by_role(role_buffer).query_all();
+        if (matches.size() == 1) return std::move(matches.front());
+        if (matches.size() > 1) throw std::runtime_error("Strict Gua selector matched multiple nodes by role: " + role_buffer);
 
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     } while (std::chrono::steady_clock::now() < deadline);
@@ -164,10 +228,9 @@ inline Locator wait_for_role(gua_context_t* context, std::string_view role, std:
     std::string role_buffer(role);
     std::string name_buffer(name);
     do {
-        char node_id[128] {};
-        if (gua_find_node_by_role(context, role_buffer.c_str(), name_buffer.c_str(), node_id, static_cast<int>(sizeof(node_id))) != 0) {
-            return Locator(context, node_id);
-        }
+        auto matches = query(context).by_role(role_buffer).by_name(name_buffer).query_all();
+        if (matches.size() == 1) return std::move(matches.front());
+        if (matches.size() > 1) throw std::runtime_error("Strict Gua selector matched multiple nodes by role and name: " + role_buffer + ", " + name_buffer);
 
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     } while (std::chrono::steady_clock::now() < deadline);
@@ -180,10 +243,9 @@ inline Locator wait_for_text(gua_context_t* context, std::string_view text, std:
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     std::string text_buffer(text);
     do {
-        char node_id[128] {};
-        if (gua_find_node_by_text(context, text_buffer.c_str(), node_id, static_cast<int>(sizeof(node_id))) != 0) {
-            return Locator(context, node_id);
-        }
+        auto matches = query(context).by_text(text_buffer).query_all();
+        if (matches.size() == 1) return std::move(matches.front());
+        if (matches.size() > 1) throw std::runtime_error("Strict Gua selector matched multiple nodes by text: " + text_buffer);
 
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     } while (std::chrono::steady_clock::now() < deadline);

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -7,10 +7,26 @@
 
 namespace gua::ws {
 
+struct QuerySelector {
+    std::string id;
+    int id_match = 0;
+    std::string role;
+    int role_match = 0;
+    std::string name;
+    int name_match = 0;
+    std::string text;
+    int text_match = 0;
+    std::string parent_id;
+    bool direct_child = false;
+    int visible = 0;
+    int enabled = 0;
+};
+
 struct BridgeHandlers {
     std::function<std::string()> get_ui_tree_json;
     std::function<std::string()> get_logs_json;
     std::function<std::string()> get_screenshot_json;
+    std::function<std::string(const QuerySelector& selector)> query_nodes_json;
     std::function<bool(std::string_view node_id)> click_node;
     std::function<bool(std::string_view node_id)> focus_node;
     std::function<bool(std::string_view key)> press_key;

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -29,6 +29,7 @@ struct Command {
     std::string type;
     std::string node_id;
     std::string key;
+    gua::ws::QuerySelector selector;
 };
 
 struct ClientConnection {
@@ -416,8 +417,11 @@ std::optional<std::string> json_string_field(std::string_view json, std::string_
     if (colon == std::string_view::npos) {
         return std::nullopt;
     }
-    const std::size_t quote = json.find('"', colon + 1U);
-    if (quote == std::string_view::npos) {
+    std::size_t quote = colon + 1U;
+    while (quote < json.size() && json[quote] == ' ') {
+        ++quote;
+    }
+    if (quote >= json.size() || json[quote] != '"') {
         return std::nullopt;
     }
 
@@ -469,6 +473,18 @@ Command parse_command(std::string_view json)
     command.type = json_string_field(json, "type").value_or("");
     command.node_id = json_string_field(json, "nodeId").value_or("");
     command.key = json_string_field(json, "key").value_or("");
+    command.selector.id = json_string_field(json, "selectorId").value_or("");
+    command.selector.id_match = json_int_field(json, "idMatch").value_or(0);
+    command.selector.role = json_string_field(json, "role").value_or("");
+    command.selector.role_match = json_int_field(json, "roleMatch").value_or(0);
+    command.selector.name = json_string_field(json, "name").value_or("");
+    command.selector.name_match = json_int_field(json, "nameMatch").value_or(0);
+    command.selector.text = json_string_field(json, "text").value_or("");
+    command.selector.text_match = json_int_field(json, "textMatch").value_or(0);
+    command.selector.parent_id = json_string_field(json, "parentId").value_or("");
+    command.selector.direct_child = json_int_field(json, "directChild").value_or(0) != 0;
+    command.selector.visible = json_int_field(json, "visible").value_or(0);
+    command.selector.enabled = json_int_field(json, "enabled").value_or(0);
     return command;
 }
 
@@ -723,6 +739,12 @@ private:
             }
             if (command.type == "get_screenshot") {
                 return ok_response(command.id, handlers_.get_screenshot_json());
+            }
+            if (command.type == "query_nodes") {
+                if (!handlers_.query_nodes_json) {
+                    return error_response(command.id, "query_nodes is not supported by this bridge");
+                }
+                return ok_response(command.id, handlers_.query_nodes_json(command.selector));
             }
             if (command.type == "click_node") {
                 return handlers_.click_node(command.node_id)

--- a/protocol/fixtures/selector-v1.json
+++ b/protocol/fixtures/selector-v1.json
@@ -1,0 +1,7 @@
+{
+  "role": { "value": "button", "match": "exact" },
+  "name": { "value": "^保存", "match": "regex" },
+  "scope": { "parentId": "settings-panel", "directChild": false },
+  "visible": true,
+  "enabled": true
+}

--- a/protocol/schema/selector.schema.json
+++ b/protocol/schema/selector.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gua.dev/schema/selector.schema.json",
+  "title": "Gua Semantic Selector",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": { "$ref": "#/$defs/stringCriterion" },
+    "role": { "$ref": "#/$defs/stringCriterion" },
+    "name": { "$ref": "#/$defs/stringCriterion" },
+    "text": { "$ref": "#/$defs/stringCriterion" },
+    "scope": {
+      "type": "object",
+      "required": ["parentId"],
+      "additionalProperties": false,
+      "properties": {
+        "parentId": { "type": "string", "minLength": 1 },
+        "directChild": { "type": "boolean", "default": false }
+      }
+    },
+    "visible": { "type": "boolean" },
+    "enabled": { "type": "boolean" }
+  },
+  "$defs": {
+    "stringCriterion": {
+      "type": "object",
+      "required": ["value"],
+      "additionalProperties": false,
+      "properties": {
+        "value": { "type": "string", "minLength": 1 },
+        "match": { "enum": ["exact", "contains", "regex"], "default": "exact" }
+      }
+    }
+  }
+}

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -59,6 +59,30 @@ and later engine adapters own the engine-specific reflection details.
 | Godot `ItemList` | `list` + `listitem` children | stable derived child id, parentId, text, selected |
 | Godot `TabContainer` | `tablist` + `tab` children | stable derived child id, parentId, text, selected |
 
+## Semantic selectors
+
+`selector.schema.json` is the source of truth for semantic queries. String
+criteria are ordinal and case-sensitive. Their default match mode is `exact`;
+callers may explicitly select `contains` or ECMAScript `regex`. An invalid regex
+is a selector syntax error, never a zero-match result.
+
+Criteria combine with logical AND. `name` means the node's accessible `label`.
+`text` uses the v2 `text` field when known and falls back to `label` for legacy
+nodes. `visible` and `enabled` are tri-state at ABI level (`any`, `false`,
+`true`) so omitting a filter differs from requiring `false`.
+
+A scope parent is excluded from its own results. The default scope searches all
+descendants by following `parentId`; `directChild: true` limits it to immediate
+children. A strict single query fails for both zero and multiple matches.
+`QueryAll` is the only query form that accepts multiple results. Ambiguity
+diagnostics include candidate `id`, `role`, `label`, and `parentId` and suggest
+adding a stable id, state filter, or narrower scope.
+
+The C ABI evaluates selectors through versioned `gua_selector_v1_t` and
+`gua_query_nodes_json`. C++, .NET local contexts, and the remote `query_nodes`
+command all use that evaluator. The legacy `gua_find_node_by_*` exports remain
+available for ABI compatibility but retain first-match behavior.
+
 The legacy `gua_register_node` and `gua_get_node_state` C exports remain valid.
 New integrations use `gua_node_descriptor_v2_t` / `gua_node_state_v2_t`, whose
 `struct_size` protects ABI versioning and whose `known_mask` distinguishes


### PR DESCRIPTION
## 対応 Issue

Closes #23

## 実装内容

- `protocol/schema/selector.schema.json` を追加し、id / role / name / text、exact / contains / regex、親 scope、visible / enabled filter を言語横断仕様として定義しました。
- additive な `gua_selector_v1_t` と `gua_query_nodes_json` を C ABI に追加しました。既存 `gua_find_node_by_*` は変更せず残しています。
- native core に ordinal・case-sensitive な selector evaluator を1つ実装し、v2 text 優先・legacy label fallback、descendant/direct-child scope、tri-state filter、invalid regex error を統一しました。
- C++ testing helper と .NET testing helper を strict query に切り替え、`QueryAll` / `Within` / `WhereVisible` / `WhereEnabled` / `AssertCount` を追加しました。
- Godot remote context と runtime WebSocket bridgeへ `query_nodes` を追加し、remote側でもnative core evaluatorを使用するようにしました。
- 0件・複数件・invalid regexを区別し、複数一致時は候補の id / role / label / parentId とscope改善案を表示します。
- optional selector fieldの `null` を次のproperty名として誤読していた既存WebSocket JSON parserを修正しました。

## Architecture判断・互換性

- selector schemaとprotocol文書をsource of truthとし、regexを含む一致判定はnative coreだけに置きました。.NET local、C++、WebSocket remoteはいずれも同じC ABI evaluatorへ到達します。
- 公開native APIはversioned structを使うadditiveなC ABIです。既存のfirst-match C ABIとclick ABIは削除・変更していません。
- C#の既存 `IGuaContext` 実装を壊さないよう、selector未対応の旧custom contextにはexactな基本queryだけlegacy finder fallbackを残しました。Gua提供のlocal/remote contextはstrict evaluatorを使用します。
- `Within(parent)` はparent自身を除く全descendant、`directChild: true` の場合だけ直下要素に限定します。
- 作業中にmainへmergeされたPR #27（generic semantic action）をmerge commit `3105832` で統合しました。action request/eventとselector queryの双方を保持し、共通core/runtime/WebSocket/testing変更を再検証しています。

## テスト・検証

- `cmake --preset windows-msvc-debug` — 成功
- `cmake --build --preset windows-msvc-debug` — 成功
- `ctest --test-dir build/windows-msvc-debug --output-on-failure -C Debug` — 2/2成功
- `dotnet build bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release --no-restore` — 成功（0 warning）
- `dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release --no-restore` — 成功（0 warning）
- `dotnet test bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj --configuration Release --no-build` — 1/1成功。local contextとnative runtime経由remote contextの同一fixture結果を比較
- `dotnet test examples/dotnet-nunit/GuaDotNetNUnitSample.csproj --configuration Release --no-build` — 統合後6/6成功。ローカルpackを隔離NuGet cacheへrestoreして検証
- `bun run check` — 全3 workspace成功
- `bunx ajv-cli validate --spec=draft2020 -s protocol/schema/selector.schema.json -d protocol/fixtures/selector-v1.json` — valid
- Godot 4.7 headless `gua_smoke.gd` — 統合後成功
- `git diff --check` / `git diff --cached --check` — 成功
- `dumpbin /exports` — `gua_query_nodes_json` / `gua_runtime_query_nodes_json` のexportを確認

新規worktreeの初回 `.NET --no-restore` は `project.assets.json` 不在で停止したため、関係projectをrestoreして同じbuildを再実行しています。初回 `bun run check` もdependencies未導入だったため、`bun install --frozen-lockfile` 後に再実行しています。同一versionのローカルNuGet再pack後は隔離cacheの旧展開物を削除してからsampleを再restoreし、stale binaryではなく統合後成果物で6/6を確認しました。

## 未対応事項

Issue #23 範囲内の未対応事項はありません。wait API、reset、diagnostics、visual comparisonは既存の後続Issueへ残しています。generic actionはPR #27の実装をそのまま統合しています。
