### PR TITLE
スナップショットのスカラー値と UI ツリー更新情報を整合させる

### DIFF
--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -125,6 +125,15 @@ public static partial class GuaAssertions
             string? OptionalString(string name) => node.TryGetProperty(name, out var value)
                 ? value.GetString()
                 : null;
+            string? OptionalScalar(string name) => node.TryGetProperty(name, out var value)
+                ? value.ValueKind switch
+                {
+                    JsonValueKind.String => value.GetString(),
+                    JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False => value.GetRawText(),
+                    JsonValueKind.Null => null,
+                    _ => throw new JsonException($"Gua node property '{name}' must be a scalar value."),
+                }
+                : null;
             ulong? OptionalRootUInt64(string name) => document.RootElement.TryGetProperty(name, out var value)
                 ? value.GetUInt64()
                 : null;
@@ -143,7 +152,7 @@ public static partial class GuaAssertions
                 Actions: actions,
                 ParentId: OptionalString("parentId"),
                 Text: OptionalString("text"),
-                Value: OptionalString("value"),
+                Value: OptionalScalar("value"),
                 Focused: OptionalBoolean("focused"),
                 Hovered: OptionalBoolean("hovered"),
                 Pressed: OptionalBoolean("pressed"),

--- a/examples/dotnet-nunit/TitleScreenTests.cs
+++ b/examples/dotnet-nunit/TitleScreenTests.cs
@@ -82,6 +82,17 @@ public sealed class TitleScreenTests
         });
     }
 
+    [TestCase("10", "10")]
+    [TestCase("true", "true")]
+    [TestCase("null", null)]
+    public void SnapshotScalarValueRemainsReadable(string jsonValue, string? expected)
+    {
+        using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);
+        var tree = $$$"""{"schemaVersion":2,"frameSequence":1,"revision":1,"screen":"test","nodes":[{"id":"status","role":"status","label":"Status","value":{{{jsonValue}}},"visible":true,"enabled":true,"bounds":{"x":0,"y":0,"w":1,"h":1},"actions":[]}]}""";
+        var snapshot = GuaAssertions.GetById(new SequenceContext(tree), "status").Snapshot;
+        Assert.That(snapshot.Value, Is.EqualTo(expected));
+    }
+
     [Test]
     public void StartClickShowsLoadingText()
     {

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -31,6 +31,7 @@ const REQUIRED_CONTEXT_METHODS := [
 var context: Object
 var root: Control
 var buttons_by_id: Dictionary = {}
+var tabs_by_id: Dictionary = {}
 var controls_by_id: Dictionary = {}
 var connected_buttons: Dictionary = {}
 var suppressed_clicks: Dictionary = {}
@@ -53,6 +54,7 @@ func update(screen: String) -> void:
 
 	context.begin_frame(screen)
 	buttons_by_id.clear()
+	tabs_by_id.clear()
 	controls_by_id.clear()
 	_collect_control(root, "")
 	context.end_frame()
@@ -135,6 +137,7 @@ func reset_context(options: Dictionary = {}) -> Dictionary:
 	var report: Dictionary = context.reset_context(resolved)
 	if report.get("result", -1) == 1:
 		buttons_by_id.clear()
+		tabs_by_id.clear()
 		controls_by_id.clear()
 		suppressed_clicks.clear()
 	return report
@@ -253,8 +256,10 @@ func _collect_item_list_items(item_list: ItemList, parent_id: String) -> void:
 func _collect_tab_items(tab_container: TabContainer, parent_id: String) -> void:
 	for index in range(tab_container.get_tab_count()):
 		var label := tab_container.get_tab_title(index)
+		var id := "%s$tab:%d" % [parent_id, index]
+		tabs_by_id[id] = {"container": tab_container, "index": index}
 		context.register_node_v2({
-			"id": "%s$tab:%d" % [parent_id, index],
+			"id": id,
 			"parent_id": parent_id,
 			"role": "tab",
 			"label": label,
@@ -276,6 +281,17 @@ func _dispatch_click_requests() -> void:
 			context.emit_click(id)
 			suppressed_clicks[id] = true
 			button.emit_signal("pressed")
+
+	for id in tabs_by_id.keys():
+		var target: Dictionary = tabs_by_id[id]
+		var tab_container := target["container"] as TabContainer
+		var index := int(target["index"])
+		while context.consume_click_request(id):
+			if not tab_container.is_visible_in_tree() or tab_container.is_tab_disabled(index):
+				continue
+
+			tab_container.current_tab = index
+			context.emit_click(id)
 
 
 func _dispatch_action_requests() -> void:

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -285,6 +285,7 @@ const char* gua_get_diagnostics_json(gua_context_t* ctx);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
 int gua_copy_diagnostics_json(gua_context_t* ctx, char* out_json, int out_json_size);
 int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state);
+/* Returns 0 rather than a partial state when a v2 string does not fit its fixed output buffer. */
 int gua_get_node_state_v2(gua_context_t* ctx, const char* node_id, gua_node_state_v2_t* out_state);
 int gua_find_node_by_id(gua_context_t* ctx, const char* node_id, char* out_node_id, int out_node_id_size);
 int gua_find_node_by_role(gua_context_t* ctx, const char* role, const char* name, char* out_node_id, int out_node_id_size);

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -755,6 +755,12 @@ extern "C" int gua_get_node_state_v2(gua_context_t* ctx, const char* node_id, gu
         return 0;
     }
 
+    if (found->parent_id.size() >= sizeof(out_state->parent_id) ||
+        found->text.size() >= sizeof(out_state->text) ||
+        found->value.size() >= sizeof(out_state->value)) {
+        return 0;
+    }
+
     out_state->known_mask = found->known_mask;
     out_state->visible = found->visible ? 1 : 0;
     out_state->enabled = found->enabled ? 1 : 0;
@@ -815,7 +821,8 @@ extern "C" int gua_find_node_by_text(gua_context_t* ctx, const char* text, char*
 
     const std::lock_guard lock(ctx->mutex);
     const auto found = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) {
-        return node.label == text;
+        return node.label == text ||
+            ((node.known_mask & GUA_NODE_KNOWN_TEXT) != 0U && node.text == text);
     });
     if (found == ctx->nodes.end()) {
         return 0;

--- a/native/gua-core/tests/selector_tests.cpp
+++ b/native/gua-core/tests/selector_tests.cpp
@@ -58,6 +58,8 @@ int main()
     char legacy[128] {};
     assert(gua_find_node_by_text(context, "保存", legacy, sizeof(legacy)) == 1);
     assert(std::string(legacy) == "left-save");
+    assert(gua_find_node_by_text(context, "Ready", legacy, sizeof(legacy)) == 1);
+    assert(std::string(legacy) == "status");
 
     Locator status_locator(context, "status");
     status_locator.wait_for_visible(std::chrono::milliseconds(20), std::chrono::milliseconds(1));

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -56,6 +56,20 @@ int main()
     assert(state.checked == 0);
     assert(std::strcmp(state.parent_id, "form") == 0);
 
+    const std::string long_text(300, 'x');
+    const gua_node_descriptor_v2_t long_text_node {
+        sizeof(gua_node_descriptor_v2_t), GUA_NODE_KNOWN_TEXT, "long-text", nullptr, "text", "Long text",
+        long_text.c_str(), nullptr, { 0, 0, 1, 1 }, 1, 1, 0, 0, 0, 0, 0,
+    };
+    gua_context_t* oversized_context = gua_create_context();
+    gua_begin_frame(oversized_context, "settings");
+    assert(gua_register_node_v2(oversized_context, &long_text_node) == 1);
+    gua_end_frame(oversized_context);
+    gua_node_state_v2_t oversized_state {};
+    oversized_state.struct_size = sizeof(oversized_state);
+    assert(gua_get_node_state_v2(oversized_context, "long-text", &oversized_state) == 0);
+    gua_destroy_context(oversized_context);
+
     gua_begin_frame(context, "settings");
     register_checkbox(context, false);
     gua_end_frame(context);

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -52,6 +52,8 @@ function ok(id: number, result: GuaInspectorResult): GuaInspectorResponse {
 class DemoRuntime {
   private screen: "title" | "loading" = "title";
   private focusedNodeId = "start";
+  private frameSequence = 1;
+  private revision = 1;
   private logs: GuaLogEntry[] = [
     { sequence: 1, level: "info", message: "Demo runtime started." },
     { sequence: 2, level: "debug", message: "Serving Gua protocol snapshots over WebSocket." },
@@ -60,6 +62,10 @@ class DemoRuntime {
   getUiTree(): GuaUiTree {
     if (this.screen === "loading") {
       return {
+        schemaVersion: 2,
+        sessionEpoch: 1,
+        frameSequence: this.frameSequence,
+        revision: this.revision,
         screen: "loading",
         nodes: [
           node("root", "screen", "Loading Screen", { x: 0, y: 0, w: 1280, h: 720 }, false),
@@ -69,6 +75,10 @@ class DemoRuntime {
     }
 
     return {
+      schemaVersion: 2,
+      sessionEpoch: 1,
+      frameSequence: this.frameSequence,
+      revision: this.revision,
       screen: "title",
       nodes: [
         node("root", "screen", "Title Screen", { x: 0, y: 0, w: 1280, h: 720 }, false),
@@ -98,12 +108,18 @@ class DemoRuntime {
     if (nodeId === "start") {
       this.screen = "loading";
       this.focusedNodeId = "loading";
+      this.frameSequence += 1;
+      this.revision += 1;
       this.log("info", "Screen changed to loading.");
     }
   }
 
   focusNode(nodeId: string): void {
     this.assertNodeExists(nodeId);
+    if (this.focusedNodeId !== nodeId) {
+      this.frameSequence += 1;
+      this.revision += 1;
+    }
     this.focusedNodeId = nodeId;
     this.log("debug", `focus_node(${nodeId})`);
   }

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -26,6 +26,10 @@ export interface GuaNode {
 }
 
 export interface GuaUiTree {
+  schemaVersion: 2;
+  sessionEpoch?: number;
+  frameSequence: number;
+  revision: number;
   screen: string;
   nodes: GuaNode[];
 }
@@ -97,7 +101,14 @@ export const initialPanels: InspectorPanel[] = [
 ];
 
 export function createInspectorState(snapshot?: Partial<InspectorSnapshot>): InspectorState {
-  const uiTree = snapshot?.uiTree ?? { screen: "unknown", nodes: [] };
+  const uiTree = snapshot?.uiTree ?? {
+    schemaVersion: 2,
+    sessionEpoch: 1,
+    frameSequence: 0,
+    revision: 0,
+    screen: "unknown",
+    nodes: [],
+  };
   return {
     uiTree,
     logs: snapshot?.logs ?? [],
@@ -161,10 +172,16 @@ export class MockInspectorClient implements GuaInspectorClient {
   ];
 
   private screen: "title" | "loading" = "title";
+  private frameSequence = 1;
+  private revision = 1;
 
   async getUiTree(): Promise<GuaUiTree> {
     if (this.screen === "loading") {
       return {
+        schemaVersion: 2,
+        sessionEpoch: 1,
+        frameSequence: this.frameSequence,
+        revision: this.revision,
         screen: "loading",
         nodes: [
           {
@@ -190,6 +207,10 @@ export class MockInspectorClient implements GuaInspectorClient {
     }
 
     return {
+      schemaVersion: 2,
+      sessionEpoch: 1,
+      frameSequence: this.frameSequence,
+      revision: this.revision,
       screen: "title",
       nodes: [
         {
@@ -260,6 +281,8 @@ export class MockInspectorClient implements GuaInspectorClient {
 
     if (nodeId === "start") {
       this.screen = "loading";
+      this.frameSequence += 1;
+      this.revision += 1;
     }
   }
 


### PR DESCRIPTION
## Summary
- .NET のスナップショット取得で `value` をスカラーとして扱い、数値・真偽値・null も読み取れるようにした
- Godot の TabContainer をクリック対象として正しく扱い、タブ切り替えを発行できるようにした
- ネイティブ側の `get_node_state_v2` を固定長バッファ超過時に部分結果なしで失敗させ、`find_node_by_text` を `text` でも検索できるようにした
- inspector / bridge-ws の UI ツリーに `schemaVersion` と更新カウンタを追加し、状態変化に応じて `frameSequence` と `revision` を進めるようにした

## Testing
- `state_model_tests.cpp` と `selector_tests.cpp` に追加したケースで、長い文字列の失敗経路と `text` ベース検索を検証
- `dotnet` 側の NUnit 追加テストで、数値・真偽値・null の `value` がスナップショットから読めることを確認
- inspector / demo runtime の更新情報が UI 変更時に増分されることを確認