### PR TITLE
#33 Godot実rendererでvisual comparison E2Eを検証する

### DIFF
--- a/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
@@ -1,0 +1,151 @@
+using System.Text;
+using System.Text.Json;
+using Gua.Core;
+using Gua.Testing.Godot;
+using Gua.Testing.Visual;
+using NUnit.Framework;
+
+namespace Gua.Godot.Visual.Integration.Tests;
+
+[NonParallelizable]
+public sealed class GodotVisualIntegrationTests
+{
+    private const string Secret = "gua-visual-secret-marker";
+    private string _root = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("GUA_GODOT_REAL_RENDERER_TEST"), "1", StringComparison.Ordinal))
+            Assert.Ignore("Set GUA_GODOT_REAL_RENDERER_TEST=1 to run the Godot real-renderer integration test.");
+        _root = Path.Combine(Path.GetTempPath(), "gua-godot-visual", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("GUA_VISUAL_E2E", null);
+        Environment.SetEnvironmentVariable("GUA_VISUAL_E2E_DIFF", null);
+        Environment.SetEnvironmentVariable("GUA_BRIDGE_PORT", null);
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    [Test]
+    public async Task RealViewportSupportsBaselineDiffReplayAndSecretRedaction()
+    {
+        var baselines = Path.Combine(_root, "baselines");
+        var failures = Path.Combine(_root, "failure");
+        var options = new ScreenshotOptions
+        {
+            BaselineDirectory = baselines,
+            FailureDirectory = failures,
+            BaselineVariant = "windows-gl-compatibility",
+            PixelThreshold = 0,
+            MaxDifferentPixelRatio = 0,
+        };
+
+        using (var update = StartGodot(diff: false))
+        {
+            var screenshot = await update.WaitForScreenshotAsync(TimeSpan.FromSeconds(15));
+            Assert.That(screenshot, Does.Contain("data:image/png;base64,"));
+            var result = await GuaVisualAssertions.ExpectScreenshotAsync(update.Context, "title", new ScreenshotOptions
+            {
+                BaselineDirectory = baselines,
+                FailureDirectory = failures,
+                BaselineVariant = options.BaselineVariant,
+                UpdateBaselines = true,
+            });
+            Assert.That(result.BaselineUpdated, Is.True);
+        }
+
+        using (var normal = StartGodot(diff: false))
+        {
+            await normal.WaitForScreenshotAsync(TimeSpan.FromSeconds(15));
+            var matched = await GuaVisualAssertions.ExpectScreenshotAsync(normal.Context, "title", options);
+            Assert.That(matched.Matched, Is.True);
+
+            var recording = new GuaRecording(1,
+            [
+                new(GuaRecordedAction.set_checked, 0, 0, 0, false,
+                    Target: new GuaRecordingTarget(Id: "visual-checkbox"), Value: "true"),
+                new(GuaRecordedAction.select, 1, 0, 0, false,
+                    Target: new GuaRecordingTarget(Id: "visual-select"), Value: "Beta"),
+                new(GuaRecordedAction.set_value, 2, 0, 0, true,
+                    Target: new GuaRecordingTarget(Id: "visual-password"), SecretKey: "password"),
+            ]);
+            await GuaReplayer.ReplayAsync(normal.Context, recording, new GuaReplayOptions
+            {
+                SecretResolver = key => key == "password" ? Secret : null,
+            });
+            var events = await WaitForActionEventsAsync(normal.Context, 3, TimeSpan.FromSeconds(5));
+
+            var diagnostics = normal.Context.GetDiagnosticsJson();
+            var recorded = JsonSerializer.Serialize(GuaRecordingFile.FromDiagnostics(diagnostics));
+            Assert.Multiple(() =>
+            {
+                Assert.That(events, Has.All.Property(nameof(GuaActionEvent.Succeeded)).True);
+                Assert.That(events.Select(value => value.NodeId), Is.EquivalentTo(new[] { "visual-checkbox", "visual-select", "visual-password" }));
+                Assert.That(diagnostics, Does.Not.Contain(Secret));
+                Assert.That(recorded, Does.Not.Contain(Secret));
+                Assert.That(recorded, Does.Contain("visual-checkbox"));
+                Assert.That(recorded, Does.Contain("visual-select"));
+                Assert.That(recorded, Does.Contain("visual-password"));
+            });
+        }
+
+        using (var different = StartGodot(diff: true))
+        {
+            await different.WaitForScreenshotAsync(TimeSpan.FromSeconds(15));
+            var error = Assert.ThrowsAsync<InvalidOperationException>(
+                () => GuaVisualAssertions.ExpectScreenshotAsync(different.Context, "title", options));
+            Assert.That(error!.Message, Does.Not.Contain(Secret));
+        }
+
+        var failureDirectory = Directory.GetDirectories(failures).Single();
+        var artifactNames = Directory.GetFiles(failureDirectory).Select(Path.GetFileName).ToArray();
+        Assert.That(artifactNames, Is.EquivalentTo(new[] { "expected.png", "actual.png", "diff.png", "comparison.json" }));
+        foreach (var path in Directory.GetFiles(failureDirectory))
+            Assert.That(Encoding.UTF8.GetString(File.ReadAllBytes(path)), Does.Not.Contain(Secret));
+    }
+
+    private static async Task<IReadOnlyList<GuaActionEvent>> WaitForActionEventsAsync(
+        IGuaContext context, int count, TimeSpan timeout)
+    {
+        var events = new List<GuaActionEvent>();
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (events.Count < count && DateTimeOffset.UtcNow < deadline)
+        {
+            while (context.TryPollActionEvent(out var value)) events.Add(value);
+            if (events.Count < count) await Task.Delay(25);
+        }
+        Assert.That(events, Has.Count.EqualTo(count), "Godot did not emit all semantic replay completion events.");
+        return events;
+    }
+
+    private static GodotSceneTestHost StartGodot(bool diff)
+    {
+        const int port = 18765;
+        Environment.SetEnvironmentVariable("GUA_VISUAL_E2E", "1");
+        Environment.SetEnvironmentVariable("GUA_VISUAL_E2E_DIFF", diff ? "1" : null);
+        Environment.SetEnvironmentVariable("GUA_BRIDGE_PORT", port.ToString());
+        return GodotSceneTestHost.Load("res://Main.tscn", new GodotSceneTestHostOptions
+        {
+            GodotExecutablePath = Environment.GetEnvironmentVariable("GODOT_EXECUTABLE"),
+            ProjectPath = Path.Combine(FindRepositoryRoot(), "examples", "godot-gdscript"),
+            BridgeUrl = $"ws://127.0.0.1:{port}",
+            Headless = false,
+            ConnectTimeout = TimeSpan.FromSeconds(15),
+            RequestTimeout = TimeSpan.FromSeconds(10),
+            SceneTimeout = TimeSpan.FromSeconds(15),
+            AdditionalArguments = ["--display-driver", "windows", "--rendering-method", "gl_compatibility", "--resolution", "1280x720", "--position", "0,0"],
+        });
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+            if (File.Exists(Path.Combine(directory.FullName, "CMakePresets.json"))) return directory.FullName;
+        throw new DirectoryNotFoundException("Could not locate the Gua repository root from the test output directory.");
+    }
+}

--- a/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/Gua.Godot.Visual.Integration.Tests.csproj
+++ b/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/Gua.Godot.Visual.Integration.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Gua.Testing.Godot\Gua.Testing.Godot.csproj" />
+    <ProjectReference Include="..\..\src\Gua.Testing.Visual\Gua.Testing.Visual.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+</Project>

--- a/examples/godot-gdscript/README.md
+++ b/examples/godot-gdscript/README.md
@@ -17,6 +17,22 @@ Use a normal run to compare without baseline mutation. Set
 `GUA_UPDATE_BASELINES=1` only for an intentional update, and change a rendered
 control to exercise the diff-failure artifact path.
 
+The opt-in .NET integration test joins real viewport readback, the WebSocket
+screenshot payload, baseline comparison, and semantic recording/replay. It opens
+a real Windows renderer and is skipped unless explicitly enabled:
+
+```powershell
+$env:GODOT_EXECUTABLE = 'C:\path\to\Godot_v4.7-stable_win64_console.exe'
+$env:GUA_GODOT_REAL_RENDERER_TEST = '1'
+dotnet test bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/Gua.Godot.Visual.Integration.Tests.csproj
+```
+
+The test uses the explicit `windows-gl-compatibility` baseline variant in a temporary
+directory, exercises update/match/intentional-diff runs, and verifies the four
+failure artifacts plus sensitive-value redaction. It deliberately does not run
+with `--headless`; the deterministic injected-image smoke below remains the fast
+dummy-renderer protocol check.
+
 Build the native extension first:
 
 ```powershell

--- a/examples/godot-gdscript/scripts/main.gd
+++ b/examples/godot-gdscript/scripts/main.gd
@@ -11,18 +11,30 @@ var title_label: Label
 var start_button: Button
 var settings_button: Button
 var loading_label: Label
+var visual_e2e := false
+var visual_e2e_update_elapsed := 0.0
 
 
 func _ready() -> void:
+	visual_e2e = OS.get_environment("GUA_VISUAL_E2E") == "1"
+	if OS.has_environment("GUA_BRIDGE_PORT"):
+		inspector_bridge_port = int(OS.get_environment("GUA_BRIDGE_PORT"))
 	_build_ui()
 	ui.attach(self)
 	ui.update(_current_screen())
 
 	if start_inspector_bridge_on_ready:
 		_start_inspector_bridge()
+	if visual_e2e:
+		_capture_visual_e2e.call_deferred()
 
 
-func _process(_delta: float) -> void:
+func _process(delta: float) -> void:
+	if visual_e2e:
+		visual_e2e_update_elapsed += delta
+		if visual_e2e_update_elapsed < 0.1:
+			return
+		visual_e2e_update_elapsed = 0.0
 	ui.update(_current_screen())
 
 
@@ -58,6 +70,53 @@ func _build_ui() -> void:
 	loading_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	loading_label.visible = false
 	add_child(loading_label)
+
+	if visual_e2e:
+		_build_visual_e2e_controls()
+
+
+func _build_visual_e2e_controls() -> void:
+	if OS.get_environment("GUA_VISUAL_E2E_DIFF") == "1":
+		title_label.text = "Gua Visual Difference"
+
+	var input := LineEdit.new()
+	input.name = "visual_password"
+	input.set_meta("gua_id", "visual-password")
+	input.set_meta("gua_sensitive", true)
+	input.secret = true
+	input.placeholder_text = "Password"
+	input.position = Vector2(512, 456)
+	input.size = Vector2(256, 40)
+	add_child(input)
+
+	var checkbox := CheckBox.new()
+	checkbox.name = "visual_checkbox"
+	checkbox.set_meta("gua_id", "visual-checkbox")
+	checkbox.text = "Enable visual mode"
+	checkbox.position = Vector2(512, 512)
+	checkbox.size = Vector2(256, 40)
+	add_child(checkbox)
+
+	var select := OptionButton.new()
+	select.name = "visual_select"
+	select.set_meta("gua_id", "visual-select")
+	select.add_item("Alpha")
+	select.add_item("Beta")
+	select.position = Vector2(512, 568)
+	select.size = Vector2(256, 40)
+	add_child(select)
+
+
+func _capture_visual_e2e() -> void:
+	await get_tree().process_frame
+	await get_tree().process_frame
+	await RenderingServer.frame_post_draw
+	ui.update(_current_screen())
+	var result := ui.capture_viewport_screenshot()
+	if not result.get("ok", false):
+		push_error("Gua real-renderer visual E2E capture failed: %s" % result)
+	else:
+		print("GUA_VISUAL_E2E_CAPTURED %sx%s" % [result.get("width", 0), result.get("height", 0)])
 
 
 func _show_loading() -> void:


### PR DESCRIPTION
## 対応 Issue

- #33

## 実装内容

- `examples/godot-gdscript` に明示 opt-in の実 renderer visual E2E モードを追加しました。
- 描画完了後に `Viewport.get_texture().get_image()` を通して PNG を取得し、既存 WebSocket screenshot payload へ公開します。
- adapter-owned reflection のまま、button、sensitive text input、checkbox、select を sample の標準 Godot control として追加しました。
- 専用 .NET integration test で update baseline、通常一致、意図的差分 failure の3経路を一時 directory 上で検証します。
- semantic ID による checkbox/select/sensitive input の recording/replay と observed completion event を検証します。
- secret marker が diagnostics、recording、exception、failure artifact に平文で残らないことを機械的に確認します。

## Architecture 判断

- #25 で追加済みの `GuaAutoAdapter.capture_viewport_screenshot()`、`GodotSceneTestHost.WaitForScreenshotAsync()`、`Gua.Testing.Visual` を再利用し、新しい capture/runtime 実装は作っていません。
- baseline variant は `windows-gl-compatibility` を明示し、OS/GPU から暗黙生成しません。
- repository baseline は通常 run で更新せず、test ごとの一時 baseline/artifact directory を使います。
- 通常の sample と dummy headless smoke は維持し、実 renderer test は `GUA_GODOT_REAL_RENDERER_TEST=1` の明示時だけ実行します。
- E2E opt-in 時は adapter update を100ms間隔にし、外部 query/enqueue が安定 snapshot 上で行えるようにしています。通常 runtime の毎 frame 更新は変更していません。

## 検証

- `cmake --preset windows-msvc-debug`: 成功
- `cmake --build --preset windows-msvc-debug`: 成功
- `ctest --test-dir build/windows-msvc-debug -C Debug --output-on-failure`: 2/2 成功
- `dotnet test bindings/dotnet/tests/Gua.Visual.Tests/Gua.Visual.Tests.csproj --configuration Release`: 6/6 成功
- `GUA_GODOT_REAL_RENDERER_TEST=1 dotnet test bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/Gua.Godot.Visual.Integration.Tests.csproj --configuration Release`: 1/1 成功（Godot 4.7 Windows real renderer、GL Compatibility）
- 同 integration test の通常実行: 1件 skip、失敗なし
- `Godot_v4.7-stable_win64_console.exe --headless --path examples/godot-gdscript --script res://scripts/gua_smoke.gd`: 成功
- `git diff --check`: 成功

## 未対応事項

- OCR、video、baseline service、Unity / Unreal / raw ImGui capture は Issue の非目標どおり未対応です。
- GPU 間の pixel 完全一致は保証しません。CI workflow への常時追加も、利用可能な real renderer runner と安定性が確定していないため行っていません。
