### PR TITLE
#24 Gua contextの検査と安全なresetを追加

### DIFF
--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -116,6 +116,54 @@ public sealed class GuaContext : IGuaContext, IDisposable
         return ReadCopiedJson(JsonSource.UiTree, _handle);
     }
 
+    public unsafe GuaContextStatus GetContextStatus()
+    {
+        ThrowIfDisposed();
+        Native.GuaNativeContextStatus status = default;
+        status.StructSize = (uint)sizeof(Native.GuaNativeContextStatus);
+        if (Native.gua_get_context_status(_handle, &status) == 0)
+        {
+            throw new InvalidOperationException("Failed to inspect the Gua context.");
+        }
+
+        return new GuaContextStatus(
+            status.SessionEpoch, status.FrameSequence, status.Revision, status.NodeCount,
+            status.PendingRequestCount, status.InFlightRequestCount, status.UnconsumedEventCount,
+            status.LogCount, status.HasScreenshot != 0, ActionOrNull(status.FirstPendingAction),
+            Marshal.PtrToStringUTF8((nint)status.FirstPendingNodeId) ?? string.Empty,
+            ActionOrNull(status.FirstEventAction),
+            Marshal.PtrToStringUTF8((nint)status.FirstEventNodeId) ?? string.Empty);
+    }
+
+    public unsafe GuaResetReport Reset(GuaResetOptions? options = null)
+    {
+        ThrowIfDisposed();
+        options ??= new GuaResetOptions();
+        var nativeOptions = new Native.GuaNativeResetOptions
+        {
+            StructSize = (uint)sizeof(Native.GuaNativeResetOptions),
+            Flags = (uint)options.Targets,
+            Strict = options.Strict ? 1 : 0,
+            ExpectedSessionEpoch = options.ExpectedSessionEpoch ?? 0,
+        };
+        Native.GuaNativeResetReport report = default;
+        report.StructSize = (uint)sizeof(Native.GuaNativeResetReport);
+        var result = Native.gua_reset_context(_handle, in nativeOptions, &report);
+        if (result == (int)GuaResetResult.InvalidArgument)
+        {
+            throw new ArgumentException("Invalid Gua reset options.", nameof(options));
+        }
+        return new GuaResetReport(
+            (GuaResetResult)result, report.PreviousSessionEpoch, report.SessionEpoch,
+            report.PendingRequestCount, report.InFlightRequestCount, report.UnconsumedEventCount,
+            report.DiscardedNodeCount, report.DiscardedPendingRequestCount, report.DiscardedInFlightRequestCount,
+            report.DiscardedEventCount, report.DiscardedLogCount, report.DiscardedScreenshot != 0,
+            ActionOrNull(report.FirstPendingAction), Marshal.PtrToStringUTF8((nint)report.FirstPendingNodeId) ?? string.Empty,
+            ActionOrNull(report.FirstEventAction), Marshal.PtrToStringUTF8((nint)report.FirstEventNodeId) ?? string.Empty);
+    }
+
+    private static GuaActionType? ActionOrNull(int action) => action == 0 ? null : (GuaActionType)action;
+
     public void AddLog(GuaLogLevel level, string message)
     {
         ThrowIfDisposed();

--- a/bindings/dotnet/src/Gua.Core/GuaReset.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaReset.cs
@@ -1,0 +1,64 @@
+namespace Gua.Core;
+
+[Flags]
+public enum GuaResetTargets : uint
+{
+    None = 0,
+    Nodes = 1 << 0,
+    Requests = 1 << 1,
+    Events = 1 << 2,
+    History = 1 << 3,
+    Logs = 1 << 4,
+    Screenshot = 1 << 5,
+    Default = Nodes | Requests | Events | History,
+    All = Default | Logs | Screenshot,
+}
+
+public enum GuaResetResult
+{
+    Succeeded = 1,
+    InvalidArgument = -1,
+    Dirty = -2,
+    StaleEpoch = -3,
+}
+
+public sealed record GuaResetOptions(
+    GuaResetTargets Targets = GuaResetTargets.Default,
+    bool Strict = false,
+    ulong? ExpectedSessionEpoch = null);
+
+public sealed record GuaContextStatus(
+    ulong SessionEpoch,
+    ulong FrameSequence,
+    ulong Revision,
+    uint NodeCount,
+    uint PendingRequestCount,
+    uint InFlightRequestCount,
+    uint UnconsumedEventCount,
+    uint LogCount,
+    bool HasScreenshot,
+    GuaActionType? FirstPendingAction,
+    string FirstPendingNodeId,
+    GuaActionType? FirstEventAction,
+    string FirstEventNodeId)
+{
+    public bool IsClean => PendingRequestCount == 0 && InFlightRequestCount == 0 && UnconsumedEventCount == 0;
+}
+
+public sealed record GuaResetReport(
+    GuaResetResult Result,
+    ulong PreviousSessionEpoch,
+    ulong SessionEpoch,
+    uint PendingRequestCount,
+    uint InFlightRequestCount,
+    uint UnconsumedEventCount,
+    uint DiscardedNodeCount,
+    uint DiscardedPendingRequestCount,
+    uint DiscardedInFlightRequestCount,
+    uint DiscardedEventCount,
+    uint DiscardedLogCount,
+    bool DiscardedScreenshot,
+    GuaActionType? FirstPendingAction,
+    string FirstPendingNodeId,
+    GuaActionType? FirstEventAction,
+    string FirstEventNodeId);

--- a/bindings/dotnet/src/Gua.Core/IGuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/IGuaContext.cs
@@ -4,6 +4,10 @@ public interface IGuaContext
 {
     string GetUiTreeJson();
 
+    GuaContextStatus GetContextStatus() => throw new NotSupportedException("This Gua context does not support status inspection.");
+
+    GuaResetReport Reset(GuaResetOptions? options = null) => throw new NotSupportedException("This Gua context does not support reset.");
+
     GuaNodeState GetNodeState(string id);
 
     string FindNodeById(string id);

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -45,6 +45,56 @@ internal static partial class Native
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct GuaNativeContextStatus
+    {
+        public uint StructSize;
+        public ulong SessionEpoch;
+        public ulong FrameSequence;
+        public ulong Revision;
+        public uint NodeCount;
+        public uint PendingRequestCount;
+        public uint InFlightRequestCount;
+        public uint UnconsumedEventCount;
+        public uint LogCount;
+        public int HasScreenshot;
+        public int FirstPendingAction;
+        public fixed byte FirstPendingNodeId[128];
+        public int FirstEventAction;
+        public fixed byte FirstEventNodeId[128];
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GuaNativeResetOptions
+    {
+        public uint StructSize;
+        public uint Flags;
+        public int Strict;
+        public ulong ExpectedSessionEpoch;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct GuaNativeResetReport
+    {
+        public uint StructSize;
+        public int Result;
+        public ulong PreviousSessionEpoch;
+        public ulong SessionEpoch;
+        public uint PendingRequestCount;
+        public uint InFlightRequestCount;
+        public uint UnconsumedEventCount;
+        public uint DiscardedNodeCount;
+        public uint DiscardedPendingRequestCount;
+        public uint DiscardedInFlightRequestCount;
+        public uint DiscardedEventCount;
+        public uint DiscardedLogCount;
+        public int DiscardedScreenshot;
+        public int FirstPendingAction;
+        public fixed byte FirstPendingNodeId[128];
+        public int FirstEventAction;
+        public fixed byte FirstEventNodeId[128];
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct GuaNativeActionRequest
     {
         public uint StructSize;
@@ -309,4 +359,10 @@ internal static partial class Native
 
     [LibraryImport("gua")]
     internal static partial int gua_emit_action_result(nint context, in GuaNativeActionResult result);
+
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_get_context_status(nint context, GuaNativeContextStatus* status);
+
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_reset_context(nint context, in GuaNativeResetOptions options, GuaNativeResetReport* report);
 }

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -31,6 +31,38 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
         return RequestRawResult(new { type = "get_ui_tree" });
     }
 
+    public GuaContextStatus GetContextStatus()
+    {
+        var status = Request<ContextStatusResult>(new { type = "get_context_status" });
+        return new GuaContextStatus(
+            status.SessionEpoch, status.FrameSequence, status.Revision, status.NodeCount,
+            status.PendingRequestCount, status.InFlightRequestCount, status.UnconsumedEventCount,
+            status.LogCount, status.HasScreenshot, ActionOrNull(status.FirstPendingAction),
+            status.FirstPendingNodeId, ActionOrNull(status.FirstEventAction), status.FirstEventNodeId);
+    }
+
+    public GuaResetReport Reset(GuaResetOptions? options = null)
+    {
+        options ??= new GuaResetOptions();
+        var expectedEpoch = options.ExpectedSessionEpoch ?? GetContextStatus().SessionEpoch;
+        var report = Request<ResetReportResult>(new
+        {
+            type = "reset_context",
+            expectedSessionEpoch = expectedEpoch,
+            flags = (uint)options.Targets,
+            strict = options.Strict,
+        });
+        return new GuaResetReport(
+            (GuaResetResult)report.Result, report.PreviousSessionEpoch, report.SessionEpoch,
+            report.PendingRequestCount, report.InFlightRequestCount, report.UnconsumedEventCount,
+            report.DiscardedNodeCount, report.DiscardedPendingRequestCount, report.DiscardedInFlightRequestCount,
+            report.DiscardedEventCount, report.DiscardedLogCount, report.DiscardedScreenshot,
+            ActionOrNull(report.FirstPendingAction), report.FirstPendingNodeId,
+            ActionOrNull(report.FirstEventAction), report.FirstEventNodeId);
+    }
+
+    private static GuaActionType? ActionOrNull(int action) => action == 0 ? null : (GuaActionType)action;
+
     public string FindNodeById(string id)
     {
         return GetUiTree().FindNodeById(id)?.Id
@@ -375,4 +407,15 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
     private sealed record ActionRequestResult(ulong RequestId);
     private sealed record ActionEventResult(
         ulong RequestId, int Action, bool Succeeded, int Error, string NodeId, string Value, bool Sensitive);
+    private sealed record ContextStatusResult(
+        ulong SessionEpoch, ulong FrameSequence, ulong Revision, uint NodeCount,
+        uint PendingRequestCount, uint InFlightRequestCount, uint UnconsumedEventCount,
+        uint LogCount, bool HasScreenshot, int FirstPendingAction, string FirstPendingNodeId,
+        int FirstEventAction, string FirstEventNodeId);
+    private sealed record ResetReportResult(
+        int Result, ulong PreviousSessionEpoch, ulong SessionEpoch, uint PendingRequestCount,
+        uint InFlightRequestCount, uint UnconsumedEventCount, uint DiscardedNodeCount,
+        uint DiscardedPendingRequestCount, uint DiscardedInFlightRequestCount, uint DiscardedEventCount,
+        uint DiscardedLogCount, bool DiscardedScreenshot, int FirstPendingAction, string FirstPendingNodeId,
+        int FirstEventAction, string FirstEventNodeId);
 }

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteUiTree.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteUiTree.cs
@@ -4,6 +4,8 @@ public sealed class GuaRemoteUiTree
 {
     public int? SchemaVersion { get; set; }
 
+    public ulong? SessionEpoch { get; set; }
+
     public ulong? FrameSequence { get; set; }
 
     public ulong? Revision { get; set; }

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -156,6 +156,7 @@ public static class GuaAssertions
                 Checked: OptionalBoolean("checked"),
                 Selected: OptionalBoolean("selected"),
                 SchemaVersion: document.RootElement.TryGetProperty("schemaVersion", out var schemaVersion) ? schemaVersion.GetInt32() : null,
+                SessionEpoch: OptionalRootUInt64("sessionEpoch"),
                 FrameSequence: OptionalRootUInt64("frameSequence"),
                 Revision: OptionalRootUInt64("revision"));
         }

--- a/bindings/dotnet/src/Gua.Testing/GuaNodeSnapshot.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaNodeSnapshot.cs
@@ -19,5 +19,6 @@ public sealed record GuaNodeSnapshot(
     bool? Checked = null,
     bool? Selected = null,
     int? SchemaVersion = null,
+    ulong? SessionEpoch = null,
     ulong? FrameSequence = null,
     ulong? Revision = null);

--- a/bindings/dotnet/src/Gua.Testing/GuaTestSession.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaTestSession.cs
@@ -1,0 +1,53 @@
+using Gua.Core;
+
+namespace Gua.Testing;
+
+public sealed class GuaTestSession
+{
+    private readonly IGuaContext _context;
+
+    public GuaTestSession(IGuaContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public GuaContextStatus Inspect() => _context.GetContextStatus();
+
+    public void AssertClean()
+    {
+        var status = Inspect();
+        if (status.IsClean) return;
+        throw new GuaAssertionException(
+            $"Gua test session {status.SessionEpoch} is dirty: pending={status.PendingRequestCount}, " +
+            $"inFlight={status.InFlightRequestCount}, events={status.UnconsumedEventCount}, " +
+            $"firstRequest={status.FirstPendingAction}:{status.FirstPendingNodeId}, " +
+            $"firstEvent={status.FirstEventAction}:{status.FirstEventNodeId}. Payload values are redacted.");
+    }
+
+    public GuaResetReport Reset(GuaResetOptions? options = null)
+    {
+        options ??= new GuaResetOptions();
+        var status = Inspect();
+        var resolved = options with { ExpectedSessionEpoch = options.ExpectedSessionEpoch ?? status.SessionEpoch };
+        var report = _context.Reset(resolved);
+        if (report.Result == GuaResetResult.Dirty)
+        {
+            throw new GuaAssertionException(
+                $"Strict Gua reset rejected dirty session {report.SessionEpoch}: " +
+                $"pending={report.PendingRequestCount}, inFlight={report.InFlightRequestCount}, " +
+                $"events={report.UnconsumedEventCount}, firstRequest={report.FirstPendingAction}:{report.FirstPendingNodeId}, " +
+                $"firstEvent={report.FirstEventAction}:{report.FirstEventNodeId}. No state was discarded; payload values are redacted.");
+        }
+        if (report.Result == GuaResetResult.StaleEpoch)
+        {
+            throw new InvalidOperationException(
+                $"Gua reset rejected stale session epoch {resolved.ExpectedSessionEpoch}; current epoch is {report.SessionEpoch}.");
+        }
+        return report;
+    }
+
+    public Task<GuaResetReport> ResetAsync(GuaResetOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() => Reset(options), cancellationToken);
+    }
+}

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -50,6 +50,22 @@ GuaAssertions.GetById(ui, "start").ToBeVisible();
 ```
 
 See `examples/dotnet-nunit` for a complete NUnit project with multiple `[Test]`
+
+Use `GuaTestSession` as the explicit process-reuse boundary. The default reset
+clears semantic nodes, requests, events, and retained history while preserving
+logs and screenshots. Strict teardown detects leaked requests/events without
+discarding them:
+
+```csharp
+var session = new GuaTestSession(context);
+session.Reset(); // setup; starts a new session epoch
+// ...test...
+session.Reset(new GuaResetOptions(Strict: true)); // teardown; throws if dirty
+```
+
+`ResetAsync` provides the same contract for remote contexts and honors
+`CancellationToken`. Remote reset always includes the inspected session epoch,
+so a stale client cannot reset a newer shared runtime session.
 methods in one file.
 Semantic locators are strict: `GetBy*` fails when zero or multiple nodes match,
 while `QueryAll()` is the explicit multi-result API. String matching is exact by

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -52,6 +52,38 @@ public sealed class SelectorParityTests
         }
     }
 
+    [Test]
+    public void RemoteResetRejectsStaleEpochAndKeepsTheConnection()
+    {
+        var port = ReservePort();
+        var runtime = Native.gua_runtime_create();
+        Assert.That(runtime, Is.Not.EqualTo(nint.Zero));
+        try
+        {
+            Native.gua_runtime_begin_frame(runtime, "fixture");
+            Native.gua_runtime_register_node(runtime, "save", "button", "Save", new GuaBounds(0, 0, 1, 1), 1, 1);
+            Native.gua_runtime_end_frame(runtime);
+            Assert.That(Native.gua_runtime_start_inspector_bridge(runtime, port), Is.EqualTo(1));
+            using var remote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+
+            var first = remote.Reset(new GuaResetOptions(ExpectedSessionEpoch: 1));
+            var stale = remote.Reset(new GuaResetOptions(ExpectedSessionEpoch: 1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.Result, Is.EqualTo(GuaResetResult.Succeeded));
+                Assert.That(first.SessionEpoch, Is.EqualTo(2));
+                Assert.That(stale.Result, Is.EqualTo(GuaResetResult.StaleEpoch));
+                Assert.That(remote.GetContextStatus().SessionEpoch, Is.EqualTo(2));
+            });
+        }
+        finally
+        {
+            Native.gua_runtime_stop_inspector_bridge(runtime);
+            Native.gua_runtime_destroy(runtime);
+        }
+    }
+
     private static int ReservePort()
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/examples/dotnet-nunit/README.md
+++ b/examples/dotnet-nunit/README.md
@@ -29,3 +29,9 @@ dotnet pack bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release
 dotnet pack bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release
 dotnet test examples/dotnet-nunit/GuaDotNetNUnitSample.csproj
 ```
+
+For a Godot process or native runtime shared across tests, create a
+`GuaTestSession` in setup, call non-strict `Reset()` to start a new epoch, and
+use `Reset(new GuaResetOptions(Strict: true))` in teardown. Strict teardown
+reports leaked requests/events and leaves them intact for diagnosis. Logs and
+screenshots are preserved by default; select `GuaResetTargets.All` to clear them.

--- a/examples/dotnet-nunit/TitleScreenTests.cs
+++ b/examples/dotnet-nunit/TitleScreenTests.cs
@@ -164,6 +164,62 @@ public sealed class TitleScreenTests
         });
     }
 
+    [Test]
+    public void StrictSessionResetDetectsLeakWithoutDiscardingIt()
+    {
+        using var ui = new GuaContext();
+        var session = new GuaTestSession(ui);
+        ui.BeginFrame("form");
+        ui.RegisterNode(new GuaNodeDescriptor("password", "textbox", "Password", new GuaBounds(0, 0, 100, 20), Value: string.Empty));
+        ui.EndFrame();
+        Assert.That(GuaAssertions.GetById(ui, "password").SetValue("secret-marker", sensitive: true), Is.GreaterThan(0));
+
+        var error = Assert.Throws<GuaAssertionException>(() =>
+            session.Reset(new GuaResetOptions(Strict: true)));
+        Assert.That(error!.Message, Does.Contain("pending=1").And.Not.Contain("secret-marker"));
+        Assert.That(session.Inspect().PendingRequestCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void NonStrictResetStartsNewEpochAndPreservesOptionalStateByDefault()
+    {
+        using var ui = new GuaContext();
+        using var other = new GuaContext();
+        var session = new GuaTestSession(ui);
+        ui.BeginFrame("title");
+        ui.RegisterNode("start", "button", "Start", new GuaBounds(0, 0, 1, 1));
+        ui.EndFrame();
+        ui.AddLog(GuaLogLevel.Info, "keep");
+        ui.SetScreenshot("data:image/png;base64,AA==", 1, 1);
+        other.BeginFrame("other");
+        other.RegisterNode("other", "button", "Other", new GuaBounds(0, 0, 1, 1));
+        other.EndFrame();
+
+        var report = session.Reset();
+        var status = session.Inspect();
+        Assert.Multiple(() =>
+        {
+            Assert.That(report.Result, Is.EqualTo(GuaResetResult.Succeeded));
+            Assert.That(report.PreviousSessionEpoch, Is.EqualTo(1));
+            Assert.That(report.SessionEpoch, Is.EqualTo(2));
+            Assert.That(status.FrameSequence, Is.Zero);
+            Assert.That(status.Revision, Is.Zero);
+            Assert.That(status.NodeCount, Is.Zero);
+            Assert.That(status.LogCount, Is.EqualTo(1));
+            Assert.That(status.HasScreenshot, Is.True);
+            Assert.That(other.GetContextStatus().NodeCount, Is.EqualTo(1));
+        });
+
+        var cleared = session.Reset(new GuaResetOptions(GuaResetTargets.All));
+        Assert.Multiple(() =>
+        {
+            Assert.That(cleared.DiscardedLogCount, Is.EqualTo(1));
+            Assert.That(cleared.DiscardedScreenshot, Is.True);
+            Assert.That(session.Inspect().LogCount, Is.Zero);
+            Assert.That(session.Inspect().HasScreenshot, Is.False);
+        });
+    }
+
     private static void RenderTitle(GuaTestHost host, bool loading)
     {
         host.Frame(loading ? "loading" : "title", frame =>

--- a/examples/godot-gdscript/README.md
+++ b/examples/godot-gdscript/README.md
@@ -50,6 +50,12 @@ actions through the real controls. The v1 matrix covers focus, `LineEdit` /
 `TabContainer` selection, `ScrollContainer`, and key input. Every requested host
 operation emits an observed result carrying the same `requestId`.
 
+`GuaAutoAdapter.reset_context()` resets the shared runtime context and its
+temporary control/request-dispatch caches as one operation. Strict reset first
+checks pending/in-flight requests and unconsumed events and changes nothing when
+it reports a leak. The default preserves logs and screenshots; all clients of
+the same runtime observe the new `sessionEpoch`.
+
 For a headless smoke check of the load-order-safe path:
 
 ```powershell

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -20,6 +20,8 @@ const REQUIRED_CONTEXT_METHODS := [
 	"consume_action_request",
 	"emit_action_result",
 	"poll_event_v2",
+	"get_context_status",
+	"reset_context",
 	"start_inspector_bridge",
 	"inspector_bridge_url",
 ]
@@ -101,6 +103,26 @@ func poll_event_v2() -> Dictionary:
 	if not _ensure_context():
 		return {}
 	return context.poll_event_v2()
+
+
+func get_context_status() -> Dictionary:
+	if not _ensure_context():
+		return {}
+	return context.get_context_status()
+
+
+func reset_context(options: Dictionary = {}) -> Dictionary:
+	if not _ensure_context():
+		return {"result": -1}
+	var resolved := options.duplicate()
+	if not resolved.has("expected_session_epoch"):
+		resolved["expected_session_epoch"] = context.get_context_status().get("session_epoch", 0)
+	var report: Dictionary = context.reset_context(resolved)
+	if report.get("result", -1) == 1:
+		buttons_by_id.clear()
+		controls_by_id.clear()
+		suppressed_clicks.clear()
+	return report
 
 
 func _ensure_context() -> bool:

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -187,6 +187,27 @@ func _run() -> void:
 		_fail("Gua smoke leaked a sensitive value in the semantic UI tree.")
 		return
 
+	var leaked := ui.enqueue_action({"action": "focus", "node_id": "start"})
+	if leaked.get("request_id", 0) == 0:
+		_fail("Gua smoke could not create a pending request for reset validation.")
+		return
+	var before_reset := ui.get_context_status()
+	var strict_report := ui.reset_context({"strict": true, "expected_session_epoch": before_reset.get("session_epoch", 0)})
+	if strict_report.get("result", 0) != -2 or ui.get_context_status().get("pending_request_count", 0) != 1:
+		_fail("Gua strict reset discarded or missed a pending request: %s" % strict_report)
+		return
+	var reset_report := ui.reset_context({"expected_session_epoch": before_reset.get("session_epoch", 0)})
+	var after_reset := ui.get_context_status()
+	if reset_report.get("result", 0) != 1 or after_reset.get("session_epoch", 0) != before_reset.get("session_epoch", 0) + 1:
+		_fail("Gua reset did not advance the session epoch: %s / %s" % [reset_report, after_reset])
+		return
+	if after_reset.get("frame_sequence", -1) != 0 or after_reset.get("revision", -1) != 0:
+		_fail("Gua reset did not initialize frame/revision metadata: %s" % after_reset)
+		return
+	if not ui.buttons_by_id.is_empty() or not ui.controls_by_id.is_empty() or not ui.suppressed_clicks.is_empty():
+		_fail("Gua adapter temporary caches survived a successful reset.")
+		return
+
 	print("Gua GDScript smoke passed.")
 	quit(0)
 

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -96,6 +96,67 @@ typedef struct gua_event_v2_t {
     int sensitive;
 } gua_event_v2_t;
 
+enum {
+    GUA_RESET_NODES = 1U << 0,
+    GUA_RESET_REQUESTS = 1U << 1,
+    GUA_RESET_EVENTS = 1U << 2,
+    GUA_RESET_HISTORY = 1U << 3,
+    GUA_RESET_LOGS = 1U << 4,
+    GUA_RESET_SCREENSHOT = 1U << 5,
+    GUA_RESET_DEFAULT = GUA_RESET_NODES | GUA_RESET_REQUESTS | GUA_RESET_EVENTS | GUA_RESET_HISTORY
+};
+
+enum {
+    GUA_RESET_SUCCEEDED = 1,
+    GUA_RESET_ERROR_INVALID_ARGUMENT = -1,
+    GUA_RESET_ERROR_DIRTY = -2,
+    GUA_RESET_ERROR_STALE_EPOCH = -3
+};
+
+typedef struct gua_context_status_t {
+    uint32_t struct_size;
+    uint64_t session_epoch;
+    uint64_t frame_sequence;
+    uint64_t revision;
+    uint32_t node_count;
+    uint32_t pending_request_count;
+    uint32_t in_flight_request_count;
+    uint32_t unconsumed_event_count;
+    uint32_t log_count;
+    int has_screenshot;
+    int first_pending_action;
+    char first_pending_node_id[128];
+    int first_event_action;
+    char first_event_node_id[128];
+} gua_context_status_t;
+
+typedef struct gua_reset_options_t {
+    uint32_t struct_size;
+    uint32_t flags;
+    int strict;
+    uint64_t expected_session_epoch;
+} gua_reset_options_t;
+
+typedef struct gua_reset_report_t {
+    uint32_t struct_size;
+    int result;
+    uint64_t previous_session_epoch;
+    uint64_t session_epoch;
+    uint32_t pending_request_count;
+    uint32_t in_flight_request_count;
+    uint32_t unconsumed_event_count;
+    uint32_t discarded_node_count;
+    uint32_t discarded_pending_request_count;
+    uint32_t discarded_in_flight_request_count;
+    uint32_t discarded_event_count;
+    uint32_t discarded_log_count;
+    int discarded_screenshot;
+    int first_pending_action;
+    char first_pending_node_id[128];
+    int first_event_action;
+    char first_event_node_id[128];
+} gua_reset_report_t;
+
 typedef struct gua_node_state_t {
     int visible;
     int enabled;
@@ -232,6 +293,8 @@ int gua_consume_action_request(gua_context_t* ctx, int action, const char* node_
 int gua_emit_action_result(gua_context_t* ctx, const gua_action_result_t* result);
 int gua_poll_event_v2(gua_context_t* ctx, gua_event_v2_t* out_event);
 int gua_poll_event_v2_for_request(gua_context_t* ctx, uint64_t request_id, gua_event_v2_t* out_event);
+int gua_get_context_status(gua_context_t* ctx, gua_context_status_t* out_status);
+int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* options, gua_reset_report_t* out_report);
 
 #ifdef __cplusplus
 }

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -270,6 +270,7 @@ struct gua_context_t {
     unsigned long long frame_sequence = 0;
     unsigned long long revision = 0;
     unsigned long long next_request_id = 1;
+    unsigned long long session_epoch = 1;
     std::string previous_semantic_snapshot;
 };
 
@@ -364,8 +365,23 @@ std::string build_ui_tree_json(const gua_context_t& ctx)
 {
     std::string semantic = build_semantic_snapshot_json(ctx);
     semantic.erase(semantic.begin());
-    return "{\"schemaVersion\":2,\"frameSequence\":" + std::to_string(ctx.frame_sequence) +
+    return "{\"schemaVersion\":2,\"sessionEpoch\":" + std::to_string(ctx.session_epoch) +
+        ",\"frameSequence\":" + std::to_string(ctx.frame_sequence) +
         ",\"revision\":" + std::to_string(ctx.revision) + "," + semantic;
+}
+
+void fill_reset_summary(const gua_context_t& ctx, gua_reset_report_t& report)
+{
+    const ActionRequest* request = !ctx.action_requests.empty() ? &ctx.action_requests.front()
+        : (!ctx.consumed_requests.empty() ? &ctx.consumed_requests.front() : nullptr);
+    if (request != nullptr) {
+        report.first_pending_action = request->action;
+        std::snprintf(report.first_pending_node_id, sizeof(report.first_pending_node_id), "%s", request->node_id.c_str());
+    }
+    if (!ctx.events.empty()) {
+        report.first_event_action = ctx.events.front().action;
+        std::snprintf(report.first_event_node_id, sizeof(report.first_event_node_id), "%s", ctx.events.front().node_id.c_str());
+    }
 }
 
 std::string build_logs_json(const gua_context_t& ctx)
@@ -874,4 +890,94 @@ extern "C" int gua_poll_event_v2_for_request(gua_context_t* ctx, uint64_t reques
     std::snprintf(out_event->value, sizeof(out_event->value), "%s", event.value.c_str());
     out_event->sensitive = event.sensitive ? 1 : 0;
     return 1;
+}
+
+extern "C" int gua_get_context_status(gua_context_t* ctx, gua_context_status_t* out_status)
+{
+    if (ctx == nullptr || out_status == nullptr || out_status->struct_size < sizeof(gua_context_status_t)) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    out_status->session_epoch = ctx->session_epoch;
+    out_status->frame_sequence = ctx->frame_sequence;
+    out_status->revision = ctx->revision;
+    out_status->node_count = static_cast<uint32_t>(ctx->nodes.size());
+    out_status->pending_request_count = static_cast<uint32_t>(ctx->action_requests.size());
+    out_status->in_flight_request_count = static_cast<uint32_t>(ctx->consumed_requests.size());
+    out_status->unconsumed_event_count = static_cast<uint32_t>(ctx->events.size());
+    out_status->log_count = static_cast<uint32_t>(ctx->logs.size());
+    out_status->has_screenshot = ctx->screenshot.data_uri.empty() ? 0 : 1;
+    out_status->first_pending_action = 0;
+    out_status->first_pending_node_id[0] = '\0';
+    out_status->first_event_action = 0;
+    out_status->first_event_node_id[0] = '\0';
+    gua_reset_report_t summary { sizeof(gua_reset_report_t) };
+    fill_reset_summary(*ctx, summary);
+    out_status->first_pending_action = summary.first_pending_action;
+    std::snprintf(out_status->first_pending_node_id, sizeof(out_status->first_pending_node_id), "%s", summary.first_pending_node_id);
+    out_status->first_event_action = summary.first_event_action;
+    std::snprintf(out_status->first_event_node_id, sizeof(out_status->first_event_node_id), "%s", summary.first_event_node_id);
+    return 1;
+}
+
+extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* options, gua_reset_report_t* out_report)
+{
+    if (ctx == nullptr || options == nullptr || options->struct_size < sizeof(gua_reset_options_t) ||
+        out_report == nullptr || out_report->struct_size < sizeof(gua_reset_report_t)) return GUA_RESET_ERROR_INVALID_ARGUMENT;
+    const uint32_t known_flags = GUA_RESET_NODES | GUA_RESET_REQUESTS | GUA_RESET_EVENTS | GUA_RESET_HISTORY | GUA_RESET_LOGS | GUA_RESET_SCREENSHOT;
+    if ((options->flags & ~known_flags) != 0U) return GUA_RESET_ERROR_INVALID_ARGUMENT;
+
+    const std::lock_guard lock(ctx->mutex);
+    *out_report = gua_reset_report_t { sizeof(gua_reset_report_t) };
+    out_report->previous_session_epoch = ctx->session_epoch;
+    out_report->session_epoch = ctx->session_epoch;
+    out_report->pending_request_count = static_cast<uint32_t>(ctx->action_requests.size());
+    out_report->in_flight_request_count = static_cast<uint32_t>(ctx->consumed_requests.size());
+    out_report->unconsumed_event_count = static_cast<uint32_t>(ctx->events.size());
+    fill_reset_summary(*ctx, *out_report);
+
+    if (options->expected_session_epoch != 0 && options->expected_session_epoch != ctx->session_epoch) {
+        out_report->result = GUA_RESET_ERROR_STALE_EPOCH;
+        return out_report->result;
+    }
+    const bool dirty_requests = (options->flags & GUA_RESET_REQUESTS) != 0U &&
+        (!ctx->action_requests.empty() || !ctx->consumed_requests.empty());
+    const bool dirty_events = (options->flags & GUA_RESET_EVENTS) != 0U && !ctx->events.empty();
+    if (options->strict != 0 && (dirty_requests || dirty_events)) {
+        out_report->result = GUA_RESET_ERROR_DIRTY;
+        return out_report->result;
+    }
+
+    out_report->discarded_node_count = (options->flags & GUA_RESET_NODES) != 0U ? static_cast<uint32_t>(ctx->nodes.size()) : 0;
+    out_report->discarded_pending_request_count = (options->flags & GUA_RESET_REQUESTS) != 0U ? static_cast<uint32_t>(ctx->action_requests.size()) : 0;
+    out_report->discarded_in_flight_request_count = (options->flags & GUA_RESET_REQUESTS) != 0U ? static_cast<uint32_t>(ctx->consumed_requests.size()) : 0;
+    out_report->discarded_event_count = (options->flags & GUA_RESET_EVENTS) != 0U ? static_cast<uint32_t>(ctx->events.size()) : 0;
+    out_report->discarded_log_count = (options->flags & GUA_RESET_LOGS) != 0U ? static_cast<uint32_t>(ctx->logs.size()) : 0;
+    out_report->discarded_screenshot = (options->flags & GUA_RESET_SCREENSHOT) != 0U && !ctx->screenshot.data_uri.empty() ? 1 : 0;
+
+    if ((options->flags & GUA_RESET_NODES) != 0U) {
+        ctx->screen = "unknown";
+        ctx->nodes.clear();
+    }
+    if ((options->flags & GUA_RESET_REQUESTS) != 0U) {
+        ctx->action_requests.clear();
+        ctx->consumed_requests.clear();
+    }
+    if ((options->flags & GUA_RESET_EVENTS) != 0U) ctx->events.clear();
+    if ((options->flags & GUA_RESET_LOGS) != 0U) {
+        ctx->logs.clear();
+        ctx->next_log_sequence = 1;
+        ctx->logs_json_cache.clear();
+    }
+    if ((options->flags & GUA_RESET_SCREENSHOT) != 0U) {
+        ctx->screenshot = Screenshot {};
+        ctx->screenshot_json_cache.clear();
+    }
+    ctx->frame_sequence = 0;
+    ctx->revision = 0;
+    ctx->previous_semantic_snapshot.clear();
+    ctx->json_cache.clear();
+    ++ctx->session_epoch;
+    ctx->next_request_id = 1;
+    out_report->session_epoch = ctx->session_epoch;
+    out_report->result = GUA_RESET_SUCCEEDED;
+    return out_report->result;
 }

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -42,6 +42,7 @@ int main()
     gua_end_frame(context);
     const std::string first = gua_get_ui_tree_json(context);
     assert(first.find("\"schemaVersion\":2") != std::string::npos);
+    assert(first.find("\"sessionEpoch\":1") != std::string::npos);
     assert(first.find("\"frameSequence\":1") != std::string::npos);
     assert(first.find("\"revision\":1") != std::string::npos);
     assert(first.find("\"parentId\":\"form\"") != std::string::npos);
@@ -139,6 +140,68 @@ int main()
     assert(event.status == GUA_ACTION_STATUS_SUCCEEDED);
     assert(event.sensitive == 1);
     assert(std::strlen(event.value) == 0);
+
+    gua_action_request_t in_flight { sizeof(gua_action_request_t) };
+    assert(gua_consume_action_request(context, GUA_ACTION_FOCUS, "name", &in_flight) == 1);
+
+    gua_context_status_t status { sizeof(gua_context_status_t) };
+    assert(gua_get_context_status(context, &status) == 1);
+    assert(status.session_epoch == 1);
+    assert(status.pending_request_count == 4);
+    assert(status.in_flight_request_count == 1);
+    assert(status.unconsumed_event_count == 0);
+    assert(status.first_pending_action == GUA_ACTION_SET_CHECKED);
+    assert(std::strcmp(status.first_pending_node_id, "remember") == 0);
+
+    gua_reset_report_t report { sizeof(gua_reset_report_t) };
+    const gua_reset_options_t strict_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 1, 1 };
+    assert(gua_reset_context(context, &strict_reset, &report) == GUA_RESET_ERROR_DIRTY);
+    assert(report.session_epoch == 1);
+    assert(report.pending_request_count == 4);
+    assert(report.in_flight_request_count == 1);
+    assert(report.discarded_pending_request_count == 0);
+    assert(gua_get_context_status(context, &status) == 1);
+    assert(status.pending_request_count == 4);
+    assert(status.in_flight_request_count == 1);
+
+    gua_context_t* other = gua_create_context();
+    gua_begin_frame(other, "other");
+    gua_register_node(other, "other", "button", "Other", { 0, 0, 1, 1 }, 1, 1);
+    gua_end_frame(other);
+
+    report = gua_reset_report_t { sizeof(gua_reset_report_t) };
+    const gua_reset_options_t stale_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 2 };
+    assert(gua_reset_context(context, &stale_reset, &report) == GUA_RESET_ERROR_STALE_EPOCH);
+    assert(report.session_epoch == 1);
+
+    report = gua_reset_report_t { sizeof(gua_reset_report_t) };
+    const gua_reset_options_t reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 1 };
+    assert(gua_reset_context(context, &reset, &report) == GUA_RESET_SUCCEEDED);
+    assert(report.previous_session_epoch == 1 && report.session_epoch == 2);
+    assert(report.discarded_pending_request_count == 4);
+    assert(report.discarded_in_flight_request_count == 1);
+    assert(gua_get_context_status(context, &status) == 1);
+    assert(status.session_epoch == 2 && status.frame_sequence == 0 && status.revision == 0);
+    assert(status.node_count == 0 && status.pending_request_count == 0 && status.unconsumed_event_count == 0);
+    assert(std::string(gua_get_ui_tree_json(context)).find("\"sessionEpoch\":2") != std::string::npos);
+    char other_id[16] {};
+    assert(gua_find_node_by_id(other, "other", other_id, sizeof(other_id)) == 1);
+
+    const gua_action_result_t unsolicited { sizeof(gua_action_result_t), 0, GUA_ACTION_FOCUS,
+        GUA_ACTION_STATUS_SUCCEEDED, 0, "focus-target", nullptr, 0 };
+    assert(gua_emit_action_result(context, &unsolicited) == 1);
+    report = gua_reset_report_t { sizeof(gua_reset_report_t) };
+    const gua_reset_options_t strict_events { sizeof(gua_reset_options_t), GUA_RESET_EVENTS, 1, 2 };
+    assert(gua_reset_context(context, &strict_events, &report) == GUA_RESET_ERROR_DIRTY);
+    assert(report.unconsumed_event_count == 1);
+    assert(report.discarded_event_count == 0);
+    assert(report.first_event_action == GUA_ACTION_FOCUS);
+    assert(std::strcmp(report.first_event_node_id, "focus-target") == 0);
+    gua_event_v2_t preserved_event { sizeof(gua_event_v2_t) };
+    assert(gua_poll_event_v2(context, &preserved_event) == 1);
+    assert(preserved_event.action == GUA_ACTION_FOCUS);
+
+    gua_destroy_context(other);
 
     gua_destroy_context(context);
     return 0;

--- a/native/gua-godot/README.md
+++ b/native/gua-godot/README.md
@@ -37,3 +37,7 @@ rebuild this target and use the DLL emitted into `examples/godot-gdscript/addons
 
 The GDExtension is intentionally thin. It does not reimplement Gua runtime
 behavior and does not turn Gua into a Godot UI framework or editor MCP.
+
+`get_context_status` and `reset_context` expose the shared C ABI isolation
+contract. Use the higher-level auto adapter when control lookup and suppressed
+click caches must be cleared together with the runtime context.

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -36,6 +36,8 @@ public:
     Dictionary consume_action_request(const String& action, const String& node_id);
     bool emit_action_result(const Dictionary& result);
     Dictionary poll_event_v2();
+    Dictionary get_context_status() const;
+    Dictionary reset_context(const Dictionary& options = Dictionary());
     bool start_inspector_bridge(int port = 8765);
     void stop_inspector_bridge();
     bool inspector_bridge_running() const;

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -289,6 +289,57 @@ Dictionary GuaContext::poll_event_v2()
     return result;
 }
 
+Dictionary GuaContext::get_context_status() const
+{
+    gua_context_status_t status { sizeof(gua_context_status_t) };
+    if (gua_runtime_get_context_status(runtime_, &status) == 0) return Dictionary();
+    Dictionary result;
+    result["session_epoch"] = status.session_epoch;
+    result["frame_sequence"] = status.frame_sequence;
+    result["revision"] = status.revision;
+    result["node_count"] = status.node_count;
+    result["pending_request_count"] = status.pending_request_count;
+    result["in_flight_request_count"] = status.in_flight_request_count;
+    result["unconsumed_event_count"] = status.unconsumed_event_count;
+    result["log_count"] = status.log_count;
+    result["has_screenshot"] = status.has_screenshot != 0;
+    result["first_pending_action"] = action_name(status.first_pending_action);
+    result["first_pending_node_id"] = String::utf8(status.first_pending_node_id);
+    result["first_event_action"] = action_name(status.first_event_action);
+    result["first_event_node_id"] = String::utf8(status.first_event_node_id);
+    return result;
+}
+
+Dictionary GuaContext::reset_context(const Dictionary& source)
+{
+    const gua_reset_options_t options {
+        sizeof(gua_reset_options_t),
+        static_cast<uint32_t>(static_cast<int64_t>(source.get("flags", GUA_RESET_DEFAULT))),
+        source.get("strict", false) ? 1 : 0,
+        static_cast<uint64_t>(static_cast<int64_t>(source.get("expected_session_epoch", 0))),
+    };
+    gua_reset_report_t report { sizeof(gua_reset_report_t) };
+    const int code = gua_runtime_reset_context(runtime_, &options, &report);
+    Dictionary result;
+    result["result"] = code;
+    result["previous_session_epoch"] = report.previous_session_epoch;
+    result["session_epoch"] = report.session_epoch;
+    result["pending_request_count"] = report.pending_request_count;
+    result["in_flight_request_count"] = report.in_flight_request_count;
+    result["unconsumed_event_count"] = report.unconsumed_event_count;
+    result["discarded_node_count"] = report.discarded_node_count;
+    result["discarded_pending_request_count"] = report.discarded_pending_request_count;
+    result["discarded_in_flight_request_count"] = report.discarded_in_flight_request_count;
+    result["discarded_event_count"] = report.discarded_event_count;
+    result["discarded_log_count"] = report.discarded_log_count;
+    result["discarded_screenshot"] = report.discarded_screenshot != 0;
+    result["first_pending_action"] = action_name(report.first_pending_action);
+    result["first_pending_node_id"] = String::utf8(report.first_pending_node_id);
+    result["first_event_action"] = action_name(report.first_event_action);
+    result["first_event_node_id"] = String::utf8(report.first_event_node_id);
+    return result;
+}
+
 bool GuaContext::start_inspector_bridge(int port)
 {
     return gua_runtime_start_inspector_bridge(runtime_, port) != 0;
@@ -333,6 +384,8 @@ void GuaContext::_bind_methods()
     ClassDB::bind_method(D_METHOD("consume_action_request", "action", "node_id"), &GuaContext::consume_action_request);
     ClassDB::bind_method(D_METHOD("emit_action_result", "result"), &GuaContext::emit_action_result);
     ClassDB::bind_method(D_METHOD("poll_event_v2"), &GuaContext::poll_event_v2);
+    ClassDB::bind_method(D_METHOD("get_context_status"), &GuaContext::get_context_status);
+    ClassDB::bind_method(D_METHOD("reset_context", "options"), &GuaContext::reset_context, DEFVAL(Dictionary()));
     ClassDB::bind_method(D_METHOD("start_inspector_bridge", "port"), &GuaContext::start_inspector_bridge, DEFVAL(8765));
     ClassDB::bind_method(D_METHOD("stop_inspector_bridge"), &GuaContext::stop_inspector_bridge);
     ClassDB::bind_method(D_METHOD("inspector_bridge_running"), &GuaContext::inspector_bridge_running);

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -50,6 +50,8 @@ int gua_runtime_consume_action_request(gua_runtime_t* runtime, int action, const
 int gua_runtime_emit_action_result(gua_runtime_t* runtime, const gua_action_result_t* result);
 int gua_runtime_poll_event_v2(gua_runtime_t* runtime, gua_event_v2_t* out_event);
 int gua_runtime_poll_event_v2_for_request(gua_runtime_t* runtime, uint64_t request_id, gua_event_v2_t* out_event);
+int gua_runtime_get_context_status(gua_runtime_t* runtime, gua_context_status_t* out_status);
+int gua_runtime_reset_context(gua_runtime_t* runtime, const gua_reset_options_t* options, gua_reset_report_t* out_report);
 
 int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int port);
 void gua_runtime_stop_inspector_bridge(gua_runtime_t* runtime);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -21,6 +21,8 @@ struct gua_runtime_t {
     std::string screenshot_json;
 };
 
+std::string escape_json(std::string_view value);
+
 namespace {
 
 bool valid_runtime(gua_runtime_t* runtime)
@@ -53,6 +55,50 @@ std::string copy_screenshot_json(gua_runtime_t* runtime)
 {
     const std::lock_guard lock(runtime->context_mutex);
     return gua_get_screenshot_json(runtime->context);
+}
+
+std::string status_json(gua_runtime_t* runtime)
+{
+    gua_context_status_t status { sizeof(gua_context_status_t) };
+    const std::lock_guard lock(runtime->context_mutex);
+    if (gua_get_context_status(runtime->context, &status) == 0) return "null";
+    return "{\"sessionEpoch\":" + std::to_string(status.session_epoch) +
+        ",\"frameSequence\":" + std::to_string(status.frame_sequence) +
+        ",\"revision\":" + std::to_string(status.revision) +
+        ",\"nodeCount\":" + std::to_string(status.node_count) +
+        ",\"pendingRequestCount\":" + std::to_string(status.pending_request_count) +
+        ",\"inFlightRequestCount\":" + std::to_string(status.in_flight_request_count) +
+        ",\"unconsumedEventCount\":" + std::to_string(status.unconsumed_event_count) +
+        ",\"logCount\":" + std::to_string(status.log_count) +
+        ",\"hasScreenshot\":" + (status.has_screenshot != 0 ? "true" : "false") +
+        ",\"firstPendingAction\":" + std::to_string(status.first_pending_action) +
+        ",\"firstPendingNodeId\":\"" + escape_json(status.first_pending_node_id) + "\"" +
+        ",\"firstEventAction\":" + std::to_string(status.first_event_action) +
+        ",\"firstEventNodeId\":\"" + escape_json(status.first_event_node_id) + "\"}";
+}
+
+std::string reset_report_json(gua_runtime_t* runtime, unsigned long long expected_epoch, unsigned int flags, bool strict)
+{
+    gua_reset_options_t options { sizeof(gua_reset_options_t), flags, strict ? 1 : 0, expected_epoch };
+    gua_reset_report_t report { sizeof(gua_reset_report_t) };
+    const std::lock_guard lock(runtime->context_mutex);
+    const int result = gua_reset_context(runtime->context, &options, &report);
+    return "{\"result\":" + std::to_string(result) +
+        ",\"previousSessionEpoch\":" + std::to_string(report.previous_session_epoch) +
+        ",\"sessionEpoch\":" + std::to_string(report.session_epoch) +
+        ",\"pendingRequestCount\":" + std::to_string(report.pending_request_count) +
+        ",\"inFlightRequestCount\":" + std::to_string(report.in_flight_request_count) +
+        ",\"unconsumedEventCount\":" + std::to_string(report.unconsumed_event_count) +
+        ",\"discardedNodeCount\":" + std::to_string(report.discarded_node_count) +
+        ",\"discardedPendingRequestCount\":" + std::to_string(report.discarded_pending_request_count) +
+        ",\"discardedInFlightRequestCount\":" + std::to_string(report.discarded_in_flight_request_count) +
+        ",\"discardedEventCount\":" + std::to_string(report.discarded_event_count) +
+        ",\"discardedLogCount\":" + std::to_string(report.discarded_log_count) +
+        ",\"discardedScreenshot\":" + (report.discarded_screenshot != 0 ? "true" : "false") +
+        ",\"firstPendingAction\":" + std::to_string(report.first_pending_action) +
+        ",\"firstPendingNodeId\":\"" + escape_json(report.first_pending_node_id) + "\"" +
+        ",\"firstEventAction\":" + std::to_string(report.first_event_action) +
+        ",\"firstEventNodeId\":\"" + escape_json(report.first_event_node_id) + "\"}";
 }
 
 } // namespace
@@ -318,8 +364,14 @@ std::string escape_json(std::string_view value)
 {
     std::string escaped;
     for (char ch : value) {
-        if (ch == '\\' || ch == '"') escaped.push_back('\\');
-        escaped.push_back(ch);
+        switch (ch) {
+        case '\\': escaped += "\\\\"; break;
+        case '"': escaped += "\\\""; break;
+        case '\n': escaped += "\\n"; break;
+        case '\r': escaped += "\\r"; break;
+        case '\t': escaped += "\\t"; break;
+        default: escaped.push_back(ch); break;
+        }
     }
     return escaped;
 }
@@ -359,6 +411,20 @@ extern "C" int gua_runtime_poll_event_v2_for_request(gua_runtime_t* runtime, uin
     return gua_poll_event_v2_for_request(runtime->context, request_id, out_event);
 }
 
+extern "C" int gua_runtime_get_context_status(gua_runtime_t* runtime, gua_context_status_t* out_status)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_get_context_status(runtime->context, out_status);
+}
+
+extern "C" int gua_runtime_reset_context(gua_runtime_t* runtime, const gua_reset_options_t* options, gua_reset_report_t* out_report)
+{
+    if (!valid_runtime(runtime)) return GUA_RESET_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_reset_context(runtime->context, options, out_report);
+}
+
 extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int port)
 {
     if (!valid_runtime(runtime) || port <= 0 || port > 65535) {
@@ -396,6 +462,10 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
             gua_query_nodes_json(runtime->context, &native, json.data(), size);
             json.resize(static_cast<std::size_t>(size - 1));
             return json;
+        },
+        .get_context_status_json = [runtime] { return status_json(runtime); },
+        .reset_context_json = [runtime](unsigned long long expected_epoch, unsigned int flags, bool strict) {
+            return reset_report_json(runtime, expected_epoch, flags, strict);
         },
         .click_node = [runtime](std::string_view node_id) {
             const std::string id(node_id);

--- a/native/gua-testing/include/gua/testing.hpp
+++ b/native/gua-testing/include/gua/testing.hpp
@@ -301,4 +301,43 @@ inline Locator wait_for_text(gua_context_t* context, std::string_view text, std:
     throw std::runtime_error("Timed out waiting for Gua node by text: " + text_buffer);
 }
 
+class TestSession {
+public:
+    explicit TestSession(gua_context_t* context) : context_(context)
+    {
+        if (context_ == nullptr) throw std::invalid_argument("Gua TestSession requires a context");
+    }
+
+    [[nodiscard]] gua_context_status_t inspect() const
+    {
+        gua_context_status_t status { sizeof(gua_context_status_t) };
+        if (gua_get_context_status(context_, &status) == 0) throw std::runtime_error("Failed to inspect Gua context");
+        return status;
+    }
+
+    void assert_clean() const
+    {
+        const auto status = inspect();
+        if (status.pending_request_count == 0 && status.in_flight_request_count == 0 && status.unconsumed_event_count == 0) return;
+        throw std::runtime_error("Dirty Gua test session: pending=" + std::to_string(status.pending_request_count) +
+            ", in-flight=" + std::to_string(status.in_flight_request_count) + ", events=" +
+            std::to_string(status.unconsumed_event_count) + ", first request=" + status.first_pending_node_id +
+            ". Payload values are redacted.");
+    }
+
+    [[nodiscard]] gua_reset_report_t reset(bool strict = false, std::uint32_t flags = GUA_RESET_DEFAULT) const
+    {
+        const auto status = inspect();
+        const gua_reset_options_t options { sizeof(gua_reset_options_t), flags, strict ? 1 : 0, status.session_epoch };
+        gua_reset_report_t report { sizeof(gua_reset_report_t) };
+        const int result = gua_reset_context(context_, &options, &report);
+        if (result == GUA_RESET_ERROR_DIRTY) throw std::runtime_error("Strict Gua reset rejected dirty state without discarding it");
+        if (result != GUA_RESET_SUCCEEDED) throw std::runtime_error("Gua reset failed: " + std::to_string(result));
+        return report;
+    }
+
+private:
+    gua_context_t* context_;
+};
+
 } // namespace gua::testing

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -40,6 +40,8 @@ struct BridgeHandlers {
     std::function<std::string()> get_logs_json;
     std::function<std::string()> get_screenshot_json;
     std::function<std::string(const QuerySelector& selector)> query_nodes_json;
+    std::function<std::string()> get_context_status_json;
+    std::function<std::string(unsigned long long expected_epoch, unsigned int flags, bool strict)> reset_context_json;
     std::function<bool(std::string_view node_id)> click_node;
     std::function<bool(std::string_view node_id)> focus_node;
     std::function<bool(std::string_view key)> press_key;

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -39,6 +39,9 @@ struct Command {
     bool sensitive = false;
     int scroll_unit = 0;
     unsigned long long request_id = 0;
+    unsigned long long expected_session_epoch = 0;
+    unsigned int reset_flags = 15;
+    bool strict = false;
 };
 
 struct ClientConnection {
@@ -543,6 +546,9 @@ Command parse_command(std::string_view json)
     command.sensitive = json_bool_field(json, "sensitive");
     command.scroll_unit = json_int_field(json, "scrollUnit").value_or(0);
     command.request_id = json_uint64_field(json, "requestId").value_or(0);
+    command.expected_session_epoch = json_uint64_field(json, "expectedSessionEpoch").value_or(0);
+    command.reset_flags = static_cast<unsigned int>(json_int_field(json, "flags").value_or(15));
+    command.strict = json_bool_field(json, "strict");
     return command;
 }
 
@@ -816,6 +822,17 @@ private:
                     return error_response(command.id, "query_nodes is not supported by this bridge");
                 }
                 return ok_response(command.id, handlers_.query_nodes_json(command.selector));
+            }
+            if (command.type == "get_context_status") {
+                return handlers_.get_context_status_json
+                    ? ok_response(command.id, handlers_.get_context_status_json())
+                    : error_response(command.id, "get_context_status is not supported by this bridge");
+            }
+            if (command.type == "reset_context") {
+                if (!handlers_.reset_context_json) return error_response(command.id, "reset_context is not supported by this bridge");
+                if (command.expected_session_epoch == 0) return error_response(command.id, "reset_context requires expectedSessionEpoch");
+                return ok_response(command.id, handlers_.reset_context_json(
+                    command.expected_session_epoch, command.reset_flags, command.strict));
             }
             if (command.type == "poll_events") {
                 return handlers_.poll_action_event_json

--- a/protocol/fixtures/reset-context-v1.json
+++ b/protocol/fixtures/reset-context-v1.json
@@ -1,0 +1,6 @@
+{
+  "type": "reset_context",
+  "expectedSessionEpoch": 7,
+  "flags": 15,
+  "strict": true
+}

--- a/protocol/fixtures/ui-tree-v2.json
+++ b/protocol/fixtures/ui-tree-v2.json
@@ -1,5 +1,6 @@
 {
   "schemaVersion": 2,
+  "sessionEpoch": 1,
   "frameSequence": 12,
   "revision": 4,
   "screen": "settings",

--- a/protocol/schema/commands.schema.json
+++ b/protocol/schema/commands.schema.json
@@ -10,6 +10,7 @@
     { "$ref": "#/$defs/checkedAction" },
     { "$ref": "#/$defs/selectAction" },
     { "$ref": "#/$defs/scrollAction" },
+    { "$ref": "#/$defs/resetContext" },
     { "$ref": "#/$defs/textInput" },
     { "$ref": "#/$defs/moveGamepad" },
     { "$ref": "#/$defs/simpleCommand" }
@@ -95,6 +96,17 @@
         "requestId": { "type": "integer", "minimum": 1 }
       }
     },
+    "resetContext": {
+      "type": "object",
+      "required": ["type", "expectedSessionEpoch"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "reset_context" },
+        "expectedSessionEpoch": { "type": "integer", "minimum": 1 },
+        "flags": { "type": "integer", "minimum": 0, "maximum": 63, "default": 15 },
+        "strict": { "type": "boolean", "default": false }
+      }
+    },
     "textInput": {
       "type": "object",
       "required": ["type", "text"],
@@ -120,7 +132,7 @@
       "additionalProperties": false,
       "properties": {
         "type": {
-          "enum": ["get_screenshot", "get_logs", "poll_events"]
+          "enum": ["get_screenshot", "get_logs", "get_context_status", "poll_events"]
         }
       }
     }

--- a/protocol/schema/ui-tree.schema.json
+++ b/protocol/schema/ui-tree.schema.json
@@ -7,6 +7,7 @@
   "additionalProperties": false,
   "properties": {
     "schemaVersion": { "const": 2 },
+    "sessionEpoch": { "type": "integer", "minimum": 1 },
     "frameSequence": { "type": "integer", "minimum": 0 },
     "revision": { "type": "integer", "minimum": 0 },
     "screen": {

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -12,6 +12,7 @@ A UI tree response describes one frame or snapshot of runtime UI state.
 - `schemaVersion`: currently `2`
 - `frameSequence`: increments once for every completed host frame
 - `revision`: increments only when the semantic screen or node content changes
+- `sessionEpoch`: identifies the current test-isolation session and increments after every successful context reset
 
 Nodes are intentionally semantic. They describe role, label, state, bounds, and
 supported actions, not rendering internals.
@@ -27,6 +28,35 @@ allows native JSON scalar values for future transports.
 semantic tree in consecutive frames increments `frameSequence` but leaves
 `revision` unchanged. Changing the screen, node membership, hierarchy, bounds,
 text, value, state, or actions increments `revision` at `end_frame`.
+
+`sessionEpoch` starts at 1. A successful reset starts a new epoch and resets
+`frameSequence` and `revision` to zero. Consumers must use the epoch together
+with frame/revision metadata; values from an older epoch are stale.
+
+## Test session inspection and reset
+
+Context inspection reports semantic node count, pending and in-flight action
+request counts, unconsumed event count, log count, screenshot presence, and the
+first request/event action plus node id. It never includes action payload values,
+so sensitive values cannot leak through teardown diagnostics.
+
+Reset is scoped to one `gua_context_t` / `gua_runtime_t`; it does not use global
+state and cannot affect another context. The selectable flags are nodes (1),
+requests (2), events (4), retained diagnostic history (8), logs (16), and
+screenshot (32). The default is 15: nodes, requests, events, and history are
+cleared, while logs and screenshot are preserved unless explicitly selected.
+Bridge server, port, active WebSocket connections, and context configuration are
+never reset.
+
+Strict reset checks selected request/event queues before mutation. If pending,
+in-flight, or unconsumed state exists, it returns `dirty` with counts and a
+redacted first-item summary and changes nothing. Non-strict reset reports how
+many selected items it discarded. Every successful reset increments
+`sessionEpoch`; local callers may pass zero to use the current epoch, but remote
+`reset_context` commands must provide `expectedSessionEpoch`. A stale remote
+epoch is rejected without mutation. Multiple clients of one runtime observe the
+same reset because the isolation boundary is the shared runtime context, not a
+WebSocket connection.
 
 ## Adapter-Owned Reflection
 
@@ -132,6 +162,8 @@ The v1 action names map directly to the additive C ABI action enum: `click`, `fo
 - `get_screenshot`
 - `get_logs`
 - `poll_events`
+- `get_context_status`
+- `reset_context` with `expectedSessionEpoch`, optional reset `flags`, and optional `strict`
 
 For the Inspector WebSocket bridge, commands are sent as JSON text messages with
 a numeric `id`. Responses echo the same `id` and either include `result` or


### PR DESCRIPTION
## 対応 Issue

Closes #24

## 実装内容

- `protocol/` に `sessionEpoch`、`get_context_status`、expected epoch 必須の `reset_context` command と fixture を追加
- additive C ABI と runtime wrapper に context status / strict・non-strict reset / reset report を追加
- pending・in-flight request、unconsumed event を種類別に検査し、先頭 action/node のみを redacted summary として返す
- reset 成功時に session epoch を進め、frame sequence / revision / request ID を初期化
- WebSocket 接続を維持したまま共有 runtime context を reset し、stale epoch を無変更で拒否
- C++ `TestSession`、C# `GuaTestSession` / `GuaResetOptions` / `Reset` / `ResetAsync` / `AssertClean` を追加
- Godot GDExtension と auto adapter を同期し、成功時に control dispatch / suppressed-click temporary cache を同時 clear
- C++、NuGet 経由 NUnit、remote WebSocket、Godot headless、schema fixture のテストを追加

## Architecture 判断

- isolation boundary は global registry ではなく既存 `gua_context_t` / `gua_runtime_t` とした。別 context には影響しない。
- strict reset は選択対象の request/event queue が dirty なら、現在数と redacted summary を返して一切変更しない。実際の破棄数は成功レポートの `discarded*` にだけ入れる。
- default flags は nodes / requests / events / history。logs / screenshot は既定で保持し、明示 flag でのみ clear する。
- remote reset は `expectedSessionEpoch` 必須。同じ runtime の複数 client は同じ epoch/reset を観測する。
- 現在 retained diagnostic history 自体は #20 の範囲で未実装だが、reset flag と protocol contract は予約し、#20 が同じ context-owned seam を延長できる形にした。

## Reset matrix

| 対象 | Default | Optional | Strict leak 判定 |
| --- | --- | --- | --- |
| semantic nodes / screen | clear | `GUA_RESET_NODES` | 対象外 |
| pending / in-flight requests | clear | `GUA_RESET_REQUESTS` | dirty |
| unconsumed events | clear | `GUA_RESET_EVENTS` | dirty |
| retained diagnostic history | clear contract | `GUA_RESET_HISTORY` | 対象外 |
| logs | preserve | `GUA_RESET_LOGS` | 対象外 |
| screenshot | preserve | `GUA_RESET_SCREENSHOT` | 対象外 |
| bridge / port / connections | preserve | 変更不可 | 対象外 |
| adapter temporary cache | clear on successful adapter reset | adapter-owned | strict failure 時は保持 |

## 検証

- `cmake --preset windows-msvc-debug` 成功
- `cmake --build --preset windows-msvc-debug` 成功
- `ctest --output-on-failure -C Debug` 成功（2/2）
- `dotnet build bindings\dotnet\src\Gua.Testing\Gua.Testing.csproj --configuration Release --no-restore` 成功（警告0、エラー0）
- `dotnet test examples\dotnet-nunit\GuaDotNetNUnitSample.csproj --configuration Release --no-build` 成功（8/8、ローカル NuGet package 経由）
- `dotnet test bindings\dotnet\tests\Gua.Selector.Tests\Gua.Selector.Tests.csproj --configuration Release --no-build` 成功（2/2、remote stale epoch / connection 維持を含む）
- `bun run check` 成功（3 workspaces）
- Godot 4.7 headless smoke 成功（strict leak、epoch、adapter cache reset を含む）
- AJV 2020 schema validation 成功（UI tree / action / reset / selector fixtures）
- `git diff --check` 成功

## 未対応事項

- diagnostics history の bounded ring buffer と artifact writer は予定どおり #20 に残す。
- process restart orchestration、global reset、client 単位 reset、recording baseline cleanup は対象外。