### PR TITLE
#25 Screenshot比較とUI操作recording/replay v1を追加

### DIFF
--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -86,6 +86,21 @@ public sealed class GodotSceneTestHost : IDisposable
         }
     }
 
+    public async Task<string> WaitForScreenshotAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var limit = timeout ?? _options.SceneTimeout;
+        var deadline = DateTimeOffset.UtcNow + limit;
+        do
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var screenshot = ((GuaRemoteContext)Context).GetScreenshotJson();
+            if (screenshot.Contains("data:image/png;base64,", StringComparison.OrdinalIgnoreCase)) return screenshot;
+            await Task.Delay(25, cancellationToken).ConfigureAwait(false);
+        } while (DateTimeOffset.UtcNow < deadline);
+        throw new TimeoutException($"Godot did not publish an opt-in viewport screenshot within {limit:g}.");
+    }
+
     public void Dispose()
     {
         if (_disposed)

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -36,6 +36,11 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
         return RequestRawResult(new { type = "get_diagnostics" });
     }
 
+    public string GetScreenshotJson()
+    {
+        return RequestRawResult(new { type = "get_screenshot" });
+    }
+
     public GuaContextStatus GetContextStatus()
     {
         var status = Request<ContextStatusResult>(new { type = "get_context_status" });

--- a/bindings/dotnet/src/Gua.Testing.Godot/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Godot/README.md
@@ -4,6 +4,11 @@
 `Gua.Testing`. It starts a Godot project, connects to the Gua WebSocket bridge,
 and lets tests assert against the live semantic UI tree.
 
+Godot visual capture is opt-in. After the adapter publishes a viewport PNG,
+`GodotSceneTestHost.WaitForScreenshotAsync` waits for that existing protocol
+payload. Add `Gua.Testing.Visual` only in visual test projects; the base Godot
+testing package deliberately has no PNG codec dependency.
+
 ```csharp
 using Gua.Testing;
 using Gua.Testing.Godot;

--- a/bindings/dotnet/src/Gua.Testing.Visual/Gua.Testing.Visual.csproj
+++ b/bindings/dotnet/src/Gua.Testing.Visual/Gua.Testing.Visual.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageId>Gua.Testing.Visual</PackageId>
+    <Description>Opt-in screenshot comparison and UI recording/replay for Gua.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Gua.Testing\Gua.Testing.csproj" />
+    <PackageReference Include="StbImageSharp" Version="2.30.15" />
+    <PackageReference Include="StbImageWriteSharp" Version="1.16.7" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/src/Gua.Testing.Visual/GuaRecording.cs
+++ b/bindings/dotnet/src/Gua.Testing.Visual/GuaRecording.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Gua.Core;
+using Gua.Testing;
+
+namespace Gua.Testing.Visual;
+
+[JsonConverter(typeof(JsonStringEnumConverter<GuaRecordedAction>))]
+public enum GuaRecordedAction { click, focus, set_value, set_checked, select, scroll, press_key }
+public sealed record GuaRecordingTarget(string? Id = null, string? Role = null, string? Name = null, string? Scope = null);
+public sealed record GuaCoordinateFallback(float X, float Y);
+public sealed record GuaRecordingStep(GuaRecordedAction Action, long RelativeMilliseconds, ulong PreRevision, ulong PostRevision, bool Sensitive, ulong RequestId = 0, ulong EventId = 0, GuaRecordingTarget? Target = null, GuaCoordinateFallback? CoordinateFallback = null, string? WaitCondition = null, string? Value = null, string? SecretKey = null);
+public sealed record GuaRecording(int SchemaVersion, IReadOnlyList<GuaRecordingStep> Steps);
+public enum GuaReplayTimingMode { PreserveDelays, PreferConditions }
+public sealed class GuaReplayOptions { public GuaReplayTimingMode TimingMode { get; init; } = GuaReplayTimingMode.PreferConditions; public bool FailOnCoordinateFallback { get; init; } = true; public Func<string, string?>? SecretResolver { get; init; } public Func<GuaCoordinateFallback, CancellationToken, Task>? CoordinateExecutor { get; init; } }
+
+public static class GuaRecordingFile
+{
+    public static void Save(string path, GuaRecording recording) { Validate(recording); Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!); File.WriteAllText(path, JsonSerializer.Serialize(recording, JsonOptions)); }
+    public static GuaRecording Load(string path) { var value = JsonSerializer.Deserialize<GuaRecording>(File.ReadAllText(path), JsonOptions) ?? throw new InvalidDataException("Recording is empty."); Validate(value); return value; }
+    public static GuaRecording FromDiagnostics(string json)
+    {
+        using var document = JsonDocument.Parse(json); var root = document.RootElement;
+        var revision = root.TryGetProperty("revision", out var rev) ? rev.GetUInt64() : 0;
+        var seen = new HashSet<ulong>(); var steps = new List<GuaRecordingStep>(); long relative = 0;
+        foreach (var op in root.GetProperty("operations").EnumerateArray())
+        {
+            var requestId = op.TryGetProperty("requestId", out var request) ? request.GetUInt64() : 0;
+            if (requestId != 0 && !seen.Add(requestId)) continue;
+            var actionText = String(op, "action"); if (!Enum.TryParse<GuaRecordedAction>(actionText, out var action)) continue;
+            var sensitive = Bool(op, "sensitive"); var nodeId = String(op, "nodeId"); var value = sensitive ? null : String(op, "value");
+            steps.Add(new(action, relative++, revision, revision, sensitive, requestId, requestId,
+                string.IsNullOrEmpty(nodeId) ? null : new GuaRecordingTarget(Id: nodeId), Value: string.IsNullOrEmpty(value) ? null : value,
+                SecretKey: sensitive ? $"request-{requestId}" : null));
+        }
+        foreach (var observed in root.GetProperty("events").EnumerateArray())
+        {
+            var requestId = observed.TryGetProperty("requestId", out var request) ? request.GetUInt64() : 0;
+            if (requestId != 0 && seen.Contains(requestId)) continue;
+            var actionText = String(observed, "action"); if (!Enum.TryParse<GuaRecordedAction>(actionText, out var action)) continue;
+            var sensitive = Bool(observed, "sensitive"); var nodeId = String(observed, "nodeId"); var value = sensitive ? null : String(observed, "value");
+            steps.Add(new(action, relative++, revision, revision, sensitive, requestId, requestId,
+                string.IsNullOrEmpty(nodeId) ? null : new GuaRecordingTarget(Id: nodeId), Value: string.IsNullOrEmpty(value) ? null : value,
+                SecretKey: sensitive ? $"event-{relative}" : null));
+        }
+        return new(1, steps);
+    }
+    public static void Validate(GuaRecording recording)
+    {
+        if (recording.SchemaVersion != 1) throw new InvalidDataException($"Unsupported Gua recording schemaVersion: {recording.SchemaVersion}.");
+        foreach (var step in recording.Steps) { if (step.Target is null && step.CoordinateFallback is null) throw new InvalidDataException("Recording step requires a semantic target or coordinate fallback."); if (step.Sensitive && (string.IsNullOrWhiteSpace(step.SecretKey) || step.Value is not null)) throw new InvalidDataException("Sensitive recording steps require secretKey and cannot store value."); }
+    }
+    private static string String(JsonElement e, string n) => e.TryGetProperty(n, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() ?? "" : "";
+    private static bool Bool(JsonElement e, string n) => e.TryGetProperty(n, out var v) && v.ValueKind == JsonValueKind.True;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+}
+
+public static class GuaReplayer
+{
+    public static async Task ReplayAsync(IGuaContext context, GuaRecording recording, GuaReplayOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        GuaRecordingFile.Validate(recording); options ??= new(); long previous = 0;
+        foreach (var step in recording.Steps)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (options.TimingMode == GuaReplayTimingMode.PreferConditions && step.WaitCondition is { } wait) await Wait(context, wait, cancellationToken);
+            else if (step.RelativeMilliseconds > previous) await Task.Delay(TimeSpan.FromMilliseconds(step.RelativeMilliseconds - previous), cancellationToken);
+            previous = step.RelativeMilliseconds;
+            if (step.Target is null) { if (options.FailOnCoordinateFallback) throw new InvalidOperationException("Coordinate fallback is disabled for this replay."); if (options.CoordinateExecutor is null) throw new InvalidOperationException("Coordinate replay requires CoordinateExecutor."); await options.CoordinateExecutor(step.CoordinateFallback!, cancellationToken); continue; }
+            var nodeId = Resolve(context, step.Target); var value = step.Sensitive ? options.SecretResolver?.Invoke(step.SecretKey!) : step.Value;
+            if (step.Sensitive && value is null) throw new InvalidOperationException($"A secret resolver value is required for key '{step.SecretKey}'.");
+            var error = context.EnqueueAction(Request(step, nodeId, value), out _); if (error != GuaActionError.None) throw new InvalidOperationException($"Recorded action '{step.Action}' was rejected for '{nodeId}': {error}.");
+        }
+    }
+    private static string Resolve(IGuaContext c, GuaRecordingTarget t) { if (!string.IsNullOrWhiteSpace(t.Id)) return GuaAssertions.Query(c).ById(t.Id).Get().Id; if (string.IsNullOrWhiteSpace(t.Role)) throw new InvalidDataException("Semantic target requires id or role."); var q = GuaAssertions.Query(c).ByRole(t.Role, t.Name); if (!string.IsNullOrWhiteSpace(t.Scope)) q = q.Within(t.Scope); return q.Get().Id; }
+    private static GuaActionRequest Request(GuaRecordingStep s, string id, string? value) => s.Action switch { GuaRecordedAction.click => new(GuaActionType.Click, id), GuaRecordedAction.focus => new(GuaActionType.Focus, id), GuaRecordedAction.set_value => new(GuaActionType.SetValue, id, value, Sensitive: s.Sensitive), GuaRecordedAction.set_checked => new(GuaActionType.SetChecked, id, BoolValue: bool.TryParse(value, out var b) && b), GuaRecordedAction.select => new(GuaActionType.Select, id, value), GuaRecordedAction.scroll => new(GuaActionType.Scroll, id), GuaRecordedAction.press_key => new(GuaActionType.PressKey, id, Key: value), _ => throw new UnreachableException() };
+    private static async Task Wait(IGuaContext c, string condition, CancellationToken token) { var p = condition.Split(':', 2); if (p.Length != 2 || p[0] != "visible") throw new InvalidDataException($"Unsupported recording wait condition: {condition}."); await GuaAssertions.WaitForVisibleAsync(c, p[1], cancellationToken: token); }
+}

--- a/bindings/dotnet/src/Gua.Testing.Visual/GuaScreenshotComparison.cs
+++ b/bindings/dotnet/src/Gua.Testing.Visual/GuaScreenshotComparison.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using Gua.Core;
+using Gua.Testing;
+using StbImageSharp;
+using StbImageWriteSharp;
+
+namespace Gua.Testing.Visual;
+
+public readonly record struct GuaMaskRectangle(int X, int Y, int Width, int Height);
+
+public sealed class ScreenshotOptions
+{
+    public string BaselineDirectory { get; init; } = "baselines";
+    public string ArtifactDirectory { get; init; } = Path.Combine("artifacts", "gua");
+    public string? FailureDirectory { get; init; }
+    public string BaselineVariant { get; init; } = "default";
+    public float PixelThreshold { get; init; }
+    public double MaxDifferentPixelRatio { get; init; }
+    public IReadOnlyList<GuaMaskRectangle> Masks { get; init; } = [];
+    public bool UpdateBaselines { get; init; }
+    public bool WaitForStableSnapshot { get; init; }
+    public int StableFrames { get; init; } = 3;
+}
+
+public sealed record ScreenshotComparisonResult(bool Matched, int Width, int Height, long ComparedPixels,
+    long DifferentPixels, double DifferentPixelRatio, string BaselinePath, string? ArtifactPath, bool BaselineUpdated);
+
+public static class GuaVisualAssertions
+{
+    private const string PngPrefix = "data:image/png;base64,";
+
+    public static async Task<ScreenshotComparisonResult> ExpectScreenshotAsync(
+        IGuaContext context, string name, ScreenshotOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        options ??= new ScreenshotOptions();
+        Validate(options);
+        if (options.WaitForStableSnapshot)
+            await GuaAssertions.WaitForStableSnapshotAsync(context, options.StableFrames, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var actualBytes = ReadScreenshot(context.GetDiagnosticsJson());
+        var safeName = Sanitize(name);
+        var variant = Sanitize(options.BaselineVariant);
+        var baseline = Path.GetFullPath(Path.Combine(options.BaselineDirectory, safeName, variant + ".png"));
+        var update = options.UpdateBaselines || string.Equals(Environment.GetEnvironmentVariable("GUA_UPDATE_BASELINES"), "1", StringComparison.Ordinal);
+        if (!File.Exists(baseline))
+        {
+            if (update)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(baseline)!);
+                File.WriteAllBytes(baseline, actualBytes);
+                return new(true, 0, 0, 0, 0, 0, baseline, null, true);
+            }
+            var missingDir = CreateArtifactDirectory(options, safeName);
+            File.WriteAllBytes(Path.Combine(missingDir, "actual.png"), actualBytes);
+            WriteComparison(missingDir, new { schemaVersion = 1, matched = false, reason = "baseline_missing", baselinePath = baseline });
+            throw new InvalidOperationException($"Screenshot baseline is missing: {baseline}. Actual artifact: {missingDir}");
+        }
+
+        var expectedBytes = File.ReadAllBytes(baseline);
+        var expected = ImageResult.FromMemory(expectedBytes, StbImageSharp.ColorComponents.RedGreenBlueAlpha);
+        var actual = ImageResult.FromMemory(actualBytes, StbImageSharp.ColorComponents.RedGreenBlueAlpha);
+        if (expected.Width != actual.Width || expected.Height != actual.Height)
+            return FailDimension(expectedBytes, actualBytes, expected, actual, baseline, options, safeName);
+
+        var diff = new byte[actual.Data.Length];
+        long compared = 0, different = 0;
+        for (var y = 0; y < actual.Height; y++)
+        for (var x = 0; x < actual.Width; x++)
+        {
+            var offset = (y * actual.Width + x) * 4;
+            if (options.Masks.Any(mask => x >= mask.X && y >= mask.Y && x < mask.X + mask.Width && y < mask.Y + mask.Height))
+            {
+                diff[offset + 3] = 255;
+                continue;
+            }
+            compared++;
+            var pixelDifferent = false;
+            for (var channel = 0; channel < 4; channel++)
+            {
+                var delta = Math.Abs(expected.Data[offset + channel] - actual.Data[offset + channel]);
+                diff[offset + channel] = (byte)delta;
+                pixelDifferent |= delta / 255f > options.PixelThreshold;
+            }
+            if (pixelDifferent) different++;
+            diff[offset + 3] = 255;
+        }
+        var ratio = compared == 0 ? 0 : (double)different / compared;
+        if (ratio <= options.MaxDifferentPixelRatio)
+            return new(true, actual.Width, actual.Height, compared, different, ratio, baseline, null, false);
+        var directory = CreateArtifactDirectory(options, safeName);
+        File.WriteAllBytes(Path.Combine(directory, "expected.png"), expectedBytes);
+        File.WriteAllBytes(Path.Combine(directory, "actual.png"), actualBytes);
+        WritePng(Path.Combine(directory, "diff.png"), diff, actual.Width, actual.Height);
+        WriteComparison(directory, new { schemaVersion = 1, matched = false, actual.Width, actual.Height, comparedPixels = compared, differentPixels = different, differentPixelRatio = ratio, options.PixelThreshold, options.MaxDifferentPixelRatio, masks = options.Masks, baselinePath = baseline });
+        throw new InvalidOperationException($"Screenshot comparison failed: ratio {ratio:F6} exceeds {options.MaxDifferentPixelRatio:F6}. Artifacts: {directory}");
+    }
+
+    private static ScreenshotComparisonResult FailDimension(byte[] expectedBytes, byte[] actualBytes, ImageResult expected, ImageResult actual, string baseline, ScreenshotOptions options, string name)
+    {
+        var directory = CreateArtifactDirectory(options, name);
+        File.WriteAllBytes(Path.Combine(directory, "expected.png"), expectedBytes);
+        File.WriteAllBytes(Path.Combine(directory, "actual.png"), actualBytes);
+        WriteComparison(directory, new { schemaVersion = 1, matched = false, reason = "dimension_mismatch", expected = new { expected.Width, expected.Height }, actual = new { actual.Width, actual.Height }, baselinePath = baseline });
+        throw new InvalidOperationException($"Screenshot dimensions differ: expected {expected.Width}x{expected.Height}, actual {actual.Width}x{actual.Height}. Artifacts: {directory}");
+    }
+
+    private static byte[] ReadScreenshot(string diagnosticsJson)
+    {
+        using var document = JsonDocument.Parse(diagnosticsJson);
+        if (!document.RootElement.TryGetProperty("screenshot", out var screenshot) || screenshot.ValueKind != JsonValueKind.Object)
+            throw new InvalidOperationException("Gua context has no screenshot.");
+        var uri = screenshot.GetProperty("dataUri").GetString() ?? "";
+        if (!uri.StartsWith(PngPrefix, StringComparison.OrdinalIgnoreCase))
+            throw new NotSupportedException("Gua visual comparison v1 supports only data:image/png;base64 screenshots.");
+        return Convert.FromBase64String(uri[PngPrefix.Length..]);
+    }
+
+    private static void Validate(ScreenshotOptions options)
+    {
+        if (options.PixelThreshold is < 0 or > 1) throw new ArgumentOutOfRangeException(nameof(options.PixelThreshold));
+        if (options.MaxDifferentPixelRatio is < 0 or > 1) throw new ArgumentOutOfRangeException(nameof(options.MaxDifferentPixelRatio));
+        if (string.IsNullOrWhiteSpace(options.BaselineVariant)) throw new ArgumentException("BaselineVariant is required.");
+        if (options.Masks.Any(x => x.Width < 0 || x.Height < 0)) throw new ArgumentException("Mask dimensions cannot be negative.");
+    }
+
+    private static string CreateArtifactDirectory(ScreenshotOptions options, string name)
+    {
+        var parent = options.FailureDirectory is { Length: > 0 }
+            ? Path.GetFullPath(options.FailureDirectory)
+            : Path.GetFullPath(Path.Combine(options.ArtifactDirectory, name));
+        var path = Path.Combine(parent, $"visual-{DateTimeOffset.UtcNow:yyyyMMddTHHmmssfffZ}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path); return path;
+    }
+    private static void WriteComparison(string directory, object value) => File.WriteAllText(Path.Combine(directory, "comparison.json"), JsonSerializer.Serialize(value, new JsonSerializerOptions { WriteIndented = true }));
+    private static void WritePng(string path, byte[] data, int width, int height) { using var stream = File.Create(path); new ImageWriter().WritePng(data, width, height, StbImageWriteSharp.ColorComponents.RedGreenBlueAlpha, stream); }
+    internal static string Sanitize(string value) { var invalid = Path.GetInvalidFileNameChars(); var result = new string(value.Select(c => invalid.Contains(c) || char.IsControl(c) ? '_' : c).ToArray()).Trim(); return string.IsNullOrEmpty(result) ? "unnamed" : result; }
+}

--- a/bindings/dotnet/src/Gua.Testing.Visual/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Visual/README.md
@@ -1,0 +1,13 @@
+# Gua.Testing.Visual
+
+This opt-in package adds PNG baseline comparison and semantic operation recording/replay.
+Semantic assertions remain the primary test path. Missing baselines fail unless
+`UpdateBaselines` or `GUA_UPDATE_BASELINES=1` is explicit; variants are caller supplied.
+Failures write expected/actual/diff PNG and `comparison.json` below the Gua artifact root.
+Pass the artifact path returned by `GuaDiagnosticWriter` as `FailureDirectory` to
+place visual output in that same failure directory.
+
+PNG support is isolated here through StbImageSharp and StbImageWriteSharp; their upstream
+licenses are included by the NuGet packages. Recording v1 follows
+`protocol/schema/recording.schema.json`. Sensitive values are represented only by a
+`secretKey` and require a caller-provided resolver during replay.

--- a/bindings/dotnet/tests/Gua.Visual.Tests/Gua.Visual.Tests.csproj
+++ b/bindings/dotnet/tests/Gua.Visual.Tests/Gua.Visual.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net10.0</TargetFramework><Nullable>enable</Nullable><ImplicitUsings>enable</ImplicitUsings><IsPackable>false</IsPackable></PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Gua.Testing.Visual\Gua.Testing.Visual.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+</Project>

--- a/bindings/dotnet/tests/Gua.Visual.Tests/VisualTests.cs
+++ b/bindings/dotnet/tests/Gua.Visual.Tests/VisualTests.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using Gua.Core;
+using Gua.Testing.Visual;
+using NUnit.Framework;
+using StbImageWriteSharp;
+
+namespace Gua.Visual.Tests;
+
+public sealed class VisualTests
+{
+    private string _root = null!;
+    [SetUp] public void SetUp() => _root = Path.Combine(Path.GetTempPath(), "gua-visual-tests", Guid.NewGuid().ToString("N"));
+    [TearDown] public void TearDown() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+
+    [Test]
+    public async Task BaselineUpdateThenExactMatchUsesExplicitVariant()
+    {
+        var context = new FakeContext(Png(2, 2, 10)); var options = Options("windows", update: true);
+        var updated = await GuaVisualAssertions.ExpectScreenshotAsync(context, "title", options);
+        Assert.That(updated.BaselineUpdated, Is.True);
+        var matched = await GuaVisualAssertions.ExpectScreenshotAsync(context, "title", Options("windows"));
+        Assert.Multiple(() => { Assert.That(matched.Matched, Is.True); Assert.That(matched.BaselinePath, Does.EndWith(Path.Combine("title", "windows.png"))); });
+    }
+
+    [Test]
+    public async Task ThresholdRatioAndMaskExcludeMaskedPixels()
+    {
+        var baseline = Png(2, 1, 10); var context = new FakeContext(baseline);
+        await GuaVisualAssertions.ExpectScreenshotAsync(context, "masked", Options("default", update: true));
+        context.Set(Png(2, 1, 20, second: 200));
+        var result = await GuaVisualAssertions.ExpectScreenshotAsync(context, "masked", Options("default", threshold: .05f, ratio: 0, masks: [new(1, 0, 1, 1)]));
+        Assert.Multiple(() => { Assert.That(result.Matched, Is.True); Assert.That(result.ComparedPixels, Is.EqualTo(1)); Assert.That(result.DifferentPixels, Is.Zero); });
+    }
+
+    [Test]
+    public async Task MissingAndDimensionMismatchWriteMachineReadableArtifacts()
+    {
+        var context = new FakeContext(Png(1, 1, 1));
+        var missing = Assert.ThrowsAsync<InvalidOperationException>(() => GuaVisualAssertions.ExpectScreenshotAsync(context, "missing", Options("default")));
+        Assert.That(missing!.Message, Does.Contain("baseline is missing"));
+        await GuaVisualAssertions.ExpectScreenshotAsync(context, "size", Options("default", update: true));
+        context.Set(Png(2, 1, 1));
+        var mismatch = Assert.ThrowsAsync<InvalidOperationException>(() => GuaVisualAssertions.ExpectScreenshotAsync(context, "size", Options("default")));
+        Assert.That(mismatch!.Message, Does.Contain("dimensions differ"));
+        Assert.That(Directory.GetFiles(Path.Combine(_root, "artifacts"), "comparison.json", SearchOption.AllDirectories), Is.Not.Empty);
+    }
+
+    [Test]
+    public void RecordingRejectsUnknownVersionAndNeverSerializesSensitiveValue()
+    {
+        Assert.Throws<InvalidDataException>(() => GuaRecordingFile.Validate(new(2, [])));
+        var recording = new GuaRecording(1, [new(GuaRecordedAction.set_value, 0, 1, 2, true, 7, 7, new(Id: "password"), SecretKey: "login-password")]);
+        var path = Path.Combine(_root, "recording.json"); GuaRecordingFile.Save(path, recording); var json = File.ReadAllText(path);
+        Assert.Multiple(() => { Assert.That(json, Does.Contain("login-password")); Assert.That(json, Does.Not.Contain("secret-marker")); Assert.That(GuaRecordingFile.Load(path).SchemaVersion, Is.EqualTo(1)); });
+    }
+
+    [Test]
+    public void RecorderDeduplicatesAutomationAndKeepsHostEvents()
+    {
+        const string json = "{\"revision\":9,\"operations\":[{\"requestId\":4,\"action\":\"click\",\"nodeId\":\"start\",\"sensitive\":false}],\"events\":[{\"requestId\":4,\"action\":\"click\",\"nodeId\":\"start\",\"sensitive\":false},{\"requestId\":0,\"action\":\"focus\",\"nodeId\":\"name\",\"sensitive\":false}]}";
+        var recording = GuaRecordingFile.FromDiagnostics(json);
+        Assert.Multiple(() => { Assert.That(recording.Steps, Has.Count.EqualTo(2)); Assert.That(recording.Steps[0].Target!.Id, Is.EqualTo("start")); Assert.That(recording.Steps[1].Target!.Id, Is.EqualTo("name")); });
+    }
+
+    [Test]
+    public async Task ReplayPrefersSemanticIdRefusesCoordinatesAndRequiresSecretResolver()
+    {
+        var context = new FakeContext(Png(1, 1, 0));
+        var semantic = new GuaRecording(1, [new(GuaRecordedAction.set_value, 0, 1, 2, true, Target: new(Id: "password"), SecretKey: "password")]);
+        Assert.ThrowsAsync<InvalidOperationException>(() => GuaReplayer.ReplayAsync(context, semantic));
+        await GuaReplayer.ReplayAsync(context, semantic, new() { SecretResolver = key => key == "password" ? "secret-marker" : null });
+        Assert.Multiple(() => { Assert.That(context.LastRequest.NodeId, Is.EqualTo("password")); Assert.That(context.LastRequest.Sensitive, Is.True); });
+        var coordinate = new GuaRecording(1, [new(GuaRecordedAction.click, 0, 1, 2, false, CoordinateFallback: new(3, 4))]);
+        Assert.ThrowsAsync<InvalidOperationException>(() => GuaReplayer.ReplayAsync(context, coordinate));
+    }
+
+    private ScreenshotOptions Options(string variant, bool update = false, float threshold = 0, double ratio = 0, IReadOnlyList<GuaMaskRectangle>? masks = null) => new() { BaselineDirectory = Path.Combine(_root, "baselines"), ArtifactDirectory = Path.Combine(_root, "artifacts"), BaselineVariant = variant, UpdateBaselines = update, PixelThreshold = threshold, MaxDifferentPixelRatio = ratio, Masks = masks ?? [] };
+    private static byte[] Png(int width, int height, byte first, byte? second = null) { var pixels = new byte[width * height * 4]; for (var i = 0; i < width * height; i++) { var value = i == 1 && second.HasValue ? second.Value : first; pixels[i * 4] = pixels[i * 4 + 1] = pixels[i * 4 + 2] = value; pixels[i * 4 + 3] = 255; } using var stream = new MemoryStream(); new ImageWriter().WritePng(pixels, width, height, ColorComponents.RedGreenBlueAlpha, stream); return stream.ToArray(); }
+
+    private sealed class FakeContext(byte[] screenshot) : IGuaContext
+    {
+        private byte[] _screenshot = screenshot; public GuaActionRequest LastRequest { get; private set; }
+        public void Set(byte[] value) => _screenshot = value;
+        public string GetDiagnosticsJson() => JsonSerializer.Serialize(new { schemaVersion = 1, revision = 1, screenshot = new { dataUri = "data:image/png;base64," + Convert.ToBase64String(_screenshot), width = 1, height = 1 }, operations = Array.Empty<object>(), events = Array.Empty<object>() });
+        public string GetUiTreeJson() => "{\"schemaVersion\":2,\"screen\":\"test\",\"frameSequence\":1,\"revision\":1,\"sessionEpoch\":1,\"nodes\":[{\"id\":\"password\",\"role\":\"textbox\",\"label\":\"Password\",\"bounds\":{\"x\":0,\"y\":0,\"w\":1,\"h\":1},\"visible\":true,\"enabled\":true,\"actions\":[\"set_value\"]}]}";
+        public GuaQueryResult Query(GuaSelector selector) => selector.Id == "password" ? new(true, [new("password", "textbox", "Password", null)]) : new(true, []);
+        public GuaActionError EnqueueAction(GuaActionRequest request, out ulong requestId) { LastRequest = request; requestId = 1; return GuaActionError.None; }
+        public GuaNodeState GetNodeState(string id) => new(true, true); public string FindNodeById(string id) => id; public string FindNodeByRole(string role, string? name = null) => "password"; public string FindNodeByText(string text) => "password"; public bool EnqueueClick(string id) => true; public bool TryPollActionEvent(out GuaActionEvent e) { e = default; return false; } public bool TryPollActionEvent(ulong id, out GuaActionEvent e) { e = default; return false; } public bool TryPollEvent(out GuaEvent e) { e = default; return false; }
+    }
+}

--- a/examples/godot-gdscript/README.md
+++ b/examples/godot-gdscript/README.md
@@ -2,6 +2,21 @@
 
 This sample uses the Gua Godot GDExtension from GDScript.
 
+## Opt-in visual capture
+
+`GuaAutoAdapter.capture_viewport_screenshot()` reads the current viewport after a
+rendered frame, encodes it as PNG, and publishes it through the existing Gua
+screenshot payload. It is never called automatically. The headless smoke covers
+button, text input, checkbox, and select semantics plus PNG capture; managed
+`Gua.Testing.Visual` tests own baseline compare and recording/replay policy.
+Because Godot's dummy headless renderer has no viewport texture, the smoke injects
+a deterministic `Image`; normal runtime calls omit that test-only argument and
+capture `Viewport.get_texture().get_image()`.
+
+Use a normal run to compare without baseline mutation. Set
+`GUA_UPDATE_BASELINES=1` only for an intentional update, and change a rendered
+control to exercise the diff-failure artifact path.
+
 Build the native extension first:
 
 ```powershell

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -12,6 +12,8 @@ const REQUIRED_CONTEXT_METHODS := [
 	"register_node_v2",
 	"end_frame",
 	"get_ui_tree_json",
+	"set_screenshot",
+	"get_screenshot_json",
 	"enqueue_click",
 	"consume_click_request",
 	"emit_click",
@@ -56,6 +58,19 @@ func update(screen: String) -> void:
 	context.end_frame()
 	_dispatch_click_requests()
 	_dispatch_action_requests()
+
+
+func capture_viewport_screenshot(image_override: Image = null) -> Dictionary:
+	if not _ensure_context() or root == null:
+		return {"ok": false, "error": "Gua adapter is not attached."}
+	var image := image_override
+	if image == null:
+		image = root.get_viewport().get_texture().get_image()
+	if image == null or image.is_empty():
+		return {"ok": false, "error": "Godot viewport capture returned an empty image."}
+	var png := image.save_png_to_buffer()
+	context.set_screenshot("data:image/png;base64," + Marshalls.raw_to_base64(png), image.get_width(), image.get_height())
+	return {"ok": true, "width": image.get_width(), "height": image.get_height()}
 
 
 func start_inspector_bridge(port: int = 8765) -> bool:

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -83,6 +83,13 @@ func _run() -> void:
 
 	ui.attach(screen)
 	ui.update("title")
+	await process_frame
+	var smoke_image := Image.create(2, 2, false, Image.FORMAT_RGBA8)
+	smoke_image.fill(Color(0.2, 0.4, 0.6, 1.0))
+	var capture := ui.capture_viewport_screenshot(smoke_image)
+	if not capture.get("ok", false) or not ui.context.get_screenshot_json().contains("data:image/png;base64,"):
+		_fail("Gua smoke did not publish an opt-in Godot viewport PNG: %s" % capture)
+		return
 
 	var tree_json := ui.get_ui_tree_json()
 	if not tree_json.contains("\"start\"") or not tree_json.contains("\"button\""):

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -28,6 +28,8 @@ public:
     bool register_node_v2(const Dictionary& descriptor);
 
     String get_ui_tree_json() const;
+    void set_screenshot(const String& data_uri, int width, int height);
+    String get_screenshot_json() const;
     bool enqueue_click(const String& node_id);
     bool consume_click_request(const String& node_id);
     bool emit_click(const String& node_id);

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -97,6 +97,17 @@ void GuaContext::end_frame()
     gua_runtime_end_frame(runtime_);
 }
 
+void GuaContext::set_screenshot(const String& data_uri, int width, int height)
+{
+    const CharString data_uri_utf8 = data_uri.utf8();
+    gua_runtime_set_screenshot(runtime_, data_uri_utf8.get_data(), width, height);
+}
+
+String GuaContext::get_screenshot_json() const
+{
+    return copy_runtime_json(runtime_, gua_runtime_copy_screenshot_json);
+}
+
 void GuaContext::register_node(
     const String& id,
     const String& role,
@@ -376,6 +387,8 @@ void GuaContext::_bind_methods()
         DEFVAL(true));
     ClassDB::bind_method(D_METHOD("register_node_v2", "descriptor"), &GuaContext::register_node_v2);
     ClassDB::bind_method(D_METHOD("get_ui_tree_json"), &GuaContext::get_ui_tree_json);
+    ClassDB::bind_method(D_METHOD("set_screenshot", "data_uri", "width", "height"), &GuaContext::set_screenshot);
+    ClassDB::bind_method(D_METHOD("get_screenshot_json"), &GuaContext::get_screenshot_json);
     ClassDB::bind_method(D_METHOD("enqueue_click", "node_id"), &GuaContext::enqueue_click);
     ClassDB::bind_method(D_METHOD("consume_click_request", "node_id"), &GuaContext::consume_click_request);
     ClassDB::bind_method(D_METHOD("emit_click", "node_id"), &GuaContext::emit_click);

--- a/protocol/fixtures/recording-v1.json
+++ b/protocol/fixtures/recording-v1.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "steps": [
+    {
+      "action": "click",
+      "requestId": 42,
+      "eventId": 42,
+      "target": { "id": "start" },
+      "relativeMilliseconds": 0,
+      "preRevision": 3,
+      "postRevision": 4,
+      "waitCondition": "visible:start",
+      "sensitive": false
+    },
+    {
+      "action": "set_value",
+      "requestId": 43,
+      "eventId": 43,
+      "target": { "role": "textbox", "name": "Password", "scope": "login" },
+      "relativeMilliseconds": 20,
+      "preRevision": 4,
+      "postRevision": 5,
+      "secretKey": "login-password",
+      "sensitive": true
+    }
+  ]
+}

--- a/protocol/schema/recording.schema.json
+++ b/protocol/schema/recording.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gua.dev/schema/recording.schema.json",
+  "title": "Gua UI operation recording v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "steps"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "steps": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/step" }
+    }
+  },
+  "$defs": {
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "minLength": 1 },
+        "name": { "type": "string" },
+        "scope": { "type": "string", "minLength": 1 }
+      },
+      "anyOf": [{ "required": ["id"] }, { "required": ["role"] }]
+    },
+    "coordinate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y"],
+      "properties": { "x": { "type": "number" }, "y": { "type": "number" } }
+    },
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "relativeMilliseconds", "preRevision", "postRevision", "sensitive"],
+      "properties": {
+        "action": { "enum": ["click", "focus", "set_value", "set_checked", "select", "scroll", "press_key"] },
+        "requestId": { "type": "integer", "minimum": 0 },
+        "eventId": { "type": "integer", "minimum": 0 },
+        "target": { "$ref": "#/$defs/target" },
+        "coordinateFallback": { "$ref": "#/$defs/coordinate" },
+        "relativeMilliseconds": { "type": "integer", "minimum": 0 },
+        "preRevision": { "type": "integer", "minimum": 0 },
+        "postRevision": { "type": "integer", "minimum": 0 },
+        "waitCondition": { "type": "string", "minLength": 1 },
+        "value": { "type": "string" },
+        "secretKey": { "type": "string", "minLength": 1 },
+        "sensitive": { "type": "boolean" }
+      },
+      "allOf": [
+        { "anyOf": [{ "required": ["target"] }, { "required": ["coordinateFallback"] }] },
+        { "if": { "properties": { "sensitive": { "const": true } }, "required": ["sensitive"] }, "then": { "required": ["secretKey"], "not": { "required": ["value"] } } }
+      ]
+    }
+  }
+}

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -158,6 +158,21 @@ The screenshot payload stores an already encoded `dataUri` plus `width` and
 `height`. This keeps the C ABI small and avoids forcing the core protocol to own
 PNG encoding, GPU readback, or platform-specific capture code.
 
+## Visual comparison and operation recording v1
+
+Visual comparison is an opt-in consumer of the existing PNG screenshot payload;
+semantic assertions remain the primary test path. Baselines use an explicit test
+name and variant, are updated only by an API option or `GUA_UPDATE_BASELINES=1`,
+and are never inferred from OS/GPU state. Masks are removed from both diff output
+and the ratio denominator. Dimension mismatch never performs an implicit resize.
+
+`recording.schema.json` is the source of truth for recording version 1. Targets
+prefer stable `id`, then strict role/name/scope selection, with coordinate fallback
+only when explicitly recorded and permitted. Request IDs deduplicate retained
+operation/event history. Replay preserves delays or prefers recorded semantic wait
+conditions. Sensitive steps contain a `secretKey`, never plaintext, and require a
+caller resolver.
+
 ## Commands
 
 Commands are external automation requests.


### PR DESCRIPTION
## 対応 Issue

- Closes #25

## 実装内容

- `protocol/schema/recording.schema.json` を recording v1 の source of truth として追加し、fixture と protocol 文書を同期
- opt-in `Gua.Testing.Visual` package を新設
  - PNG data URI の decode、exact/tolerance/ratio/mask/dimension comparison
  - explicit variant baseline と明示 update guard
  - expected/actual/diff PNG、machine-readable `comparison.json`
  - diagnostics artifact path と同じ failure directory への出力
  - diagnostics operation/event history からの重複除去 recording、versioned load/save、replay
- semantic ID → strict role/name/scope → 明示 coordinate fallback の優先順を実装
- `PreserveDelays` / `PreferConditions`、coordinate refusal、sensitive `secretKey` resolver を実装
- Godot GDExtension に既存 screenshot payload の set/get を公開し、GDScript adapter に opt-in viewport PNG capture を追加
- Godot test host に screenshot publish 待機 APIを追加

## Architecture 判断

visual codec 依存は base `Gua.Testing` / native core に持ち込まず `Gua.Testing.Visual` のみに隔離しました。runtime protocol/ABI は既存 screenshot、diagnostics、selector、action、wait seam を再利用しています。Godot capture は adapter-owned かつ opt-in です。dummy headless renderer は viewport texture を持たないため、smoke だけ deterministic `Image` injection seam を使い、通常呼び出しは実 viewport を capture します。

## Baseline policy / comparison matrix

- baseline: `baselines/<sanitized-name>/<explicit-variant>.png`
- update: API option または `GUA_UPDATE_BASELINES=1` のみ
- missing: fail + actual PNG / comparison JSON
- exact / channel threshold / max different pixel ratio / rectangle mask / dimension mismatch をテスト
- mask は diff と ratio 分母の双方から除外、暗黙 resize なし

## Recording / sensitive

- schemaVersion 1 以外と invalid sensitive step を明確に拒否
- requestId で automation operation/event を重複除去し、requestId なしの host event も保持
- sensitive value は file/exception に保存せず `secretKey` のみ。resolver 不在時は実行前に拒否
- coordinate fallback は既定拒否

## 検証

- `cmake --preset windows-msvc-debug`: 成功
- `cmake --build --preset windows-msvc-debug`: 成功
- `ctest --test-dir build/windows-msvc-debug -C Debug --output-on-failure`: 2/2 成功
- `dotnet build bindings\dotnet\src\Gua.Testing.Visual\Gua.Testing.Visual.csproj --configuration Release --no-restore`: 成功、警告0
- `dotnet build bindings\dotnet\src\Gua.Testing.Godot\Gua.Testing.Godot.csproj --configuration Release --no-restore`: 成功、警告0
- `dotnet test bindings\dotnet\tests\Gua.Visual.Tests\Gua.Visual.Tests.csproj --configuration Release --no-restore`: 6/6 成功
- `dotnet test examples\dotnet-nunit\GuaDotNetNUnitSample.csproj --configuration Release -p:UseProjectReferences=true` (`GUA_NATIVE_DIR` 指定): 13/13 成功
- `bun run check`: 3 workspace 成功
- `bunx ajv-cli validate --spec=draft2020 -s protocol/schema/recording.schema.json -d protocol/fixtures/recording-v1.json`: 成功
- Godot 4.7 headless GDScript smoke: 成功（semantic controls + opt-in PNG publish）
- `git diff --check`: 成功

## 未対応事項

Issue 範囲外の OCR、video、baseline service、CI provider 固有 UI、Unity/Unreal/raw ImGui capture、gamepad/drag/long press recording は未対応です。Godot dummy headless renderer は実 viewport texture を提供しないため、実 viewport readback 自体は通常 renderer で行い、headless smoke は deterministic Image で PNG publish 経路を検証します。
