### PR TITLE
#20 UI Test失敗時の診断artifactを自動生成する

### DIFF
--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -116,6 +116,22 @@ public sealed class GuaContext : IGuaContext, IDisposable
         return ReadCopiedJson(JsonSource.UiTree, _handle);
     }
 
+    public string GetDiagnosticsJson()
+    {
+        ThrowIfDisposed();
+        return ReadCopiedJson(JsonSource.Diagnostics, _handle);
+    }
+
+    public void ConfigureDiagnostics(uint historyLimit, string environmentJson = "{}")
+    {
+        ThrowIfDisposed();
+        if (Native.gua_set_diagnostics_history_limit(_handle, historyLimit) == 0 ||
+            Native.gua_set_diagnostics_environment_json(_handle, environmentJson) == 0)
+        {
+            throw new ArgumentException("Invalid Gua diagnostics configuration.", nameof(environmentJson));
+        }
+    }
+
     public unsafe GuaContextStatus GetContextStatus()
     {
         ThrowIfDisposed();
@@ -550,6 +566,7 @@ public sealed class GuaContext : IGuaContext, IDisposable
             JsonSource.UiTree => Native.gua_copy_ui_tree_json(handle, buffer, bufferSize),
             JsonSource.Logs => Native.gua_copy_logs_json(handle, buffer, bufferSize),
             JsonSource.Screenshot => Native.gua_copy_screenshot_json(handle, buffer, bufferSize),
+            JsonSource.Diagnostics => Native.gua_copy_diagnostics_json(handle, buffer, bufferSize),
             _ => throw new ArgumentOutOfRangeException(nameof(source), source, null),
         };
     }
@@ -559,6 +576,7 @@ public sealed class GuaContext : IGuaContext, IDisposable
         UiTree,
         Logs,
         Screenshot,
+        Diagnostics,
     }
 
     private static readonly System.Text.Json.JsonSerializerOptions QueryJsonOptions = new()

--- a/bindings/dotnet/src/Gua.Core/IGuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/IGuaContext.cs
@@ -4,6 +4,8 @@ public interface IGuaContext
 {
     string GetUiTreeJson();
 
+    string GetDiagnosticsJson() => throw new NotSupportedException("This Gua context does not support diagnostics capture.");
+
     GuaContextStatus GetContextStatus() => throw new NotSupportedException("This Gua context does not support status inspection.");
 
     GuaResetReport Reset(GuaResetOptions? options = null) => throw new NotSupportedException("This Gua context does not support reset.");

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -315,6 +315,15 @@ internal static partial class Native
     [LibraryImport("gua")]
     internal static unsafe partial int gua_copy_screenshot_json(nint context, byte* outJson, int outJsonSize);
 
+    [LibraryImport("gua")]
+    internal static partial int gua_set_diagnostics_history_limit(nint context, uint historyLimit);
+
+    [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int gua_set_diagnostics_environment_json(nint context, string environmentJson);
+
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_copy_diagnostics_json(nint context, byte* outJson, int outJsonSize);
+
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int gua_get_node_state(nint context, string nodeId, out GuaNodeState state);
 

--- a/bindings/dotnet/src/Gua.Core/README.md
+++ b/bindings/dotnet/src/Gua.Core/README.md
@@ -32,3 +32,8 @@ cmake --preset windows-msvc-release
 cmake --build --preset windows-msvc-release --target gua
 dotnet pack bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release
 ```
+
+`GuaContext.ConfigureDiagnostics` sets the bounded retained-history limit and
+environment JSON. `GetDiagnosticsJson` returns the versioned semantic failure
+snapshot without draining the event queue; sensitive action values are already
+redacted by the native core.

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using Gua.Core;
+using Gua.Testing;
 
 namespace Gua.Testing.Godot;
 
@@ -20,6 +21,23 @@ public sealed class GodotSceneTestHost : IDisposable
     public IGuaContext Context { get; }
 
     public int ProcessId => _process.Id;
+
+    public GuaDiagnosticOptions CreateDiagnosticOptions(string testName, string? outputDirectory = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(testName);
+        return new GuaDiagnosticOptions
+        {
+            TestName = testName,
+            OutputDirectory = outputDirectory ?? Path.Combine("artifacts", "gua"),
+            Environment = new Dictionary<string, string>
+            {
+                ["host"] = "Godot",
+                ["processId"] = ProcessId.ToString(),
+                ["bridgeUrl"] = _options.BridgeUrl,
+                ["projectPath"] = _options.ProjectPath ?? string.Empty,
+            },
+        };
+    }
 
     public static GodotSceneTestHost Load(string scenePath, GodotSceneTestHostOptions? options = null)
     {

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -31,6 +31,11 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
         return RequestRawResult(new { type = "get_ui_tree" });
     }
 
+    public string GetDiagnosticsJson()
+    {
+        return RequestRawResult(new { type = "get_diagnostics" });
+    }
+
     public GuaContextStatus GetContextStatus()
     {
         var status = Request<ContextStatusResult>(new { type = "get_context_status" });

--- a/bindings/dotnet/src/Gua.Testing.Godot/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Godot/README.md
@@ -30,3 +30,7 @@ path such as `game/scenes/village_list.tscn`. Scene paths are matched against
 common logical screen names derived from the file name, and also accept a screen
 change from the previous value because Godot adapters often publish logical
 screen names instead of resource paths.
+
+For failure artifacts, `host.CreateDiagnosticOptions(testName)` includes the
+Godot process id, bridge URL, and project metadata. The remote context captures
+the same versioned diagnostics JSON as an in-process context.

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertionOptions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertionOptions.cs
@@ -5,4 +5,6 @@ public sealed class GuaAssertionOptions
     public static GuaAssertionOptions Default { get; } = new();
 
     public Action<string> Fail { get; init; } = message => throw new GuaAssertionException(message);
+
+    public GuaDiagnosticOptions? Diagnostics { get; init; }
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -84,6 +84,16 @@ public static partial class GuaAssertions
         throw new GuaAssertionException(message);
     }
 
+    internal static void Fail(IGuaContext context, string message, string? initialUiTreeJson = null)
+    {
+        var diagnostics = Options.Diagnostics;
+        var suffix = diagnostics is null
+            ? string.Empty
+            : GuaDiagnosticWriter.Capture(context, message, diagnostics, initialUiTreeJson).MessageSuffix;
+        Options.Fail(message + suffix);
+        throw new GuaAssertionException(message + suffix);
+    }
+
     internal static GuaNodeSnapshot? TryGetSnapshot(IGuaContext context, string id)
     {
         using var document = JsonDocument.Parse(context.GetUiTreeJson());
@@ -180,6 +190,7 @@ public static partial class GuaAssertions
 
     private static GuaNodeExpectation WaitForQuery(IGuaContext context, Func<GuaNodeExpectation> query, string description, TimeSpan? timeout, TimeSpan? pollInterval)
     {
+        var initialUiTreeJson = context.GetUiTreeJson();
         var stopwatch = Stopwatch.StartNew();
         var limit = timeout ?? TimeSpan.FromSeconds(1);
         var interval = pollInterval ?? TimeSpan.FromMilliseconds(10);
@@ -201,7 +212,7 @@ public static partial class GuaAssertions
         while (stopwatch.Elapsed < limit);
 
         var last = ReadWaitSnapshot(context);
-        Fail($"Timed out after {FormatTimeout(timeout)} (elapsed {stopwatch.Elapsed:g}) waiting for Gua node by {description}. Last frameSequence={Format(last.FrameSequence)}, revision={Format(last.Revision)}. {lastException?.Message}");
+        Fail(context, $"Timed out after {FormatTimeout(timeout)} (elapsed {stopwatch.Elapsed:g}) waiting for Gua node by {description}. Last frameSequence={Format(last.FrameSequence)}, revision={Format(last.Revision)}. {lastException?.Message}", initialUiTreeJson);
         throw new UnreachableException();
     }
 
@@ -232,7 +243,7 @@ public sealed class GuaNodeExpectation
     {
         if (GuaAssertions.TryGetSnapshot(_context, _id) is null)
         {
-            GuaAssertions.Fail($"Expected Gua node {_description} to exist. {GuaAssertions.DescribeTree(_context)}");
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to exist. {GuaAssertions.DescribeTree(_context)}");
         }
 
         return this;
@@ -242,7 +253,7 @@ public sealed class GuaNodeExpectation
     {
         if (GuaAssertions.TryGetSnapshot(_context, _id) is not null)
         {
-            GuaAssertions.Fail($"Expected Gua node {_description} not to exist. {GuaAssertions.DescribeTree(_context)}");
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} not to exist. {GuaAssertions.DescribeTree(_context)}");
         }
 
         return this;
@@ -253,7 +264,7 @@ public sealed class GuaNodeExpectation
         var snapshot = GetSnapshotOrFail();
         if (!snapshot.Visible)
         {
-            GuaAssertions.Fail($"Expected Gua node {_description} to be visible, but it was hidden. {GuaAssertions.DescribeTree(_context)}");
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to be visible, but it was hidden. {GuaAssertions.DescribeTree(_context)}");
         }
 
         return this;
@@ -264,7 +275,7 @@ public sealed class GuaNodeExpectation
         var snapshot = GetSnapshotOrFail();
         if (snapshot.Visible)
         {
-            GuaAssertions.Fail($"Expected Gua node {_description} to be hidden, but it was visible. {GuaAssertions.DescribeTree(_context)}");
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to be hidden, but it was visible. {GuaAssertions.DescribeTree(_context)}");
         }
 
         return this;
@@ -275,7 +286,7 @@ public sealed class GuaNodeExpectation
         var snapshot = GetSnapshotOrFail();
         if (!snapshot.Enabled)
         {
-            GuaAssertions.Fail($"Expected Gua node {_description} to be enabled, but it was disabled. {GuaAssertions.DescribeTree(_context)}");
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to be enabled, but it was disabled. {GuaAssertions.DescribeTree(_context)}");
         }
 
         return this;
@@ -286,7 +297,7 @@ public sealed class GuaNodeExpectation
         var snapshot = GetSnapshotOrFail();
         if (snapshot.Enabled)
         {
-            GuaAssertions.Fail($"Expected Gua node {_description} to be disabled, but it was enabled. {GuaAssertions.DescribeTree(_context)}");
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to be disabled, but it was enabled. {GuaAssertions.DescribeTree(_context)}");
         }
 
         return this;
@@ -298,7 +309,7 @@ public sealed class GuaNodeExpectation
         var snapshot = GetSnapshotOrFail();
         if (!string.Equals(snapshot.Role, role, StringComparison.Ordinal))
         {
-            GuaAssertions.Fail($"Expected Gua node {_description} to have role '{role}', but it had role '{snapshot.Role}'.");
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to have role '{role}', but it had role '{snapshot.Role}'.");
         }
 
         return this;
@@ -310,7 +321,7 @@ public sealed class GuaNodeExpectation
         var snapshot = GetSnapshotOrFail();
         if (!string.Equals(snapshot.Label, label, StringComparison.Ordinal))
         {
-            GuaAssertions.Fail($"Expected Gua node {_description} to have label '{label}', but it had label '{snapshot.Label}'.");
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to have label '{label}', but it had label '{snapshot.Label}'.");
         }
 
         return this;
@@ -322,7 +333,7 @@ public sealed class GuaNodeExpectation
         var snapshot = GetSnapshotOrFail();
         if (!snapshot.Actions.Contains(action, StringComparer.Ordinal))
         {
-            GuaAssertions.Fail($"Expected Gua node {_description} to expose action '{action}', but actions were [{string.Join(", ", snapshot.Actions)}].");
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to expose action '{action}', but actions were [{string.Join(", ", snapshot.Actions)}].");
         }
 
         return this;
@@ -336,7 +347,7 @@ public sealed class GuaNodeExpectation
 
         if (!_context.EnqueueClick(_id))
         {
-            GuaAssertions.Fail(
+            GuaAssertions.Fail(_context,
                 $"Failed to enqueue click for Gua node {_description}. Click() records a request; the game adapter or GuaTestHost must consume it and emit a click event.");
         }
 
@@ -361,7 +372,7 @@ public sealed class GuaNodeExpectation
         }
         while (DateTime.UtcNow < deadline);
 
-        GuaAssertions.Fail($"Timed out waiting for click event from Gua node {_description}. The adapter consumed no click request for '{_id}'.");
+        GuaAssertions.Fail(_context, $"Timed out waiting for click event from Gua node {_description}. The adapter consumed no click request for '{_id}'.");
         return this;
     }
 
@@ -389,13 +400,13 @@ public sealed class GuaNodeExpectation
         {
             if (_context.TryPollActionEvent(requestId, out var e))
             {
-                if (!e.Succeeded) GuaAssertions.Fail($"Gua action {e.Action} failed for {_description}: {e.Error}.");
+                if (!e.Succeeded) GuaAssertions.Fail(_context, $"Gua action {e.Action} failed for {_description}: {e.Error}.");
                 return this;
             }
             Thread.Sleep(10);
         }
         while (Stopwatch.GetTimestamp() < deadline);
-        GuaAssertions.Fail($"Timed out waiting for action request {requestId} on Gua node {_description}.");
+        GuaAssertions.Fail(_context, $"Timed out waiting for action request {requestId} on Gua node {_description}.");
         return this;
     }
 
@@ -453,7 +464,7 @@ public sealed class GuaNodeExpectation
         var snapshot = GuaAssertions.TryGetSnapshot(_context, _id);
         if (snapshot is null)
         {
-            GuaAssertions.Fail($"Expected Gua node {_description} to exist. {GuaAssertions.DescribeTree(_context)}");
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to exist. {GuaAssertions.DescribeTree(_context)}");
             throw new UnreachableException();
         }
 
@@ -466,7 +477,7 @@ public sealed class GuaNodeExpectation
         ToBeEnabled();
         ToHaveAction(action);
         var error = _context.EnqueueAction(request, out var requestId);
-        if (error != GuaActionError.None) GuaAssertions.Fail($"Failed to enqueue {action} for Gua node {_description}: {error}.");
+        if (error != GuaActionError.None) GuaAssertions.Fail(_context, $"Failed to enqueue {action} for Gua node {_description}: {error}.");
         return requestId;
     }
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaDiagnostics.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaDiagnostics.cs
@@ -1,0 +1,170 @@
+using System.Text;
+using System.Text.Json;
+using Gua.Core;
+
+namespace Gua.Testing;
+
+public sealed class GuaDiagnosticOptions
+{
+    public required string TestName { get; init; }
+    public string OutputDirectory { get; init; } = Path.Combine("artifacts", "gua");
+    public IReadOnlyDictionary<string, string> Environment { get; init; } = new Dictionary<string, string>();
+    public Func<DateTimeOffset> Clock { get; init; } = () => DateTimeOffset.UtcNow;
+}
+
+public sealed record GuaDiagnosticCapture(string? ArtifactPath, string? Error)
+{
+    internal string MessageSuffix => ArtifactPath is not null
+        ? $" Gua diagnostics: {ArtifactPath}"
+        : Error is not null ? $" Gua diagnostics capture error: {Error}" : string.Empty;
+}
+
+public static class GuaDiagnosticWriter
+{
+    public static GuaDiagnosticCapture Capture(
+        IGuaContext context, string failureMessage, GuaDiagnosticOptions options, string? initialUiTreeJson = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(options);
+        var errors = new List<string>();
+        string diagnosticsJson;
+        try
+        {
+            diagnosticsJson = context.GetDiagnosticsJson();
+        }
+        catch (Exception error)
+        {
+            return new GuaDiagnosticCapture(null, $"{error.GetType().Name}: {error.Message}");
+        }
+
+        try
+        {
+            using var diagnostics = JsonDocument.Parse(diagnosticsJson);
+            var root = diagnostics.RootElement;
+            var directory = CreateUniqueDirectory(options);
+            WriteNew(Path.Combine(directory, "failure-summary.txt"), failureMessage + Environment.NewLine);
+            var environment = new Dictionary<string, object?>
+            {
+                ["testName"] = options.TestName,
+                ["processId"] = Environment.ProcessId,
+                ["framework"] = ".NET",
+                ["runtime"] = Environment.Version.ToString(),
+                ["capturedAt"] = options.Clock().ToString("O"),
+                ["host"] = options.Environment,
+                ["runtimeMetadata"] = root.GetProperty("environment").Clone(),
+            };
+            WriteNew(Path.Combine(directory, "environment.json"), JsonSerializer.Serialize(environment, JsonOptions));
+            var finalTree = root.GetProperty("uiTree").GetRawText();
+            WriteNew(Path.Combine(directory, "ui-tree.json"), Pretty(finalTree));
+            WriteNew(Path.Combine(directory, "pending-requests.json"), Pretty(root.GetProperty("pendingRequests").GetRawText()));
+            WriteNew(Path.Combine(directory, "logs.json"), Pretty(root.GetProperty("logs").GetRawText()));
+            WriteJsonLines(Path.Combine(directory, "operations.jsonl"), root.GetProperty("operations"));
+            WriteJsonLines(Path.Combine(directory, "events.jsonl"), root.GetProperty("events"));
+
+            if (initialUiTreeJson is not null)
+            {
+                WriteNew(Path.Combine(directory, "ui-tree-before.json"), Pretty(initialUiTreeJson));
+                WriteNew(Path.Combine(directory, "ui-tree.diff.json"), BuildNodeDiff(initialUiTreeJson, finalTree));
+            }
+
+            if (root.TryGetProperty("screenshot", out var screenshot) && screenshot.ValueKind == JsonValueKind.Object)
+            {
+                try
+                {
+                    WriteScreenshot(directory, screenshot);
+                }
+                catch (Exception error)
+                {
+                    errors.Add($"screenshot: {error.GetType().Name}: {error.Message}");
+                }
+            }
+            if (errors.Count > 0)
+                WriteNew(Path.Combine(directory, "capture-errors.json"), JsonSerializer.Serialize(errors, JsonOptions));
+            return new GuaDiagnosticCapture(Path.GetFullPath(directory), errors.Count == 0 ? null : string.Join("; ", errors));
+        }
+        catch (Exception error)
+        {
+            return new GuaDiagnosticCapture(null, $"{error.GetType().Name}: {error.Message}");
+        }
+    }
+
+    private static string CreateUniqueDirectory(GuaDiagnosticOptions options)
+    {
+        var testName = Sanitize(options.TestName);
+        var parent = Path.Combine(options.OutputDirectory, testName);
+        Directory.CreateDirectory(parent);
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            var id = Guid.NewGuid().ToString("N")[..8];
+            var name = $"{options.Clock():yyyyMMddTHHmmssfffZ}-{id}";
+            var path = Path.Combine(parent, name);
+            if (Directory.Exists(path)) continue;
+            Directory.CreateDirectory(path);
+            return path;
+        }
+        throw new IOException("Could not allocate a unique Gua diagnostics directory.");
+    }
+
+    private static string Sanitize(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars().ToHashSet();
+        var sanitized = new string(value.Select(ch => invalid.Contains(ch) || char.IsControl(ch) ? '_' : ch).ToArray()).Trim();
+        return string.IsNullOrWhiteSpace(sanitized) ? "unnamed-test" : sanitized;
+    }
+
+    private static void WriteNew(string path, string contents)
+    {
+        using var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+        using var writer = new StreamWriter(stream, new UTF8Encoding(false));
+        writer.Write(contents);
+    }
+
+    private static void WriteJsonLines(string path, JsonElement array)
+    {
+        var lines = array.ValueKind == JsonValueKind.Array
+            ? string.Join(Environment.NewLine, array.EnumerateArray().Select(item => item.GetRawText()))
+            : string.Empty;
+        if (lines.Length > 0) lines += Environment.NewLine;
+        WriteNew(path, lines);
+    }
+
+    private static string Pretty(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return JsonSerializer.Serialize(document.RootElement, JsonOptions);
+    }
+
+    private static string BuildNodeDiff(string beforeJson, string afterJson)
+    {
+        using var before = JsonDocument.Parse(beforeJson);
+        using var after = JsonDocument.Parse(afterJson);
+        var oldNodes = NodesById(before.RootElement);
+        var newNodes = NodesById(after.RootElement);
+        var added = newNodes.Keys.Except(oldNodes.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+        var removed = oldNodes.Keys.Except(newNodes.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+        var changed = oldNodes.Keys.Intersect(newNodes.Keys, StringComparer.Ordinal)
+            .Where(id => !string.Equals(oldNodes[id], newNodes[id], StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal).ToArray();
+        return JsonSerializer.Serialize(new { schemaVersion = 1, added, removed, changed }, JsonOptions);
+    }
+
+    private static Dictionary<string, string> NodesById(JsonElement root) =>
+        root.GetProperty("nodes").EnumerateArray().ToDictionary(
+            node => node.GetProperty("id").GetString() ?? string.Empty,
+            node => node.GetRawText(), StringComparer.Ordinal);
+
+    private static void WriteScreenshot(string directory, JsonElement screenshot)
+    {
+        var dataUri = screenshot.GetProperty("dataUri").GetString() ?? string.Empty;
+        const string prefix = "data:image/png;base64,";
+        if (dataUri.Length == 0) return;
+        if (!dataUri.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            throw new NotSupportedException("Only PNG data URIs are written by diagnostics v1.");
+        var bytes = Convert.FromBase64String(dataUri[prefix.Length..]);
+        var path = Path.Combine(directory, "screenshot.png");
+        using var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+        stream.Write(bytes);
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+}

--- a/bindings/dotnet/src/Gua.Testing/GuaLocatorQuery.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaLocatorQuery.cs
@@ -31,12 +31,12 @@ public sealed record GuaLocatorQuery
     {
         var result = Execute();
         if (result.Matches.Count == 0)
-            GuaAssertions.Fail($"Strict Gua selector matched no nodes: {Describe()}.");
+            GuaAssertions.Fail(_context, $"Strict Gua selector matched no nodes: {Describe()}.");
         if (result.Matches.Count > 1)
         {
             var candidates = string.Join("; ", result.Matches.Select(match =>
                 $"{match.Id} ({match.Role}, '{match.Label}', parentId='{match.ParentId ?? "<root>"}')"));
-            GuaAssertions.Fail($"Strict Gua selector matched {result.Matches.Count} nodes: {Describe()}. Candidates: {candidates}. Narrow the scope with Within(...) or add stable id/state filters.");
+            GuaAssertions.Fail(_context, $"Strict Gua selector matched {result.Matches.Count} nodes: {Describe()}. Candidates: {candidates}. Narrow the scope with Within(...) or add stable id/state filters.");
         }
         return new GuaNodeExpectation(_context, result.Matches[0].Id, Describe());
     }
@@ -45,7 +45,7 @@ public sealed record GuaLocatorQuery
     {
         var actual = Execute().Matches.Count;
         if (actual != expected)
-            GuaAssertions.Fail($"Expected selector {Describe()} to match {expected} nodes, but matched {actual}.");
+            GuaAssertions.Fail(_context, $"Expected selector {Describe()} to match {expected} nodes, but matched {actual}.");
         return this;
     }
 
@@ -66,7 +66,7 @@ public sealed record GuaLocatorQuery
             result = new GuaQueryResult(true, [new GuaNodeQueryMatch(id, "legacy", "legacy", null)]);
         }
         if (!result.Valid)
-            GuaAssertions.Fail($"Invalid Gua selector {Describe()}: {result.Error ?? "unknown syntax error"}");
+            GuaAssertions.Fail(_context, $"Invalid Gua selector {Describe()}: {result.Error ?? "unknown syntax error"}");
         return result;
     }
 

--- a/bindings/dotnet/src/Gua.Testing/GuaWaits.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWaits.cs
@@ -87,6 +87,7 @@ public static partial class GuaAssertions
         if (stableFrames <= 0) throw new ArgumentOutOfRangeException(nameof(stableFrames));
         var (limit, interval) = ValidateWait(timeout, pollInterval);
         var stopwatch = Stopwatch.StartNew();
+        var initialUiTreeJson = context.GetUiTreeJson();
         ulong? sessionEpoch = null;
         ulong? lastFrame = null;
         ulong? stableRevision = null;
@@ -118,7 +119,7 @@ public static partial class GuaAssertions
         }
         while (true);
 
-        Fail($"Timed out after {limit:g} (elapsed {stopwatch.Elapsed:g}) waiting for {stableFrames} distinct stable semantic frames; observed {observedStableFrames}. Last frameSequence={Format(last?.FrameSequence)}, revision={Format(last?.Revision)}, sessionEpoch={Format(last?.SessionEpoch)}.");
+        Fail(context, $"Timed out after {limit:g} (elapsed {stopwatch.Elapsed:g}) waiting for {stableFrames} distinct stable semantic frames; observed {observedStableFrames}. Last frameSequence={Format(last?.FrameSequence)}, revision={Format(last?.Revision)}, sessionEpoch={Format(last?.SessionEpoch)}.", initialUiTreeJson);
     }
 
     public static void WaitForStableSnapshot(IGuaContext context, int stableFrames = 3, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
@@ -132,6 +133,7 @@ public static partial class GuaAssertions
         ArgumentException.ThrowIfNullOrWhiteSpace(id);
         var (limit, interval) = ValidateWait(timeout, pollInterval);
         var stopwatch = Stopwatch.StartNew();
+        var initialUiTreeJson = context.GetUiTreeJson();
         WaitSnapshot? last = null;
         GuaNodeSnapshot? node = null;
         do
@@ -145,7 +147,7 @@ public static partial class GuaAssertions
         }
         while (true);
 
-        Fail($"Timed out after {limit:g} (elapsed {stopwatch.Elapsed:g}) waiting for Gua node id '{id}' to {description}. Last state: {DescribeNode(node)}; frameSequence={Format(last?.FrameSequence)}, revision={Format(last?.Revision)}.");
+        Fail(context, $"Timed out after {limit:g} (elapsed {stopwatch.Elapsed:g}) waiting for Gua node id '{id}' to {description}. Last state: {DescribeNode(node)}; frameSequence={Format(last?.FrameSequence)}, revision={Format(last?.Revision)}.", initialUiTreeJson);
         throw new UnreachableException();
     }
 

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -108,3 +108,26 @@ Node expectations expose `Focus`, `SetValue`, `SetChecked`, `Select`, `Scroll`,
 and `PressKey`. These methods enqueue requests and return a request ID;
 `WaitForAction` waits for the adapter's correlated observed result rather than
 treating enqueue acceptance as completion.
+
+## Failure diagnostics
+
+Configure `GuaAssertionOptions.Diagnostics` to capture a unique artifact
+directory automatically when a semantic assertion or wait fails:
+
+```csharp
+using var scope = GuaAssertionScope.Use(new GuaAssertionOptions
+{
+    Diagnostics = new GuaDiagnosticOptions
+    {
+        TestName = TestContext.CurrentContext.Test.FullName,
+        OutputDirectory = Path.Combine("artifacts", "gua"),
+    },
+});
+```
+
+The directory contains the final UI tree, bounded operation/event history,
+pending requests, logs, environment metadata, and an optional PNG. A wait also
+writes its initial tree and a deterministic node-id diff. Sensitive action
+values are redacted before the writer receives them. If capture fails, the
+original assertion delegate still determines the exception type and a secondary
+capture error is appended to its message.

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using Gua.Core;
 using Gua.Testing;
 using Gua.Testing.Godot;
@@ -46,6 +47,13 @@ public sealed class SelectorParityTests
             {
                 Assert.That(local.Query(invalid).Valid, Is.False);
                 Assert.That(remote.Query(invalid).Valid, Is.False);
+            });
+            using var diagnostics = JsonDocument.Parse(remote.GetDiagnosticsJson());
+            Assert.Multiple(() =>
+            {
+                Assert.That(diagnostics.RootElement.GetProperty("schemaVersion").GetInt32(), Is.EqualTo(1));
+                Assert.That(diagnostics.RootElement.GetProperty("uiTree").GetProperty("screen").GetString(), Is.EqualTo("fixture"));
+                Assert.That(diagnostics.RootElement.GetProperty("screenshot").ValueKind, Is.EqualTo(JsonValueKind.Null));
             });
         }
         finally

--- a/examples/dotnet-nunit/GuaDotNetNUnitSample.csproj
+++ b/examples/dotnet-nunit/GuaDotNetNUnitSample.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Gua.Testing" Version="$(GuaPackageVersion)" />
+    <PackageReference Include="Gua.Testing" Version="$(GuaPackageVersion)" Condition="'$(UseProjectReferences)' != 'true'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseProjectReferences)' == 'true'">
+    <ProjectReference Include="..\..\bindings\dotnet\src\Gua.Testing\Gua.Testing.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/examples/dotnet-nunit/TitleScreenTests.cs
+++ b/examples/dotnet-nunit/TitleScreenTests.cs
@@ -221,6 +221,103 @@ public sealed class TitleScreenTests
     }
 
     [Test]
+    public void DiagnosticsWriterCreatesVersionedRedactedArtifacts()
+    {
+        using var ui = new GuaContext();
+        ui.ConfigureDiagnostics(2, "{\"bridge\":\"local\"}");
+        ui.BeginFrame("form");
+        ui.RegisterNode(new GuaNodeDescriptor("password", "textbox", "Password", new GuaBounds(0, 0, 100, 20), Value: string.Empty));
+        ui.EndFrame();
+        var before = ui.GetUiTreeJson();
+        var requestId = GuaAssertions.GetById(ui, "password").SetValue("secret-marker", sensitive: true);
+        Assert.That(ui.TryConsumeAction(GuaActionType.SetValue, "password", out var request), Is.True);
+        Assert.That(ui.EmitActionResult(new GuaActionEvent(requestId, GuaActionType.SetValue, true,
+            GuaActionError.None, "password", request.Value!, true)), Is.True);
+        Assert.That(ui.TryPollActionEvent(requestId, out _), Is.True);
+        ui.BeginFrame("form");
+        ui.RegisterNode(new GuaNodeDescriptor("password", "textbox", "Password changed", new GuaBounds(0, 0, 100, 20), Value: string.Empty));
+        ui.EndFrame();
+
+        var output = Path.Combine(TestContext.CurrentContext.WorkDirectory, "gua-diagnostics", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var capture = GuaDiagnosticWriter.Capture(ui, "intentional failure", new GuaDiagnosticOptions
+            {
+                TestName = "diagnostics/redaction",
+                OutputDirectory = output,
+                Environment = new Dictionary<string, string> { ["bridge"] = "in-process" },
+            }, before);
+            Assert.That(capture.Error, Is.Null);
+            Assert.That(capture.ArtifactPath, Is.Not.Null);
+            var path = capture.ArtifactPath!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(File.Exists(Path.Combine(path, "failure-summary.txt")), Is.True);
+                Assert.That(File.Exists(Path.Combine(path, "environment.json")), Is.True);
+                Assert.That(File.Exists(Path.Combine(path, "ui-tree.json")), Is.True);
+                Assert.That(File.Exists(Path.Combine(path, "ui-tree.diff.json")), Is.True);
+                Assert.That(File.Exists(Path.Combine(path, "events.jsonl")), Is.True);
+                Assert.That(File.Exists(Path.Combine(path, "operations.jsonl")), Is.True);
+                Assert.That(File.Exists(Path.Combine(path, "pending-requests.json")), Is.True);
+                Assert.That(File.Exists(Path.Combine(path, "logs.json")), Is.True);
+                Assert.That(File.Exists(Path.Combine(path, "screenshot.png")), Is.False);
+                Assert.That(string.Join("\n", Directory.EnumerateFiles(path).Select(File.ReadAllText)), Does.Not.Contain("secret-marker"));
+                Assert.That(File.ReadAllText(Path.Combine(path, "ui-tree.diff.json")), Does.Contain("password").And.Contain("changed"));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(output)) Directory.Delete(output, recursive: true);
+        }
+    }
+
+    [Test]
+    public void AssertionAndWaitFailuresCaptureArtifactsAndPreserveFailureOnWriterError()
+    {
+        using var ui = new GuaContext();
+        ui.BeginFrame("test");
+        ui.RegisterNode(new GuaNodeDescriptor("status", "status", "Status", new GuaBounds(0, 0, 1, 1), Visible: false));
+        ui.EndFrame();
+        var output = Path.Combine(TestContext.CurrentContext.WorkDirectory, "gua-diagnostics", Guid.NewGuid().ToString("N"));
+        try
+        {
+            using (GuaAssertionScope.Use(new GuaAssertionOptions
+            {
+                Diagnostics = new GuaDiagnosticOptions { TestName = "assertion", OutputDirectory = output },
+            }))
+            {
+                var assertion = Assert.Throws<GuaAssertionException>(() => GuaAssertions.GetById(ui, "status").ToBeVisible());
+                Assert.That(assertion!.Message, Does.Contain("Gua diagnostics:"));
+            }
+            using (GuaAssertionScope.Use(new GuaAssertionOptions
+            {
+                Diagnostics = new GuaDiagnosticOptions { TestName = "wait", OutputDirectory = output },
+            }))
+            {
+                var timeout = Assert.ThrowsAsync<GuaAssertionException>(async () =>
+                    await GuaAssertions.WaitForVisibleAsync(ui, "status", TimeSpan.FromMilliseconds(5), TimeSpan.FromMilliseconds(1)));
+                Assert.That(timeout!.Message, Does.Contain("Gua diagnostics:"));
+            }
+
+            var blockingFile = Path.Combine(output, "not-a-directory");
+            Directory.CreateDirectory(output);
+            File.WriteAllText(blockingFile, "block");
+            using (GuaAssertionScope.Use(new GuaAssertionOptions
+            {
+                Diagnostics = new GuaDiagnosticOptions { TestName = "writer-failure", OutputDirectory = blockingFile },
+            }))
+            {
+                var original = Assert.Throws<GuaAssertionException>(() => GuaAssertions.GetById(ui, "status").ToBeVisible());
+                Assert.That(original!.Message, Does.StartWith("Expected Gua node").And.Contain("capture error"));
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(output)) Directory.Delete(output, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task AsyncWaitsObserveStateTextValueAndRemovalWithoutFixedSleeps()
     {
         using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -277,6 +277,13 @@ void gua_set_screenshot(gua_context_t* ctx, const char* data_uri, int width, int
 const char* gua_get_screenshot_json(gua_context_t* ctx);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
 int gua_copy_screenshot_json(gua_context_t* ctx, char* out_json, int out_json_size);
+/* Configures the bounded diagnostics history. A limit of 0 disables retained history. */
+int gua_set_diagnostics_history_limit(gua_context_t* ctx, uint32_t history_limit);
+/* Stores caller-provided environment metadata as a JSON object for later diagnostics capture. */
+int gua_set_diagnostics_environment_json(gua_context_t* ctx, const char* environment_json);
+const char* gua_get_diagnostics_json(gua_context_t* ctx);
+/* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
+int gua_copy_diagnostics_json(gua_context_t* ctx, char* out_json, int out_json_size);
 int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state);
 int gua_get_node_state_v2(gua_context_t* ctx, const char* node_id, gua_node_state_v2_t* out_state);
 int gua_find_node_by_id(gua_context_t* ctx, const char* node_id, char* out_node_id, int out_node_id_size);

--- a/native/gua-core/include/gua/gua.hpp
+++ b/native/gua-core/include/gua/gua.hpp
@@ -239,6 +239,20 @@ public:
         return copy_json(gua_copy_screenshot_json);
     }
 
+    void configure_diagnostics(std::uint32_t history_limit, std::string_view environment_json = "{}")
+    {
+        environment_buffer_.assign(environment_json);
+        if (gua_set_diagnostics_history_limit(context_, history_limit) == 0 ||
+            gua_set_diagnostics_environment_json(context_, environment_buffer_.c_str()) == 0) {
+            throw std::invalid_argument("Invalid Gua diagnostics configuration");
+        }
+    }
+
+    [[nodiscard]] std::string diagnostics_json() const
+    {
+        return copy_json(gua_copy_diagnostics_json);
+    }
+
     [[nodiscard]] bool enqueue_click(std::string_view node_id)
     {
         id_buffer_.assign(node_id);
@@ -359,6 +373,7 @@ private:
     mutable std::string key_buffer_;
     mutable std::string message_buffer_;
     std::string screenshot_buffer_;
+    std::string environment_buffer_;
     std::string screen_buffer_;
 };
 

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -68,6 +68,18 @@ struct Screenshot {
     int height = 0;
 };
 
+struct HistoryEntry {
+    unsigned long long sequence;
+    std::string phase;
+    unsigned long long request_id;
+    int action;
+    std::string node_id;
+    int status;
+    int error_code;
+    std::string value;
+    bool sensitive;
+};
+
 const char* log_level_name(int level)
 {
     switch (level) {
@@ -267,11 +279,17 @@ struct gua_context_t {
     std::string json_cache;
     std::string logs_json_cache;
     std::string screenshot_json_cache;
+    std::string diagnostics_json_cache;
     unsigned long long frame_sequence = 0;
     unsigned long long revision = 0;
     unsigned long long next_request_id = 1;
     unsigned long long session_epoch = 1;
     std::string previous_semantic_snapshot;
+    std::deque<HistoryEntry> operation_history;
+    std::deque<HistoryEntry> event_history;
+    std::size_t diagnostics_history_limit = 100;
+    unsigned long long next_history_sequence = 1;
+    std::string diagnostics_environment_json = "{}";
 };
 
 namespace {
@@ -415,6 +433,74 @@ std::string build_screenshot_json(const gua_context_t& ctx)
     json += std::to_string(ctx.screenshot.height);
     json += "}";
     return json;
+}
+
+void trim_history(std::deque<HistoryEntry>& history, std::size_t limit)
+{
+    while (history.size() > limit) history.pop_front();
+}
+
+void append_history(gua_context_t& ctx, std::deque<HistoryEntry>& history, std::string phase,
+    unsigned long long request_id, int action, const std::string& node_id, int status,
+    int error_code, const std::string& value, bool sensitive)
+{
+    if (ctx.diagnostics_history_limit == 0) return;
+    history.push_back(HistoryEntry { ctx.next_history_sequence++, std::move(phase), request_id, action,
+        node_id, status, error_code, sensitive ? "" : value, sensitive });
+    trim_history(history, ctx.diagnostics_history_limit);
+    ctx.diagnostics_json_cache.clear();
+}
+
+std::string build_request_json(const ActionRequest& request)
+{
+    return "{\"requestId\":" + std::to_string(request.request_id) +
+        ",\"action\":\"" + action_name(request.action) + "\",\"nodeId\":\"" + escape_json(request.node_id) +
+        "\",\"value\":\"" + escape_json(request.sensitive ? "" : request.value) +
+        "\",\"sensitive\":" + (request.sensitive ? "true" : "false") + "}";
+}
+
+std::string build_history_json(const std::deque<HistoryEntry>& history)
+{
+    std::string json = "[";
+    for (std::size_t i = 0; i < history.size(); ++i) {
+        if (i > 0) json += ",";
+        const auto& entry = history[i];
+        json += "{\"sequence\":" + std::to_string(entry.sequence) + ",\"phase\":\"" + escape_json(entry.phase) +
+            "\",\"requestId\":" + std::to_string(entry.request_id) + ",\"action\":\"" + action_name(entry.action) +
+            "\",\"nodeId\":\"" + escape_json(entry.node_id) + "\",\"status\":" + std::to_string(entry.status) +
+            ",\"errorCode\":" + std::to_string(entry.error_code) + ",\"value\":\"" + escape_json(entry.value) +
+            "\",\"sensitive\":" + (entry.sensitive ? "true" : "false") + "}";
+    }
+    return json + "]";
+}
+
+std::string build_diagnostics_json(const gua_context_t& ctx)
+{
+    std::string pending = "[";
+    bool comma = false;
+    for (const auto& request : ctx.action_requests) {
+        if (comma) pending += ",";
+        pending += build_request_json(request);
+        comma = true;
+    }
+    for (const auto& request : ctx.consumed_requests) {
+        if (comma) pending += ",";
+        pending += build_request_json(request);
+        comma = true;
+    }
+    pending += "]";
+    return "{\"schemaVersion\":1,\"sessionEpoch\":" + std::to_string(ctx.session_epoch) +
+        ",\"frameSequence\":" + std::to_string(ctx.frame_sequence) + ",\"revision\":" + std::to_string(ctx.revision) +
+        ",\"historyLimit\":" + std::to_string(ctx.diagnostics_history_limit) +
+        ",\"pendingRequestCount\":" + std::to_string(ctx.action_requests.size()) +
+        ",\"inFlightRequestCount\":" + std::to_string(ctx.consumed_requests.size()) +
+        ",\"unconsumedEventCount\":" + std::to_string(ctx.events.size()) +
+        ",\"environment\":" + ctx.diagnostics_environment_json +
+        ",\"uiTree\":" + build_ui_tree_json(ctx) + ",\"pendingRequests\":" + pending +
+        ",\"operations\":" + build_history_json(ctx.operation_history) +
+        ",\"events\":" + build_history_json(ctx.event_history) +
+        ",\"logs\":" + build_logs_json(ctx) + ",\"screenshot\":" +
+        (ctx.screenshot.data_uri.empty() ? "null" : build_screenshot_json(ctx)) + "}";
 }
 
 } // namespace
@@ -597,6 +683,45 @@ extern "C" int gua_copy_screenshot_json(gua_context_t* ctx, char* out_json, int 
 
     const std::lock_guard lock(ctx->mutex);
     return copy_json_string(build_screenshot_json(*ctx), out_json, out_json_size);
+}
+
+extern "C" int gua_set_diagnostics_history_limit(gua_context_t* ctx, uint32_t history_limit)
+{
+    if (ctx == nullptr) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    ctx->diagnostics_history_limit = history_limit;
+    trim_history(ctx->operation_history, history_limit);
+    trim_history(ctx->event_history, history_limit);
+    ctx->diagnostics_json_cache.clear();
+    return 1;
+}
+
+extern "C" int gua_set_diagnostics_environment_json(gua_context_t* ctx, const char* environment_json)
+{
+    if (ctx == nullptr || environment_json == nullptr) return 0;
+    const std::string value(environment_json);
+    const auto first = value.find_first_not_of(" \t\r\n");
+    const auto last = value.find_last_not_of(" \t\r\n");
+    if (first == std::string::npos || value[first] != '{' || value[last] != '}') return 0;
+    const std::lock_guard lock(ctx->mutex);
+    ctx->diagnostics_environment_json = value;
+    ctx->diagnostics_json_cache.clear();
+    return 1;
+}
+
+extern "C" const char* gua_get_diagnostics_json(gua_context_t* ctx)
+{
+    if (ctx == nullptr) return "{}";
+    const std::lock_guard lock(ctx->mutex);
+    ctx->diagnostics_json_cache = build_diagnostics_json(*ctx);
+    return ctx->diagnostics_json_cache.c_str();
+}
+
+extern "C" int gua_copy_diagnostics_json(gua_context_t* ctx, char* out_json, int out_json_size)
+{
+    if (ctx == nullptr) return copy_json_string("{}", out_json, out_json_size);
+    const std::lock_guard lock(ctx->mutex);
+    return copy_json_string(build_diagnostics_json(*ctx), out_json, out_json_size);
 }
 
 extern "C" int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state)
@@ -801,6 +926,8 @@ extern "C" int gua_enqueue_action(gua_context_t* ctx, const gua_action_request_d
         request_id, descriptor->action, node_id, value, descriptor->delta_x, descriptor->delta_y,
         descriptor->bool_value, key, descriptor->modifiers, descriptor->sensitive != 0, descriptor->scroll_unit
     });
+    append_history(*ctx, ctx->operation_history, "enqueued", request_id, descriptor->action, node_id,
+        GUA_ACTION_ACCEPTED, 0, value, descriptor->sensitive != 0);
     if (out_request_id != nullptr) *out_request_id = request_id;
     return GUA_ACTION_ACCEPTED;
 }
@@ -817,6 +944,8 @@ extern "C" int gua_consume_action_request(gua_context_t* ctx, int action, const 
     const ActionRequest value = *request;
     ctx->action_requests.erase(request);
     ctx->consumed_requests.push_back(value);
+    append_history(*ctx, ctx->operation_history, "consumed", value.request_id, value.action, value.node_id,
+        GUA_ACTION_ACCEPTED, 0, value.value, value.sensitive);
     out_request->request_id = value.request_id;
     out_request->action = value.action;
     std::snprintf(out_request->node_id, sizeof(out_request->node_id), "%s", value.node_id.c_str());
@@ -853,6 +982,9 @@ extern "C" int gua_emit_action_result(gua_context_t* ctx, const gua_action_resul
         result->sensitive != 0 ? "" : (result->value != nullptr ? result->value : ""),
         result->sensitive != 0,
     });
+    append_history(*ctx, ctx->event_history, "observed", result->request_id, result->action,
+        result->node_id != nullptr ? result->node_id : "", result->status, result->error_code,
+        result->value != nullptr ? result->value : "", result->sensitive != 0);
     if (consumed != ctx->consumed_requests.end()) ctx->consumed_requests.erase(consumed);
     return 1;
 }
@@ -962,6 +1094,12 @@ extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* 
         ctx->consumed_requests.clear();
     }
     if ((options->flags & GUA_RESET_EVENTS) != 0U) ctx->events.clear();
+    if ((options->flags & GUA_RESET_HISTORY) != 0U) {
+        ctx->operation_history.clear();
+        ctx->event_history.clear();
+        ctx->next_history_sequence = 1;
+        ctx->diagnostics_json_cache.clear();
+    }
     if ((options->flags & GUA_RESET_LOGS) != 0U) {
         ctx->logs.clear();
         ctx->next_log_sequence = 1;

--- a/native/gua-core/tests/selector_tests.cpp
+++ b/native/gua-core/tests/selector_tests.cpp
@@ -2,6 +2,8 @@
 #include "gua/testing.hpp"
 
 #include <cassert>
+#include <filesystem>
+#include <fstream>
 #include <stdexcept>
 #include <string>
 
@@ -72,6 +74,37 @@ int main()
             message.find("frameSequence=1") != std::string::npos && message.find("revision=1") != std::string::npos;
     }
     assert(stale_snapshot_rejected);
+
+    const auto diagnostics_root = std::filesystem::temp_directory_path() / "gua-native-diagnostics-test";
+    std::filesystem::remove_all(diagnostics_root);
+    bool native_artifact_reported = false;
+    {
+        DiagnosticScope diagnostics({ diagnostics_root, "hidden assertion" });
+        try { Locator(context, "hidden").to_be_visible(); }
+        catch (const std::runtime_error& error) {
+            native_artifact_reported = std::string(error.what()).find("Gua diagnostics:") != std::string::npos;
+        }
+    }
+    assert(native_artifact_reported);
+    bool native_artifact_exists = false;
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(diagnostics_root)) {
+        if (entry.path().filename() == "diagnostics.json") native_artifact_exists = true;
+    }
+    assert(native_artifact_exists);
+    const auto blocking_file = diagnostics_root / "not-a-directory";
+    std::ofstream(blocking_file) << "block";
+    bool native_capture_error_preserved = false;
+    {
+        DiagnosticScope diagnostics({ blocking_file, "writer failure" });
+        try { Locator(context, "hidden").to_be_visible(); }
+        catch (const std::runtime_error& error) {
+            const std::string message(error.what());
+            native_capture_error_preserved = message.starts_with("Expected Gua node") &&
+                message.find("Gua diagnostics capture error:") != std::string::npos;
+        }
+    }
+    assert(native_capture_error_preserved);
+    std::filesystem::remove_all(diagnostics_root);
 
     int attempts = 0;
     wait_until([&attempts] { return ++attempts == 3; }, "third predicate evaluation", std::chrono::milliseconds(20), std::chrono::milliseconds(1));

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -141,6 +141,16 @@ int main()
     assert(event.sensitive == 1);
     assert(std::strlen(event.value) == 0);
 
+    assert(gua_set_diagnostics_history_limit(context, 2) == 1);
+    assert(gua_set_diagnostics_environment_json(context, "{\"testName\":\"native-state\"}") == 1);
+    const std::string diagnostics = gua_get_diagnostics_json(context);
+    assert(diagnostics.find("\"schemaVersion\":1") != std::string::npos);
+    assert(diagnostics.find("\"historyLimit\":2") != std::string::npos);
+    assert(diagnostics.find("\"testName\":\"native-state\"") != std::string::npos);
+    assert(diagnostics.find("\"screenshot\":null") != std::string::npos);
+    assert(diagnostics.find("secret-marker") == std::string::npos);
+    assert(diagnostics.find("\"sensitive\":true") != std::string::npos);
+
     gua_action_request_t in_flight { sizeof(gua_action_request_t) };
     assert(gua_consume_action_request(context, GUA_ACTION_FOCUS, "name", &in_flight) == 1);
 
@@ -183,6 +193,9 @@ int main()
     assert(gua_get_context_status(context, &status) == 1);
     assert(status.session_epoch == 2 && status.frame_sequence == 0 && status.revision == 0);
     assert(status.node_count == 0 && status.pending_request_count == 0 && status.unconsumed_event_count == 0);
+    const std::string reset_diagnostics = gua_get_diagnostics_json(context);
+    assert(reset_diagnostics.find("\"operations\":[]") != std::string::npos);
+    assert(reset_diagnostics.find("\"events\":[]") != std::string::npos);
     assert(std::string(gua_get_ui_tree_json(context)).find("\"sessionEpoch\":2") != std::string::npos);
     char other_id[16] {};
     assert(gua_find_node_by_id(other, "other", other_id, sizeof(other_id)) == 1);

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -35,6 +35,10 @@ void gua_runtime_set_screenshot(gua_runtime_t* runtime, const char* data_uri, in
 const char* gua_runtime_get_screenshot_json(gua_runtime_t* runtime);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
 int gua_runtime_copy_screenshot_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
+int gua_runtime_set_diagnostics_history_limit(gua_runtime_t* runtime, uint32_t history_limit);
+int gua_runtime_set_diagnostics_environment_json(gua_runtime_t* runtime, const char* environment_json);
+const char* gua_runtime_get_diagnostics_json(gua_runtime_t* runtime);
+int gua_runtime_copy_diagnostics_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
 int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* node_id, gua_node_state_t* out_state);
 int gua_runtime_get_node_state_v2(gua_runtime_t* runtime, const char* node_id, gua_node_state_v2_t* out_state);
 int gua_runtime_find_node_by_id(gua_runtime_t* runtime, const char* node_id, char* out_node_id, int out_node_id_size);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -19,6 +19,7 @@ struct gua_runtime_t {
     std::string ui_tree_json;
     std::string logs_json;
     std::string screenshot_json;
+    std::string diagnostics_json;
 };
 
 std::string escape_json(std::string_view value);
@@ -55,6 +56,12 @@ std::string copy_screenshot_json(gua_runtime_t* runtime)
 {
     const std::lock_guard lock(runtime->context_mutex);
     return gua_get_screenshot_json(runtime->context);
+}
+
+std::string copy_diagnostics_json(gua_runtime_t* runtime)
+{
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_get_diagnostics_json(runtime->context);
 }
 
 std::string status_json(gua_runtime_t* runtime)
@@ -258,6 +265,33 @@ extern "C" int gua_runtime_copy_screenshot_json(gua_runtime_t* runtime, char* ou
     return copy_json_string(copy_screenshot_json(runtime), out_json, out_json_size);
 }
 
+extern "C" int gua_runtime_set_diagnostics_history_limit(gua_runtime_t* runtime, uint32_t history_limit)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_set_diagnostics_history_limit(runtime->context, history_limit);
+}
+
+extern "C" int gua_runtime_set_diagnostics_environment_json(gua_runtime_t* runtime, const char* environment_json)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_set_diagnostics_environment_json(runtime->context, environment_json);
+}
+
+extern "C" const char* gua_runtime_get_diagnostics_json(gua_runtime_t* runtime)
+{
+    if (!valid_runtime(runtime)) return "{}";
+    runtime->diagnostics_json = copy_diagnostics_json(runtime);
+    return runtime->diagnostics_json.c_str();
+}
+
+extern "C" int gua_runtime_copy_diagnostics_json(gua_runtime_t* runtime, char* out_json, int out_json_size)
+{
+    if (!valid_runtime(runtime)) return copy_json_string("{}", out_json, out_json_size);
+    return copy_json_string(copy_diagnostics_json(runtime), out_json, out_json_size);
+}
+
 extern "C" int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* node_id, gua_node_state_t* out_state)
 {
     if (!valid_runtime(runtime)) {
@@ -445,6 +479,9 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
         },
         .get_screenshot_json = [runtime] {
             return copy_screenshot_json(runtime);
+        },
+        .get_diagnostics_json = [runtime] {
+            return copy_diagnostics_json(runtime);
         },
         .query_nodes_json = [runtime](const gua::ws::QuerySelector& selector) {
             gua_selector_v1_t native {

--- a/native/gua-testing/include/gua/testing.hpp
+++ b/native/gua-testing/include/gua/testing.hpp
@@ -3,8 +3,12 @@
 #include "gua/gua.h"
 
 #include <chrono>
+#include <atomic>
+#include <cctype>
 #include <cstdint>
 #include <functional>
+#include <filesystem>
+#include <fstream>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -14,6 +18,52 @@
 #include <vector>
 
 namespace gua::testing {
+
+struct DiagnosticOptions {
+    std::filesystem::path output_directory = std::filesystem::path("artifacts") / "gua";
+    std::string test_name = "native-test";
+};
+
+inline thread_local std::optional<DiagnosticOptions> current_diagnostics;
+
+class DiagnosticScope {
+public:
+    explicit DiagnosticScope(DiagnosticOptions options) : previous_(current_diagnostics)
+    {
+        current_diagnostics = std::move(options);
+    }
+    ~DiagnosticScope() { current_diagnostics = previous_; }
+private:
+    std::optional<DiagnosticOptions> previous_;
+};
+
+[[noreturn]] inline void fail(gua_context_t* context, std::string message)
+{
+    if (!current_diagnostics.has_value() || context == nullptr) throw std::runtime_error(message);
+    std::filesystem::path directory;
+    try {
+        std::string name = current_diagnostics->test_name;
+        for (char& ch : name) if (!std::isalnum(static_cast<unsigned char>(ch)) && ch != '-' && ch != '_') ch = '_';
+        static std::atomic<unsigned long long> failure_id { 1 };
+        directory = current_diagnostics->output_directory / name /
+            (std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count()) + "-" + std::to_string(failure_id++));
+        std::filesystem::create_directories(directory);
+        const int required = gua_copy_diagnostics_json(context, nullptr, 0);
+        std::string json(static_cast<std::size_t>(required), '\0');
+        gua_copy_diagnostics_json(context, json.data(), required);
+        json.resize(static_cast<std::size_t>(required - 1));
+        std::ofstream diagnostics_file(directory / "diagnostics.json", std::ios::binary);
+        diagnostics_file.exceptions(std::ios::badbit | std::ios::failbit);
+        diagnostics_file << json;
+        std::ofstream summary_file(directory / "failure-summary.txt", std::ios::binary);
+        summary_file.exceptions(std::ios::badbit | std::ios::failbit);
+        summary_file << message << '\n';
+    } catch (const std::exception& error) {
+        throw std::runtime_error(message + " Gua diagnostics capture error: " + error.what());
+    }
+    throw std::runtime_error(message + " Gua diagnostics: " + directory.string());
+}
 
 class Locator {
 public:
@@ -37,7 +87,7 @@ public:
     {
         const gua_node_state_t state = read_state();
         if (state.visible == 0) {
-            throw std::runtime_error("Expected Gua node to be visible: " + id_);
+            fail(context_, "Expected Gua node to be visible: " + id_);
         }
     }
 
@@ -45,14 +95,14 @@ public:
     {
         const gua_node_state_t state = read_state();
         if (state.enabled == 0) {
-            throw std::runtime_error("Expected Gua node to be enabled: " + id_);
+            fail(context_, "Expected Gua node to be enabled: " + id_);
         }
     }
 
     void click() const
     {
         if (gua_enqueue_click(context_, id_.c_str()) == 0) {
-            throw std::runtime_error("Failed to click Gua node: " + id_);
+            fail(context_, "Failed to click Gua node: " + id_);
         }
     }
 
@@ -84,7 +134,7 @@ public:
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         } while (std::chrono::steady_clock::now() < deadline);
-        throw std::runtime_error("Timed out waiting for Gua action completion: " + id_);
+        fail(context_, "Timed out waiting for Gua action completion: " + id_);
     }
 
     void wait_for(

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -39,6 +39,7 @@ struct BridgeHandlers {
     std::function<std::string()> get_ui_tree_json;
     std::function<std::string()> get_logs_json;
     std::function<std::string()> get_screenshot_json;
+    std::function<std::string()> get_diagnostics_json;
     std::function<std::string(const QuerySelector& selector)> query_nodes_json;
     std::function<std::string()> get_context_status_json;
     std::function<std::string(unsigned long long expected_epoch, unsigned int flags, bool strict)> reset_context_json;

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -817,6 +817,11 @@ private:
             if (command.type == "get_screenshot") {
                 return ok_response(command.id, handlers_.get_screenshot_json());
             }
+            if (command.type == "get_diagnostics") {
+                return handlers_.get_diagnostics_json
+                    ? ok_response(command.id, handlers_.get_diagnostics_json())
+                    : error_response(command.id, "get_diagnostics is not supported by this bridge");
+            }
             if (command.type == "query_nodes") {
                 if (!handlers_.query_nodes_json) {
                     return error_response(command.id, "query_nodes is not supported by this bridge");

--- a/protocol/fixtures/diagnostics-v1.json
+++ b/protocol/fixtures/diagnostics-v1.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "sessionEpoch": 1,
+  "frameSequence": 1,
+  "revision": 1,
+  "historyLimit": 100,
+  "pendingRequestCount": 0,
+  "inFlightRequestCount": 0,
+  "unconsumedEventCount": 0,
+  "environment": { "testName": "fixture" },
+  "uiTree": { "schemaVersion": 2, "sessionEpoch": 1, "frameSequence": 1, "revision": 1, "screen": "title", "nodes": [] },
+  "pendingRequests": [],
+  "operations": [],
+  "events": [],
+  "logs": [],
+  "screenshot": null
+}

--- a/protocol/schema/commands.schema.json
+++ b/protocol/schema/commands.schema.json
@@ -132,7 +132,7 @@
       "additionalProperties": false,
       "properties": {
         "type": {
-          "enum": ["get_screenshot", "get_logs", "get_context_status", "poll_events"]
+          "enum": ["get_screenshot", "get_logs", "get_diagnostics", "get_context_status", "poll_events"]
         }
       }
     }

--- a/protocol/schema/diagnostics.schema.json
+++ b/protocol/schema/diagnostics.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gua.dev/schema/diagnostics.schema.json",
+  "title": "Gua diagnostics snapshot",
+  "type": "object",
+  "required": ["schemaVersion", "sessionEpoch", "frameSequence", "revision", "historyLimit", "pendingRequestCount", "inFlightRequestCount", "unconsumedEventCount", "environment", "uiTree", "pendingRequests", "operations", "events", "logs", "screenshot"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "sessionEpoch": { "type": "integer", "minimum": 1 },
+    "frameSequence": { "type": "integer", "minimum": 0 },
+    "revision": { "type": "integer", "minimum": 0 },
+    "historyLimit": { "type": "integer", "minimum": 0 },
+    "pendingRequestCount": { "type": "integer", "minimum": 0 },
+    "inFlightRequestCount": { "type": "integer", "minimum": 0 },
+    "unconsumedEventCount": { "type": "integer", "minimum": 0 },
+    "environment": { "type": "object" },
+    "uiTree": { "$ref": "ui-tree.schema.json" },
+    "pendingRequests": { "type": "array", "items": { "$ref": "#/$defs/request" } },
+    "operations": { "type": "array", "items": { "$ref": "#/$defs/history" } },
+    "events": { "type": "array", "items": { "$ref": "#/$defs/history" } },
+    "logs": { "$ref": "logs.schema.json" },
+    "screenshot": { "oneOf": [{ "type": "null" }, { "$ref": "screenshot.schema.json" }] }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "action": { "enum": ["click", "focus", "set_value", "set_checked", "select", "scroll", "press_key"] },
+    "request": { "type": "object", "required": ["requestId", "action", "nodeId", "value", "sensitive"], "properties": { "requestId": { "type": "integer", "minimum": 1 }, "action": { "$ref": "#/$defs/action" }, "nodeId": { "type": "string" }, "value": { "type": "string" }, "sensitive": { "type": "boolean" } }, "additionalProperties": false },
+    "history": { "type": "object", "required": ["sequence", "phase", "requestId", "action", "nodeId", "status", "errorCode", "value", "sensitive"], "properties": { "sequence": { "type": "integer", "minimum": 1 }, "phase": { "enum": ["enqueued", "consumed", "observed"] }, "requestId": { "type": "integer", "minimum": 0 }, "action": { "$ref": "#/$defs/action" }, "nodeId": { "type": "string" }, "status": { "type": "integer" }, "errorCode": { "type": "integer" }, "value": { "type": "string" }, "sensitive": { "type": "boolean" } }, "additionalProperties": false }
+  }
+}

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -58,6 +58,31 @@ epoch is rejected without mutation. Multiple clients of one runtime observe the
 same reset because the isolation boundary is the shared runtime context, not a
 WebSocket connection.
 
+## Failure diagnostics and artifact version 1
+
+`diagnostics.schema.json` is the source of truth for a best-effort failure
+snapshot. The additive C ABI copy-JSON API and WebSocket `get_diagnostics`
+command return the same versioned document. It includes the final semantic UI
+tree, session/frame/revision, pending and in-flight requests, recent operation
+and observed-event history, logs, optional screenshot, and caller-provided
+environment metadata.
+
+Operation and event history are context-owned bounded ring buffers. The default
+limit is 100 entries per history and callers may set another non-negative limit;
+zero disables retention. Polling an event never removes its retained history.
+`GUA_RESET_HISTORY` clears both histories without changing queue semantics.
+
+Sensitive action values are available only while the adapter consumes a
+request. Pending diagnostics and retained history store an empty value with
+`sensitive: true`; they never retain plaintext. A missing screenshot is `null`
+and does not fail semantic diagnostics capture.
+
+Filesystem layout and overwrite policy belong to testing helpers, not the
+runtime core. Writers use a unique failure directory, preserve the original
+assertion/timeout when capture fails, and report capture errors as a secondary
+note. When a wait captured an initial tree, the writer creates a deterministic
+node-id diff with added, removed, and changed IDs.
+
 ## Adapter-Owned Reflection
 
 Runtime adapters should rebuild the semantic tree from the host UI every frame
@@ -161,6 +186,7 @@ The v1 action names map directly to the additive C ABI action enum: `click`, `fo
 - `wait_for_node`
 - `get_screenshot`
 - `get_logs`
+- `get_diagnostics`
 - `poll_events`
 - `get_context_status`
 - `reset_context` with `expectedSessionEpoch`, optional reset `flags`, and optional `strict`
@@ -209,6 +235,7 @@ Initial MCP tools:
 - `wait_for_node`: polls `get_ui_tree` until a node id appears
 - `get_screenshot`: returns the latest screenshot payload
 - `get_logs`: returns ordered runtime logs
+- `get_diagnostics`: returns the versioned best-effort diagnostics snapshot
 - `run_test`: executes a small list of `wait_for_node` and `click_node` steps
 
 The MCP server uses stdio JSON-RPC for MCP clients and the existing Gua


### PR DESCRIPTION
## 対応 Issue

Closes #20

## 実装内容

- `protocol/schema/diagnostics.schema.json` と fixture、`get_diagnostics` command contract を追加
- core に event poll と独立した bounded operation/event history（既定100、0で無効）を追加
- pending / in-flight request、session/frame/revision、UI tree、logs、任意 screenshot、environment metadata を versioned diagnostics JSON に集約
- additive C ABI / C++ wrapper / runtime ABI と WebSocket `get_diagnostics` を追加
- .NET P/Invoke と `IGuaContext.GetDiagnosticsJson`、Godot remote parity を追加
- C++ testing に opt-in `DiagnosticScope`、.NET testing に `GuaDiagnosticOptions` / `GuaDiagnosticWriter` と assertion/wait failure hook を追加
- Godot test host から test name / process id / bridge URL / project metadata を渡せる helper を追加
- assertion / wait timeout、history limit、event poll非破壊、screenshot absent、mask、writer failure、remote transport、schema のテストを追加

## Architecture 判断

- protocol を source of truth とし、既存 ABI/struct は変更せず additive symbol のみ追加しました。
- history は context-owned bounded ring buffer とし、通常の event poll queue を drain/変更しません。
- file writer は `gua-testing` / `Gua.Testing` に置き、native core に filesystem policy を持ち込みません。
- sensitive action value は adapter consume 時だけ平文を渡し、pending diagnostics と全 history では空文字 + `sensitive: true` に固定しました。
- screenshot 未設定は `null` とし、semantic diagnostics 全体を成功させます。
- wait は開始 UI tree を保持し、node id 基準の added / removed / changed diff を書きます。
- capture/write failure は secondary note とし、既存 assertion delegate が投げる例外型と元メッセージを維持します。
- reset の `GUA_RESET_HISTORY` は retained history のみをclearし、request/event queue contractを維持します。

## Artifact 一覧

- `failure-summary.txt`
- `environment.json`
- `ui-tree.json`
- `ui-tree-before.json`（開始 snapshot がある場合）
- `ui-tree.diff.json`（before がある場合）
- `events.jsonl`
- `operations.jsonl`
- `pending-requests.json`
- `logs.json`
- `screenshot.png`（PNG data URI がある場合）
- `capture-errors.json`（secondary error がある場合）

各 failure directory は sanitized test name + timestamp + failure id で一意に作り、既存 file を上書きしません。

## Mask / capture failure test

- sensitive `set_value("secret-marker")` を enqueue / consume / emit / poll した後、core diagnostics と生成 artifact 全ファイルに marker がないことを機械確認
- screenshot 未設定でも artifact 生成成功、PNGなしを確認
- output root を通常 file で塞いだ writer failure で、C++ / C# とも元 failure message/type を維持し `capture error` を追加することを確認
- event poll 後も retained event history が残り、history limit と reset clear が効くことを確認

## 検証

- `cmake --preset windows-msvc-debug` — 成功
- `cmake --build --preset windows-msvc-debug -- /m:1` — 成功
- `ctest --test-dir build\windows-msvc-debug -C Debug --output-on-failure` — 2/2 成功
- `dotnet build bindings\dotnet\src\Gua.Testing\Gua.Testing.csproj --configuration Release --no-restore` — 成功、警告0
- `dotnet build bindings\dotnet\src\Gua.Testing.Godot\Gua.Testing.Godot.csproj --configuration Release --no-restore` — 成功、警告0
- `dotnet test examples\dotnet-nunit\GuaDotNetNUnitSample.csproj --configuration Release --no-restore` — 13/13 成功（local NuGet package 経由）
- `dotnet test bindings\dotnet\tests\Gua.Selector.Tests\Gua.Selector.Tests.csproj --configuration Release --no-restore` — 2/2 成功（remote `get_diagnostics` を含む）
- `bun run check` — 3 workspace 成功
- Godot 4.7 headless `gua_smoke.gd` — 成功
- AJV 2020 — diagnostics fixture と実 core 生成 JSON の schema validation 成功
- MSVC `dumpbin /exports` — core/runtime の diagnostics additive symbol を確認
- `git diff --check` — 成功

## 互換性

- 既存 C ABI symbol / struct、event poll semantics、reset既定flag値、C++/.NET API は維持しています。
- diagnostics は opt-in artifact writer と additive JSON API であり、既存テスト実行時に filesystem 出力を増やしません。

## 未対応事項

Issue #20 範囲内の未完了はありません。screenshot pixel comparison / baseline update と recording/replay は #25 のままです。