### PR TITLE
#19 条件待機とsemantic snapshot安定判定を追加

### DIFF
--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -4,7 +4,7 @@ using Gua.Core;
 
 namespace Gua.Testing;
 
-public static class GuaAssertions
+public static partial class GuaAssertions
 {
     private static readonly AsyncLocal<GuaAssertionOptions?> CurrentOptions = new();
 
@@ -53,20 +53,20 @@ public static class GuaAssertions
         expectation.WaitFor(timeout);
     }
 
-    public static GuaNodeExpectation WaitForId(IGuaContext context, string id, TimeSpan? timeout = null)
+    public static GuaNodeExpectation WaitForId(IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null)
     {
-        return WaitForQuery(() => GetById(context, id).RequireExistingSnapshot(), $"id '{id}'", timeout);
+        return WaitForQuery(context, () => GetById(context, id).RequireExistingSnapshot(), $"id '{id}'", timeout, pollInterval);
     }
 
-    public static GuaNodeExpectation WaitForRole(IGuaContext context, string role, string? name = null, TimeSpan? timeout = null)
+    public static GuaNodeExpectation WaitForRole(IGuaContext context, string role, string? name = null, TimeSpan? timeout = null, TimeSpan? pollInterval = null)
     {
         var description = name is null ? $"role '{role}'" : $"role '{role}' and label '{name}'";
-        return WaitForQuery(() => GetByRole(context, role, name).RequireExistingSnapshot(), description, timeout);
+        return WaitForQuery(context, () => GetByRole(context, role, name).RequireExistingSnapshot(), description, timeout, pollInterval);
     }
 
-    public static GuaNodeExpectation WaitForText(IGuaContext context, string text, TimeSpan? timeout = null)
+    public static GuaNodeExpectation WaitForText(IGuaContext context, string text, TimeSpan? timeout = null, TimeSpan? pollInterval = null)
     {
-        return WaitForQuery(() => GetByText(context, text).RequireExistingSnapshot(), $"text '{text}'", timeout);
+        return WaitForQuery(context, () => GetByText(context, text).RequireExistingSnapshot(), $"text '{text}'", timeout, pollInterval);
     }
 
     public static void WaitUntil(
@@ -75,23 +75,7 @@ public static class GuaAssertions
         TimeSpan? timeout = null,
         TimeSpan? pollInterval = null)
     {
-        ArgumentNullException.ThrowIfNull(condition);
-        ArgumentException.ThrowIfNullOrWhiteSpace(description);
-
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(1));
-        var interval = pollInterval ?? TimeSpan.FromMilliseconds(10);
-        do
-        {
-            if (condition())
-            {
-                return;
-            }
-
-            Thread.Sleep(interval);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        Fail($"Timed out after {FormatTimeout(timeout)} waiting for {description}.");
+        WaitUntilAsync(condition, description, timeout, pollInterval).GetAwaiter().GetResult();
     }
 
     internal static void Fail(string message)
@@ -194,9 +178,13 @@ public static class GuaAssertions
         }
     }
 
-    private static GuaNodeExpectation WaitForQuery(Func<GuaNodeExpectation> query, string description, TimeSpan? timeout)
+    private static GuaNodeExpectation WaitForQuery(IGuaContext context, Func<GuaNodeExpectation> query, string description, TimeSpan? timeout, TimeSpan? pollInterval)
     {
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(1));
+        var stopwatch = Stopwatch.StartNew();
+        var limit = timeout ?? TimeSpan.FromSeconds(1);
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(10);
+        if (limit < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+        if (interval <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(pollInterval));
         Exception? lastException = null;
         do
         {
@@ -207,12 +195,13 @@ public static class GuaAssertions
             catch (Exception ex) when (ex is InvalidOperationException or GuaAssertionException)
             {
                 lastException = ex;
-                Thread.Sleep(10);
+                Thread.Sleep(interval);
             }
         }
-        while (DateTime.UtcNow < deadline);
+        while (stopwatch.Elapsed < limit);
 
-        Fail($"Timed out after {FormatTimeout(timeout)} waiting for Gua node by {description}. {lastException?.Message}");
+        var last = ReadWaitSnapshot(context);
+        Fail($"Timed out after {FormatTimeout(timeout)} (elapsed {stopwatch.Elapsed:g}) waiting for Gua node by {description}. Last frameSequence={Format(last.FrameSequence)}, revision={Format(last.Revision)}. {lastException?.Message}");
         throw new UnreachableException();
     }
 
@@ -412,50 +401,50 @@ public sealed class GuaNodeExpectation
 
     public GuaNodeExpectation WaitFor(TimeSpan? timeout = null)
     {
-        return WaitUntil(node => node is not null, "exist", timeout);
+        return GuaAssertions.WaitForId(_context, _id, timeout);
     }
 
-    public GuaNodeExpectation WaitUntilVisible(TimeSpan? timeout = null)
+    public GuaNodeExpectation WaitUntilVisible(TimeSpan? timeout = null, TimeSpan? pollInterval = null)
     {
-        return WaitUntil(node => node is { Visible: true }, "be visible", timeout);
+        return GuaAssertions.WaitForVisible(_context, _id, timeout, pollInterval);
     }
 
-    public GuaNodeExpectation WaitUntilHidden(TimeSpan? timeout = null)
+    public GuaNodeExpectation WaitUntilHidden(TimeSpan? timeout = null, TimeSpan? pollInterval = null)
     {
-        return WaitUntil(node => node is { Visible: false } || node is null, "be hidden or removed", timeout);
+        return GuaAssertions.WaitForHidden(_context, _id, timeout, pollInterval);
     }
 
-    public GuaNodeExpectation WaitUntilEnabled(TimeSpan? timeout = null)
+    public GuaNodeExpectation WaitUntilEnabled(TimeSpan? timeout = null, TimeSpan? pollInterval = null)
     {
-        return WaitUntil(node => node is { Enabled: true }, "be enabled", timeout);
+        return GuaAssertions.WaitForEnabled(_context, _id, timeout, pollInterval);
     }
 
-    public GuaNodeExpectation WaitUntilDisabled(TimeSpan? timeout = null)
+    public GuaNodeExpectation WaitUntilDisabled(TimeSpan? timeout = null, TimeSpan? pollInterval = null)
     {
-        return WaitUntil(node => node is { Enabled: false }, "be disabled", timeout);
+        return GuaAssertions.WaitForDisabled(_context, _id, timeout, pollInterval);
     }
+
+    public Task<GuaNodeExpectation> WaitUntilVisibleAsync(TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) =>
+        GuaAssertions.WaitForVisibleAsync(_context, _id, timeout, pollInterval, cancellationToken);
+
+    public Task<GuaNodeExpectation> WaitUntilHiddenAsync(TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) =>
+        GuaAssertions.WaitForHiddenAsync(_context, _id, timeout, pollInterval, cancellationToken);
+
+    public Task<GuaNodeExpectation> WaitUntilEnabledAsync(TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) =>
+        GuaAssertions.WaitForEnabledAsync(_context, _id, timeout, pollInterval, cancellationToken);
+
+    public Task<GuaNodeExpectation> WaitUntilDisabledAsync(TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) =>
+        GuaAssertions.WaitForDisabledAsync(_context, _id, timeout, pollInterval, cancellationToken);
+
+    public Task<GuaNodeExpectation> WaitForTextAsync(string expected, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) =>
+        GuaAssertions.WaitForTextAsync(_context, _id, expected, timeout, pollInterval, cancellationToken);
+
+    public Task<GuaNodeExpectation> WaitForValueAsync(string expected, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) =>
+        GuaAssertions.WaitForValueAsync(_context, _id, expected, timeout, pollInterval, cancellationToken);
 
     internal GuaNodeExpectation RequireExistingSnapshot()
     {
         ToExist();
-        return this;
-    }
-
-    private GuaNodeExpectation WaitUntil(Func<GuaNodeSnapshot?, bool> condition, string description, TimeSpan? timeout)
-    {
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(1));
-        do
-        {
-            if (condition(GuaAssertions.TryGetSnapshot(_context, _id)))
-            {
-                return this;
-            }
-
-            Thread.Sleep(10);
-        }
-        while (DateTime.UtcNow < deadline);
-
-        GuaAssertions.Fail($"Timed out waiting for Gua node {_description} to {description}. {GuaAssertions.DescribeTree(_context)}");
         return this;
     }
 

--- a/bindings/dotnet/src/Gua.Testing/GuaWaits.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWaits.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Gua.Core;
+
+namespace Gua.Testing;
+
+public static partial class GuaAssertions
+{
+    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(10);
+
+    public static Task<GuaNodeExpectation> WaitForVisibleAsync(
+        IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        WaitForNodeAsync(context, id, node => node is { Visible: true }, "be visible", timeout, pollInterval, cancellationToken);
+
+    public static Task<GuaNodeExpectation> WaitForHiddenAsync(
+        IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        WaitForNodeAsync(context, id, node => node is null || !node.Visible, "be hidden or removed", timeout, pollInterval, cancellationToken);
+
+    public static Task<GuaNodeExpectation> WaitForEnabledAsync(
+        IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        WaitForNodeAsync(context, id, node => node is { Enabled: true }, "be enabled", timeout, pollInterval, cancellationToken);
+
+    public static Task<GuaNodeExpectation> WaitForDisabledAsync(
+        IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        WaitForNodeAsync(context, id, node => node is { Enabled: false }, "be disabled", timeout, pollInterval, cancellationToken);
+
+    public static Task<GuaNodeExpectation> WaitForTextAsync(
+        IGuaContext context, string id, string expected, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        WaitForNodeAsync(context, id, node => string.Equals(node?.Text, expected, StringComparison.Ordinal),
+            $"have text '{expected}'", timeout, pollInterval, cancellationToken);
+
+    public static Task<GuaNodeExpectation> WaitForValueAsync(
+        IGuaContext context, string id, string expected, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        WaitForNodeAsync(context, id, node => string.Equals(node?.Value, expected, StringComparison.Ordinal),
+            $"have value '{expected}'", timeout, pollInterval, cancellationToken);
+
+    public static GuaNodeExpectation WaitForVisible(IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForVisibleAsync(context, id, timeout, pollInterval).GetAwaiter().GetResult();
+
+    public static GuaNodeExpectation WaitForHidden(IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForHiddenAsync(context, id, timeout, pollInterval).GetAwaiter().GetResult();
+
+    public static GuaNodeExpectation WaitForEnabled(IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForEnabledAsync(context, id, timeout, pollInterval).GetAwaiter().GetResult();
+
+    public static GuaNodeExpectation WaitForDisabled(IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForDisabledAsync(context, id, timeout, pollInterval).GetAwaiter().GetResult();
+
+    public static GuaNodeExpectation WaitForText(IGuaContext context, string id, string expected, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForTextAsync(context, id, expected, timeout, pollInterval).GetAwaiter().GetResult();
+
+    public static GuaNodeExpectation WaitForValue(IGuaContext context, string id, string expected, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForValueAsync(context, id, expected, timeout, pollInterval).GetAwaiter().GetResult();
+
+    public static async Task WaitUntilAsync(
+        Func<bool> condition, string description, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(description);
+        var (limit, interval) = ValidateWait(timeout, pollInterval);
+        var stopwatch = Stopwatch.StartNew();
+        do
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (condition()) return;
+            if (stopwatch.Elapsed >= limit) break;
+            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+        }
+        while (true);
+
+        Fail($"Timed out after {limit:g} (elapsed {stopwatch.Elapsed:g}) waiting for {description}.");
+    }
+
+    public static async Task WaitForStableSnapshotAsync(
+        IGuaContext context, int stableFrames = 3, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        if (stableFrames <= 0) throw new ArgumentOutOfRangeException(nameof(stableFrames));
+        var (limit, interval) = ValidateWait(timeout, pollInterval);
+        var stopwatch = Stopwatch.StartNew();
+        ulong? sessionEpoch = null;
+        ulong? lastFrame = null;
+        ulong? stableRevision = null;
+        var observedStableFrames = 0;
+        WaitSnapshot? last = null;
+
+        do
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            last = ReadWaitSnapshot(context);
+            if (last.FrameSequence is { } frame && last.Revision is { } revision && frame != lastFrame)
+            {
+                if (last.SessionEpoch != sessionEpoch || stableRevision != revision)
+                {
+                    sessionEpoch = last.SessionEpoch;
+                    stableRevision = revision;
+                    observedStableFrames = 1;
+                }
+                else
+                {
+                    observedStableFrames++;
+                }
+                lastFrame = frame;
+                if (observedStableFrames >= stableFrames) return;
+            }
+
+            if (stopwatch.Elapsed >= limit) break;
+            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+        }
+        while (true);
+
+        Fail($"Timed out after {limit:g} (elapsed {stopwatch.Elapsed:g}) waiting for {stableFrames} distinct stable semantic frames; observed {observedStableFrames}. Last frameSequence={Format(last?.FrameSequence)}, revision={Format(last?.Revision)}, sessionEpoch={Format(last?.SessionEpoch)}.");
+    }
+
+    public static void WaitForStableSnapshot(IGuaContext context, int stableFrames = 3, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForStableSnapshotAsync(context, stableFrames, timeout, pollInterval).GetAwaiter().GetResult();
+
+    private static async Task<GuaNodeExpectation> WaitForNodeAsync(
+        IGuaContext context, string id, Func<GuaNodeSnapshot?, bool> condition, string description,
+        TimeSpan? timeout, TimeSpan? pollInterval, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        var (limit, interval) = ValidateWait(timeout, pollInterval);
+        var stopwatch = Stopwatch.StartNew();
+        WaitSnapshot? last = null;
+        GuaNodeSnapshot? node = null;
+        do
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            last = ReadWaitSnapshot(context);
+            node = last.Nodes.FirstOrDefault(candidate => string.Equals(candidate.Id, id, StringComparison.Ordinal));
+            if (condition(node)) return new GuaNodeExpectation(context, id, $"id '{id}'");
+            if (stopwatch.Elapsed >= limit) break;
+            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+        }
+        while (true);
+
+        Fail($"Timed out after {limit:g} (elapsed {stopwatch.Elapsed:g}) waiting for Gua node id '{id}' to {description}. Last state: {DescribeNode(node)}; frameSequence={Format(last?.FrameSequence)}, revision={Format(last?.Revision)}.");
+        throw new UnreachableException();
+    }
+
+    private static (TimeSpan Timeout, TimeSpan PollInterval) ValidateWait(TimeSpan? timeout, TimeSpan? pollInterval)
+    {
+        var limit = timeout ?? DefaultWaitTimeout;
+        var interval = pollInterval ?? DefaultPollInterval;
+        if (limit < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+        if (interval <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(pollInterval));
+        return (limit, interval);
+    }
+
+    private static WaitSnapshot ReadWaitSnapshot(IGuaContext context)
+    {
+        using var document = JsonDocument.Parse(context.GetUiTreeJson());
+        var root = document.RootElement;
+        var nodes = new List<GuaNodeSnapshot>();
+        if (root.TryGetProperty("nodes", out var array) && array.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var element in array.EnumerateArray()) nodes.Add(ReadWaitNode(element, root));
+        }
+        return new WaitSnapshot(RootUInt64(root, "sessionEpoch"), RootUInt64(root, "frameSequence"), RootUInt64(root, "revision"), nodes);
+    }
+
+    private static GuaNodeSnapshot ReadWaitNode(JsonElement node, JsonElement root)
+    {
+        var bounds = node.GetProperty("bounds");
+        var actions = node.TryGetProperty("actions", out var actionValues) && actionValues.ValueKind == JsonValueKind.Array
+            ? actionValues.EnumerateArray().Select(action => action.GetString() ?? string.Empty).ToArray()
+            : [];
+        var hasState = node.TryGetProperty("state", out var state) && state.ValueKind == JsonValueKind.Object;
+        bool? StateBoolean(string name) => hasState && state.TryGetProperty(name, out var value) ? value.GetBoolean() : null;
+        string? NodeString(string name) => node.TryGetProperty(name, out var value) ? value.GetString() : null;
+        return new GuaNodeSnapshot(
+            node.GetProperty("id").GetString() ?? string.Empty,
+            node.GetProperty("role").GetString() ?? string.Empty,
+            node.GetProperty("label").GetString() ?? string.Empty,
+            new GuaBounds(bounds.GetProperty("x").GetSingle(), bounds.GetProperty("y").GetSingle(), bounds.GetProperty("w").GetSingle(), bounds.GetProperty("h").GetSingle()),
+            node.GetProperty("visible").GetBoolean(), node.GetProperty("enabled").GetBoolean(), actions,
+            NodeString("parentId"), NodeString("text"), NodeString("value"), StateBoolean("focused"), StateBoolean("hovered"),
+            StateBoolean("pressed"), StateBoolean("checked"), StateBoolean("selected"),
+            root.TryGetProperty("schemaVersion", out var schemaVersion) ? schemaVersion.GetInt32() : null,
+            RootUInt64(root, "sessionEpoch"), RootUInt64(root, "frameSequence"), RootUInt64(root, "revision"));
+    }
+
+    private static ulong? RootUInt64(JsonElement root, string name) => root.TryGetProperty(name, out var value) ? value.GetUInt64() : null;
+    private static string Format(ulong? value) => value?.ToString() ?? "<unknown>";
+    private static string DescribeNode(GuaNodeSnapshot? node) => node is null
+        ? "<removed or not found>"
+        : $"visible={node.Visible}, enabled={node.Enabled}, text='{node.Text ?? "<unknown>"}', value='{node.Value ?? "<unknown>"}'";
+
+    private sealed record WaitSnapshot(ulong? SessionEpoch, ulong? FrameSequence, ulong? Revision, IReadOnlyList<GuaNodeSnapshot> Nodes);
+}

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -50,6 +50,24 @@ GuaAssertions.GetById(ui, "start").ToBeVisible();
 ```
 
 See `examples/dotnet-nunit` for a complete NUnit project with multiple `[Test]`
+methods in one file.
+
+Async condition waits are the primary synchronization API. They use a monotonic
+timeout, honor cancellation, and work with both local `GuaContext` and remote
+`GuaRemoteContext` snapshot polling:
+
+```csharp
+await GuaAssertions.WaitForVisibleAsync(ui, "status", cancellationToken: token);
+await GuaAssertions.WaitForTextAsync(ui, "status", "Ready", pollInterval: TimeSpan.FromMilliseconds(20));
+await GuaAssertions.WaitForValueAsync(ui, "progress", "100");
+await GuaAssertions.WaitForStableSnapshotAsync(ui, stableFrames: 3);
+```
+
+Stable snapshot waiting counts only distinct `frameSequence` values whose
+`revision` remains unchanged; repeatedly polling one stopped frame never
+satisfies the wait. Hidden waiting succeeds for either `visible=false` or a
+removed node. Timeout messages include the condition, last node state, frame,
+and revision. Sync wrappers remain available for compatibility.
 
 Use `GuaTestSession` as the explicit process-reuse boundary. The default reset
 clears semantic nodes, requests, events, and retained history while preserving
@@ -66,7 +84,6 @@ session.Reset(new GuaResetOptions(Strict: true)); // teardown; throws if dirty
 `ResetAsync` provides the same contract for remote contexts and honors
 `CancellationToken`. Remote reset always includes the inspected session epoch,
 so a stale client cannot reset a newer shared runtime session.
-methods in one file.
 Semantic locators are strict: `GetBy*` fails when zero or multiple nodes match,
 while `QueryAll()` is the explicit multi-result API. String matching is exact by
 default and can opt into ordinal contains or ECMAScript regex matching:

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using Gua.Core;
+using Gua.Testing;
 using Gua.Testing.Godot;
 using NUnit.Framework;
 
@@ -32,6 +33,8 @@ public sealed class SelectorParityTests
 
             using var remote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
             remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            GuaAssertions.WaitForVisible(remote, "save-a", pollInterval: TimeSpan.FromMilliseconds(5));
+            GuaAssertions.WaitForHidden(remote, "missing", pollInterval: TimeSpan.FromMilliseconds(5));
             var selector = new GuaSelector(Role: "button", Name: "^Save", NameMatch: GuaMatchMode.Regex);
             var remoteResult = remote.Query(selector);
             var localResult = local.Query(selector);

--- a/examples/dotnet-nunit/README.md
+++ b/examples/dotnet-nunit/README.md
@@ -35,3 +35,7 @@ For a Godot process or native runtime shared across tests, create a
 use `Reset(new GuaResetOptions(Strict: true))` in teardown. Strict teardown
 reports leaked requests/events and leaves them intact for diagnosis. Logs and
 screenshots are preserved by default; select `GuaResetTargets.All` to clear them.
+
+The sample's async wait tests use semantic state and distinct frame/revision
+progress as synchronization points. They do not use fixed `Thread.Sleep` or
+`Task.Delay` calls to guess when UI work has completed.

--- a/examples/dotnet-nunit/TitleScreenTests.cs
+++ b/examples/dotnet-nunit/TitleScreenTests.cs
@@ -220,6 +220,56 @@ public sealed class TitleScreenTests
         });
     }
 
+    [Test]
+    public async Task AsyncWaitsObserveStateTextValueAndRemovalWithoutFixedSleeps()
+    {
+        using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);
+        var changing = new SequenceContext(
+            Tree(1, 1, Node(visible: false, enabled: false, text: "Old", value: "1")),
+            Tree(2, 2, Node(visible: true, enabled: true, text: "Ready", value: "2")));
+
+        await GuaAssertions.WaitForVisibleAsync(changing, "status", pollInterval: TimeSpan.FromMilliseconds(1));
+        await GuaAssertions.WaitForEnabledAsync(changing, "status", pollInterval: TimeSpan.FromMilliseconds(1));
+        await GuaAssertions.WaitForTextAsync(changing, "status", "Ready", pollInterval: TimeSpan.FromMilliseconds(1));
+        await GuaAssertions.WaitForValueAsync(changing, "status", "2", pollInterval: TimeSpan.FromMilliseconds(1));
+
+        var removed = new SequenceContext(Tree(1, 1, Node()), Tree(2, 2));
+        await GuaAssertions.WaitForHiddenAsync(removed, "status", pollInterval: TimeSpan.FromMilliseconds(1));
+    }
+
+    [Test]
+    public async Task StableSnapshotCountsDistinctFramesOnly()
+    {
+        var advancing = new SequenceContext(Tree(1, 7, Node()), Tree(1, 7, Node()), Tree(2, 7, Node()), Tree(3, 7, Node()));
+        await GuaAssertions.WaitForStableSnapshotAsync(advancing, 3, pollInterval: TimeSpan.FromMilliseconds(1));
+
+        var stopped = new SequenceContext(Tree(9, 7, Node()));
+        var error = Assert.ThrowsAsync<GuaAssertionException>(async () =>
+            await GuaAssertions.WaitForStableSnapshotAsync(stopped, 3, TimeSpan.FromMilliseconds(15), TimeSpan.FromMilliseconds(1)));
+        Assert.That(error!.Message, Does.Contain("observed 1").And.Contain("frameSequence=9").And.Contain("revision=7"));
+    }
+
+    [Test]
+    public void AsyncWaitHonorsCancellationAndReportsLastSemanticState()
+    {
+        var stopped = new SequenceContext(Tree(4, 8, Node(visible: false, enabled: false, text: "Old", value: "1")));
+        var timeout = Assert.ThrowsAsync<GuaAssertionException>(async () =>
+            await GuaAssertions.WaitForVisibleAsync(stopped, "status", TimeSpan.FromMilliseconds(15), TimeSpan.FromMilliseconds(1)));
+        Assert.That(timeout!.Message, Does.Contain("id 'status'").And.Contain("be visible").And.Contain("visible=False")
+            .And.Contain("frameSequence=4").And.Contain("revision=8"));
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await GuaAssertions.WaitForEnabledAsync(stopped, "status", cancellationToken: cancellation.Token));
+    }
+
+    private static string Tree(ulong frame, ulong revision, string? node = null) =>
+        $$$"""{"schemaVersion":2,"sessionEpoch":1,"frameSequence":{{{frame}}},"revision":{{{revision}}},"screen":"test","nodes":[{{{node}}}]}""";
+
+    private static string Node(bool visible = true, bool enabled = true, string text = "Ready", string value = "2") =>
+        $$$"""{"id":"status","role":"status","label":"Status","text":"{{{text}}}","value":"{{{value}}}","visible":{{{visible.ToString().ToLowerInvariant()}}},"enabled":{{{enabled.ToString().ToLowerInvariant()}}},"bounds":{"x":0,"y":0,"w":1,"h":1},"actions":[],"state":{}}""";
+
     private static void RenderTitle(GuaTestHost host, bool loading)
     {
         host.Frame(loading ? "loading" : "title", frame =>
@@ -247,6 +297,25 @@ public sealed class TitleScreenTests
         public string FindNodeById(string id) => id == "legacy" ? id : throw new InvalidOperationException();
         public string FindNodeByRole(string role, string? name = null) => "legacy";
         public string FindNodeByText(string text) => "legacy";
+        public bool EnqueueClick(string id) => true;
+        public GuaActionError EnqueueAction(GuaActionRequest request, out ulong requestId) { requestId = 1; return GuaActionError.None; }
+        public bool TryPollActionEvent(out GuaActionEvent e) { e = default; return false; }
+        public bool TryPollActionEvent(ulong requestId, out GuaActionEvent e) { e = default; return false; }
+        public bool TryPollEvent(out GuaEvent e) { e = default; return false; }
+    }
+
+    private sealed class SequenceContext(params string[] snapshots) : IGuaContext
+    {
+        private int _index;
+        public string GetUiTreeJson()
+        {
+            var index = Math.Min(Interlocked.Increment(ref _index) - 1, snapshots.Length - 1);
+            return snapshots[index];
+        }
+        public GuaNodeState GetNodeState(string id) => new(true, true);
+        public string FindNodeById(string id) => id;
+        public string FindNodeByRole(string role, string? name = null) => "status";
+        public string FindNodeByText(string text) => "status";
         public bool EnqueueClick(string id) => true;
         public GuaActionError EnqueueAction(GuaActionRequest request, out ulong requestId) { requestId = 1; return GuaActionError.None; }
         public bool TryPollActionEvent(out GuaActionEvent e) { e = default; return false; }

--- a/native/gua-core/tests/selector_tests.cpp
+++ b/native/gua-core/tests/selector_tests.cpp
@@ -29,6 +29,11 @@ int main()
     node(context, "left-save", "left-group", "button", "保存", "保存");
     node(context, "right-save", "right", "button", "保存", "保存");
     node(context, "hidden", "left", "button", "Hidden", "Hidden", false);
+    const gua_node_descriptor_v2_t status {
+        sizeof(gua_node_descriptor_v2_t), GUA_NODE_KNOWN_TEXT | GUA_NODE_KNOWN_VALUE,
+        "status", nullptr, "status", "Status", "Ready", "2", { 0, 0, 1, 1 }, 1, 1, 0, 0, 0, 0, 0,
+    };
+    assert(gua_register_node_v2(context, &status) == 1);
     gua_end_frame(context);
 
     using namespace gua::testing;
@@ -51,5 +56,24 @@ int main()
     char legacy[128] {};
     assert(gua_find_node_by_text(context, "保存", legacy, sizeof(legacy)) == 1);
     assert(std::string(legacy) == "left-save");
+
+    Locator status_locator(context, "status");
+    status_locator.wait_for_visible(std::chrono::milliseconds(20), std::chrono::milliseconds(1));
+    status_locator.wait_for_enabled(std::chrono::milliseconds(20), std::chrono::milliseconds(1));
+    status_locator.wait_for_text("Ready", std::chrono::milliseconds(20), std::chrono::milliseconds(1));
+    status_locator.wait_for_value("2", std::chrono::milliseconds(20), std::chrono::milliseconds(1));
+    Locator(context, "missing").wait_for_hidden(std::chrono::milliseconds(20), std::chrono::milliseconds(1));
+
+    bool stale_snapshot_rejected = false;
+    try { wait_for_stable_snapshot(context, 3, std::chrono::milliseconds(5), std::chrono::milliseconds(1)); }
+    catch (const std::runtime_error& error) {
+        const std::string message(error.what());
+        stale_snapshot_rejected = message.find("distinct stable semantic frames") != std::string::npos &&
+            message.find("frameSequence=1") != std::string::npos && message.find("revision=1") != std::string::npos;
+    }
+    assert(stale_snapshot_rejected);
+
+    int attempts = 0;
+    wait_until([&attempts] { return ++attempts == 3; }, "third predicate evaluation", std::chrono::milliseconds(20), std::chrono::milliseconds(1));
     gua_destroy_context(context);
 }

--- a/native/gua-testing/include/gua/testing.hpp
+++ b/native/gua-testing/include/gua/testing.hpp
@@ -4,6 +4,8 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -85,22 +87,93 @@ public:
         throw std::runtime_error("Timed out waiting for Gua action completion: " + id_);
     }
 
-    void wait_for(std::chrono::milliseconds timeout = std::chrono::milliseconds(1000)) const
+    void wait_for(
+        std::chrono::milliseconds timeout = std::chrono::milliseconds(1000),
+        std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10)) const
     {
-        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        if (timeout.count() < 0 || poll_interval.count() <= 0) throw std::invalid_argument("Gua wait timeout must be non-negative and poll interval must be positive");
+        const auto start = std::chrono::steady_clock::now();
+        const auto deadline = start + timeout;
         do {
             gua_node_state_t state {};
             if (gua_get_node_state(context_, id_.c_str(), &state) != 0) {
                 return;
             }
 
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        } while (std::chrono::steady_clock::now() < deadline);
+            if (std::chrono::steady_clock::now() >= deadline) break;
+            std::this_thread::sleep_for(poll_interval);
+        } while (true);
 
-        throw std::runtime_error("Timed out waiting for Gua node: " + id_);
+        throw_wait_timeout("exist", timeout, std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start));
+    }
+
+    void wait_for_visible(std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10)) const
+    {
+        wait_for_state([](const gua_node_state_v2_t& state, bool found) { return found && state.visible != 0; }, "be visible", timeout, poll_interval);
+    }
+
+    void wait_for_hidden(std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10)) const
+    {
+        wait_for_state([](const gua_node_state_v2_t& state, bool found) { return !found || state.visible == 0; }, "be hidden or removed", timeout, poll_interval);
+    }
+
+    void wait_for_enabled(std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10)) const
+    {
+        wait_for_state([](const gua_node_state_v2_t& state, bool found) { return found && state.enabled != 0; }, "be enabled", timeout, poll_interval);
+    }
+
+    void wait_for_disabled(std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10)) const
+    {
+        wait_for_state([](const gua_node_state_v2_t& state, bool found) { return found && state.enabled == 0; }, "be disabled", timeout, poll_interval);
+    }
+
+    void wait_for_text(std::string_view expected, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10)) const
+    {
+        const std::string value(expected);
+        wait_for_state([&](const gua_node_state_v2_t& state, bool found) {
+            return found && (state.known_mask & GUA_NODE_KNOWN_TEXT) != 0U && value == state.text;
+        }, "have text '" + value + "'", timeout, poll_interval);
+    }
+
+    void wait_for_value(std::string_view expected, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10)) const
+    {
+        const std::string value(expected);
+        wait_for_state([&](const gua_node_state_v2_t& state, bool found) {
+            return found && (state.known_mask & GUA_NODE_KNOWN_VALUE) != 0U && value == state.value;
+        }, "have value '" + value + "'", timeout, poll_interval);
     }
 
 private:
+    template <typename Predicate>
+    void wait_for_state(Predicate&& predicate, const std::string& description, std::chrono::milliseconds timeout, std::chrono::milliseconds poll_interval) const
+    {
+        if (timeout.count() < 0 || poll_interval.count() <= 0) throw std::invalid_argument("Gua wait timeout must be non-negative and poll interval must be positive");
+        const auto start = std::chrono::steady_clock::now();
+        const auto deadline = start + timeout;
+        do {
+            gua_node_state_v2_t state { sizeof(gua_node_state_v2_t) };
+            const bool found = gua_get_node_state_v2(context_, id_.c_str(), &state) != 0;
+            if (std::invoke(predicate, state, found)) return;
+            if (std::chrono::steady_clock::now() >= deadline) break;
+            std::this_thread::sleep_for(poll_interval);
+        } while (true);
+        throw_wait_timeout(description, timeout, std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start));
+    }
+
+    [[noreturn]] void throw_wait_timeout(const std::string& description, std::chrono::milliseconds timeout, std::chrono::milliseconds elapsed) const
+    {
+        gua_context_status_t status { sizeof(gua_context_status_t) };
+        (void)gua_get_context_status(context_, &status);
+        gua_node_state_v2_t state { sizeof(gua_node_state_v2_t) };
+        const bool found = gua_get_node_state_v2(context_, id_.c_str(), &state) != 0;
+        const std::string last_state = found
+            ? "visible=" + std::to_string(state.visible) + ", enabled=" + std::to_string(state.enabled) +
+                ", text='" + state.text + "', value='" + state.value + "'"
+            : "removed or not found";
+        throw std::runtime_error("Timed out after " + std::to_string(timeout.count()) + "ms (elapsed " + std::to_string(elapsed.count()) + "ms) waiting for Gua node id '" + id_ + "' to " + description +
+            ". Last state: " + last_state + "; frameSequence=" + std::to_string(status.frame_sequence) + ", revision=" + std::to_string(status.revision));
+    }
+
     [[nodiscard]] std::uint64_t enqueue(int action, std::string_view value = {}, bool bool_value = false, bool sensitive = false) const
     {
         std::string value_buffer(value);
@@ -236,43 +309,112 @@ inline Locator expect_node(gua_context_t* context, std::string id)
     return get_by_id(context, std::move(id));
 }
 
-inline void wait_for(const Locator& locator, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+inline void wait_for(const Locator& locator, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10))
 {
-    locator.wait_for(timeout);
+    locator.wait_for(timeout, poll_interval);
 }
 
-inline Locator wait_for_id(gua_context_t* context, std::string id, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+[[noreturn]] inline void throw_selector_wait_timeout(gua_context_t* context, const std::string& description,
+    std::chrono::milliseconds timeout, std::chrono::steady_clock::time_point start)
 {
-    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    gua_context_status_t status { sizeof(gua_context_status_t) };
+    (void)gua_get_context_status(context, &status);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+    throw std::runtime_error("Timed out after " + std::to_string(timeout.count()) + "ms (elapsed " + std::to_string(elapsed.count()) +
+        "ms) waiting for Gua node by " + description + "; last frameSequence=" + std::to_string(status.frame_sequence) +
+        ", revision=" + std::to_string(status.revision));
+}
+
+template <typename Predicate>
+inline void wait_until(Predicate&& condition, std::string_view description,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(1000),
+    std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10))
+{
+    if (timeout.count() < 0 || poll_interval.count() <= 0) throw std::invalid_argument("Gua wait timeout must be non-negative and poll interval must be positive");
+    const auto start = std::chrono::steady_clock::now();
+    const auto deadline = start + timeout;
+    do {
+        if (std::invoke(condition)) return;
+        if (std::chrono::steady_clock::now() >= deadline) break;
+        std::this_thread::sleep_for(poll_interval);
+    } while (true);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+    throw std::runtime_error("Timed out after " + std::to_string(timeout.count()) + "ms (elapsed " + std::to_string(elapsed.count()) + "ms) waiting for " + std::string(description));
+}
+
+inline void wait_for_stable_snapshot(gua_context_t* context, std::size_t stable_frames = 3,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(1000),
+    std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10))
+{
+    if (context == nullptr) throw std::invalid_argument("Gua stable snapshot wait requires a context");
+    if (stable_frames == 0) throw std::invalid_argument("Gua stable snapshot wait requires at least one frame");
+    if (timeout.count() < 0 || poll_interval.count() <= 0) throw std::invalid_argument("Gua wait timeout must be non-negative and poll interval must be positive");
+    const auto start = std::chrono::steady_clock::now();
+    const auto deadline = start + timeout;
+    std::optional<std::uint64_t> session_epoch;
+    std::optional<std::uint64_t> last_frame;
+    std::optional<std::uint64_t> stable_revision;
+    std::size_t observed = 0;
+    gua_context_status_t status { sizeof(gua_context_status_t) };
+    do {
+        if (gua_get_context_status(context, &status) == 0) throw std::runtime_error("Failed to inspect Gua context while waiting for stable snapshot");
+        if (!last_frame.has_value() || status.frame_sequence != *last_frame) {
+            if (!session_epoch.has_value() || status.session_epoch != *session_epoch || !stable_revision.has_value() || status.revision != *stable_revision) {
+                session_epoch = status.session_epoch;
+                stable_revision = status.revision;
+                observed = 1;
+            } else {
+                ++observed;
+            }
+            last_frame = status.frame_sequence;
+            if (observed >= stable_frames) return;
+        }
+        if (std::chrono::steady_clock::now() >= deadline) break;
+        std::this_thread::sleep_for(poll_interval);
+    } while (true);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+    throw std::runtime_error("Timed out after " + std::to_string(timeout.count()) + "ms (elapsed " + std::to_string(elapsed.count()) + "ms) waiting for " + std::to_string(stable_frames) + " distinct stable semantic frames; observed " +
+        std::to_string(observed) + ", frameSequence=" + std::to_string(status.frame_sequence) + ", revision=" + std::to_string(status.revision));
+}
+
+inline Locator wait_for_id(gua_context_t* context, std::string id, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10))
+{
+    if (timeout.count() < 0 || poll_interval.count() <= 0) throw std::invalid_argument("Gua wait timeout must be non-negative and poll interval must be positive");
+    const auto start = std::chrono::steady_clock::now();
+    const auto deadline = start + timeout;
     do {
         auto matches = query(context).by_id(id).query_all();
         if (matches.size() == 1) return std::move(matches.front());
         if (matches.size() > 1) throw std::runtime_error("Strict Gua selector matched multiple nodes by id: " + id);
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(poll_interval);
     } while (std::chrono::steady_clock::now() < deadline);
 
-    throw std::runtime_error("Timed out waiting for Gua node by id: " + id);
+    throw_selector_wait_timeout(context, "id '" + id + "'", timeout, start);
 }
 
-inline Locator wait_for_role(gua_context_t* context, std::string_view role, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+inline Locator wait_for_role(gua_context_t* context, std::string_view role, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10))
 {
-    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    if (timeout.count() < 0 || poll_interval.count() <= 0) throw std::invalid_argument("Gua wait timeout must be non-negative and poll interval must be positive");
+    const auto start = std::chrono::steady_clock::now();
+    const auto deadline = start + timeout;
     std::string role_buffer(role);
     do {
         auto matches = query(context).by_role(role_buffer).query_all();
         if (matches.size() == 1) return std::move(matches.front());
         if (matches.size() > 1) throw std::runtime_error("Strict Gua selector matched multiple nodes by role: " + role_buffer);
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(poll_interval);
     } while (std::chrono::steady_clock::now() < deadline);
 
-    throw std::runtime_error("Timed out waiting for Gua node by role: " + role_buffer);
+    throw_selector_wait_timeout(context, "role '" + role_buffer + "'", timeout, start);
 }
 
-inline Locator wait_for_role(gua_context_t* context, std::string_view role, std::string_view name, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+inline Locator wait_for_role(gua_context_t* context, std::string_view role, std::string_view name, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10))
 {
-    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    if (timeout.count() < 0 || poll_interval.count() <= 0) throw std::invalid_argument("Gua wait timeout must be non-negative and poll interval must be positive");
+    const auto start = std::chrono::steady_clock::now();
+    const auto deadline = start + timeout;
     std::string role_buffer(role);
     std::string name_buffer(name);
     do {
@@ -280,25 +422,27 @@ inline Locator wait_for_role(gua_context_t* context, std::string_view role, std:
         if (matches.size() == 1) return std::move(matches.front());
         if (matches.size() > 1) throw std::runtime_error("Strict Gua selector matched multiple nodes by role and name: " + role_buffer + ", " + name_buffer);
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(poll_interval);
     } while (std::chrono::steady_clock::now() < deadline);
 
-    throw std::runtime_error("Timed out waiting for Gua node by role and name: " + role_buffer + ", " + name_buffer);
+    throw_selector_wait_timeout(context, "role '" + role_buffer + "' and name '" + name_buffer + "'", timeout, start);
 }
 
-inline Locator wait_for_text(gua_context_t* context, std::string_view text, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+inline Locator wait_for_text(gua_context_t* context, std::string_view text, std::chrono::milliseconds timeout = std::chrono::milliseconds(1000), std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10))
 {
-    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    if (timeout.count() < 0 || poll_interval.count() <= 0) throw std::invalid_argument("Gua wait timeout must be non-negative and poll interval must be positive");
+    const auto start = std::chrono::steady_clock::now();
+    const auto deadline = start + timeout;
     std::string text_buffer(text);
     do {
         auto matches = query(context).by_text(text_buffer).query_all();
         if (matches.size() == 1) return std::move(matches.front());
         if (matches.size() > 1) throw std::runtime_error("Strict Gua selector matched multiple nodes by text: " + text_buffer);
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(poll_interval);
     } while (std::chrono::steady_clock::now() < deadline);
 
-    throw std::runtime_error("Timed out waiting for Gua node by text: " + text_buffer);
+    throw_selector_wait_timeout(context, "text '" + text_buffer + "'", timeout, start);
 }
 
 class TestSession {


### PR DESCRIPTION
## 対応 Issue

Closes #19

## 実装内容

- C# に `WaitForVisibleAsync` / `WaitForHiddenAsync` / `WaitForEnabledAsync` / `WaitForDisabledAsync` / node text・value wait / generic `WaitUntilAsync` を追加
- C# async wait で `CancellationToken`、timeout、poll interval を統一し、既存 sync API を互換 wrapper として維持
- C++ `Locator` に visible / hidden-or-removed / enabled / disabled / text / value wait と明示的 poll interval を追加
- C++ / C# に semantic snapshot 安定判定を追加し、同じ `frameSequence` の高速再pollを複数frameとして数えないよう実装
- timeout 診断へ条件、timeout、実経過時間、最後のnode state、frameSequence、revisionを追加
- local context と `GuaRemoteContext` が同じ snapshot-based wait API を利用する parity test を追加
- NUnit sample に固定 sleep を使わない deterministic state transition、stable frame、停止frame、cancellation、timeout診断 testを追加
- .NET testing README と sample README に安定判定・同期規則を記載

## Architecture 判断

- 待機は既存どおり testing helper 層で実装し、C ABI/runtimeにblocking APIやcallbackを追加していない。
- local/remoteの差を新しいruntime実装で吸収せず、既存 `IGuaContext.GetUiTreeJson()` seamを唯一のsnapshot providerとして使用した。
- stable判定は同一session内の異なるframeSequenceだけを数え、revisionまたはsessionEpochが変わった時点で連続数を1へ戻す。
- hiddenはnodeの `visible=false` またはsnapshotからの消失のどちらでも成立する。
- timeoutはC++ `steady_clock` / C# `Stopwatch` で測定し、wall clock変更の影響を受けない。

## 検証

- `cmake --preset windows-msvc-debug` 成功
- `cmake --build --preset windows-msvc-debug` 成功
- `ctest --test-dir build\windows-msvc-debug -C Debug --output-on-failure` 成功（2/2）
- `dotnet build bindings\dotnet\src\Gua.Testing\Gua.Testing.csproj --configuration Release --no-restore` 成功（警告0）
- `dotnet build bindings\dotnet\src\Gua.Testing.Godot\Gua.Testing.Godot.csproj --configuration Release --no-restore` 成功（警告0）
- local package経由 `dotnet build examples\dotnet-nunit\GuaDotNetNUnitSample.csproj --configuration Release --no-restore` 成功
- `dotnet test examples\dotnet-nunit\GuaDotNetNUnitSample.csproj --configuration Release --no-build --no-restore` 成功（11/11）
- `dotnet test bindings\dotnet\tests\Gua.Selector.Tests\Gua.Selector.Tests.csproj --configuration Release --no-build --no-restore` 成功（2/2、remote wait parityを含む）
- `bun run check` 成功（3 workspaces）
- Godot 4.7 headless smoke 成功
- C++ ImGui `--smoke` 成功
- `git diff --check` 成功

## Flaky test対策

- sample test自身には `Thread.Sleep` / `Task.Delay` を同期手段として追加していない。
- state遷移fixtureはsnapshot列を決定論的に返すため、実時間の速さに依存しない。
- stopped snapshot testで同一frameの再pollがstableFramesを満たさないことを明示的に検証した。

## 未対応事項

- `WaitForIdle`、diagnostics artifact、screenshot pixel stabilityはIssue範囲外のため未実装。
- runtime/core ABI、protocol schemaの変更はない。