### PR TITLE
リリースワークフローをタグ駆動の版管理に統一する

### DIFF
--- a/.github/scripts/next-release-version.ps1
+++ b/.github/scripts/next-release-version.ps1
@@ -1,0 +1,49 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$TagPrefix,
+
+    [string]$RequestedMajor = ""
+)
+
+$ErrorActionPreference = "Stop"
+$tagPattern = "^$([regex]::Escape($TagPrefix))-v(?<major>\d+)\.(?<minor>\d+)\.0$"
+$versions = git tag --list "$TagPrefix-v*" |
+    ForEach-Object {
+        if ($_ -match $tagPattern) {
+            [pscustomobject]@{
+                Tag = $_
+                Major = [int]$Matches.major
+                Minor = [int]$Matches.minor
+            }
+        }
+    } |
+    Sort-Object Major, Minor -Descending
+
+$latest = $versions | Select-Object -First 1
+
+if ([string]::IsNullOrWhiteSpace($RequestedMajor)) {
+    if ($null -eq $latest) {
+        $major = 0
+        $minor = 1
+    } else {
+        $major = $latest.Major
+        $minor = $latest.Minor + 1
+    }
+} else {
+    $parsedMajor = 0
+    if (-not [int]::TryParse($RequestedMajor, [ref]$parsedMajor) -or $parsedMajor -lt 1) {
+        throw "major must be a positive integer."
+    }
+    if ($null -ne $latest -and $parsedMajor -le $latest.Major) {
+        throw "major must be greater than the latest released major ($($latest.Major))."
+    }
+
+    $major = $parsedMajor
+    $minor = 0
+}
+
+$version = "$major.$minor.0"
+"version=$version" >> $env:GITHUB_OUTPUT
+"tag=$TagPrefix-v$version" >> $env:GITHUB_OUTPUT
+
+Write-Host "Next $TagPrefix release: v$version"

--- a/.github/workflows/godot-plugin-release.yml
+++ b/.github/workflows/godot-plugin-release.yml
@@ -1,11 +1,18 @@
 name: Godot Plugin Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      major:
+        description: New major version (major upgrades only; leave empty for an automatic minor release)
+        required: false
+        type: string
   push:
     branches:
       - main
     paths:
       - .github/workflows/godot-plugin-release.yml
+      - .github/scripts/next-release-version.ps1
       - CMakeLists.txt
       - CMakePresets.json
       - examples/godot-gdscript/addons/gua/**
@@ -29,6 +36,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine release version
+        id: version
+        shell: pwsh
+        env:
+          REQUESTED_MAJOR: ${{ inputs.major }}
+        run: .github/scripts/next-release-version.ps1 -TagPrefix godot-plugin -RequestedMajor $env:REQUESTED_MAJOR
 
       - name: Configure native build
         run: cmake --preset windows-msvc-debug
@@ -40,11 +56,10 @@ jobs:
         id: package
         shell: pwsh
         run: |
-          $shortSha = "${env:GITHUB_SHA}".Substring(0, 12)
           $packageRoot = Join-Path $env:RUNNER_TEMP "gua-godot-plugin"
           $addonSource = "examples/godot-gdscript/addons/gua"
           $addonTarget = Join-Path $packageRoot "addons/gua"
-          $zipPath = Join-Path $env:RUNNER_TEMP "gua-godot-plugin-windows-debug-$shortSha.zip"
+          $zipPath = Join-Path $env:RUNNER_TEMP "gua-godot-plugin-windows-debug-v${{ steps.version.outputs.version }}.zip"
 
           Remove-Item -Recurse -Force $packageRoot, $zipPath -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force $addonTarget | Out-Null
@@ -61,8 +76,6 @@ jobs:
           Compress-Archive -Path (Join-Path $packageRoot "addons") -DestinationPath $zipPath -CompressionLevel Optimal
 
           "asset=$zipPath" >> $env:GITHUB_OUTPUT
-          "tag=godot-plugin-$shortSha" >> $env:GITHUB_OUTPUT
-          "name=Gua Godot Plugin $shortSha" >> $env:GITHUB_OUTPUT
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
@@ -74,8 +87,8 @@ jobs:
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.package.outputs.tag }}
-          name: ${{ steps.package.outputs.name }}
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Gua Godot Plugin v${{ steps.version.outputs.version }}
           body: |
             Automated Gua Godot plugin build from `${{ github.sha }}`.
 

--- a/.github/workflows/inspector-release.yml
+++ b/.github/workflows/inspector-release.yml
@@ -1,11 +1,18 @@
 name: Inspector Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      major:
+        description: New major version (major upgrades only; leave empty for an automatic minor release)
+        required: false
+        type: string
   push:
     branches:
       - main
     paths:
       - .github/workflows/inspector-release.yml
+      - .github/scripts/next-release-version.ps1
       - bun.lock
       - package.json
       - tsconfig.base.json
@@ -31,6 +38,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine release version
+        id: version
+        shell: pwsh
+        env:
+          REQUESTED_MAJOR: ${{ inputs.major }}
+        run: .github/scripts/next-release-version.ps1 -TagPrefix inspector -RequestedMajor $env:REQUESTED_MAJOR
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -47,19 +63,11 @@ jobs:
       - name: Build Tauri inspector
         run: bun run --filter @gua/inspector tauri:build
 
-      - name: Collect release metadata
-        id: meta
-        shell: pwsh
-        run: |
-          $shortSha = "${env:GITHUB_SHA}".Substring(0, 12)
-          "tag=inspector-$shortSha" >> $env:GITHUB_OUTPUT
-          "name=Gua Inspector $shortSha" >> $env:GITHUB_OUTPUT
-
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          name: ${{ steps.meta.outputs.name }}
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Gua Inspector v${{ steps.version.outputs.version }}
           body: |
             Automated Gua Inspector build from `${{ github.sha }}`.
 

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,11 +1,18 @@
 name: MCP npm Publish
 
 on:
+  workflow_dispatch:
+    inputs:
+      major:
+        description: New major version (major upgrades only; leave empty for an automatic minor release)
+        required: false
+        type: string
   push:
     branches:
       - main
     paths:
       - .github/workflows/mcp-publish.yml
+      - .github/scripts/next-release-version.ps1
       - bun.lock
       - package.json
       - tsconfig.base.json
@@ -15,7 +22,7 @@ on:
       - protocol/**
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 concurrency:
@@ -30,6 +37,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine release version
+        id: version
+        shell: pwsh
+        env:
+          REQUESTED_MAJOR: ${{ inputs.major }}
+        run: .github/scripts/next-release-version.ps1 -TagPrefix mcp -RequestedMajor $env:REQUESTED_MAJOR
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -54,8 +70,7 @@ jobs:
         id: prepare
         shell: bash
         run: |
-          short_sha="${GITHUB_SHA::12}"
-          package_version="0.0.0-main.${GITHUB_RUN_NUMBER}.${short_sha}"
+          package_version="${{ steps.version.outputs.version }}"
           publish_dir="${RUNNER_TEMP}/gui-mcp-package"
 
           rm -rf "${publish_dir}"
@@ -89,3 +104,9 @@ jobs:
         run: |
           cd "${{ steps.prepare.outputs.publish_dir }}"
           npm publish --access public --tag latest
+
+      - name: Record published version
+        shell: pwsh
+        run: |
+          git tag '${{ steps.version.outputs.tag }}' $env:GITHUB_SHA
+          git push origin '${{ steps.version.outputs.tag }}'

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -2,11 +2,17 @@ name: NuGet Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      major:
+        description: New major version (major upgrades only; leave empty for an automatic minor release)
+        required: false
+        type: string
   push:
     branches:
       - main
     paths:
       - .github/workflows/nuget-publish.yml
+      - .github/scripts/next-release-version.ps1
       - Directory.Build.props
       - CMakeLists.txt
       - CMakePresets.json
@@ -17,7 +23,7 @@ on:
       - protocol/**
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 concurrency:
@@ -32,6 +38,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine release version
+        id: version
+        shell: pwsh
+        env:
+          REQUESTED_MAJOR: ${{ inputs.major }}
+        run: .github/scripts/next-release-version.ps1 -TagPrefix nuget -RequestedMajor $env:REQUESTED_MAJOR
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
@@ -48,16 +63,16 @@ jobs:
         run: dotnet restore bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj
 
       - name: Build
-        run: dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release --no-restore
+        run: dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release --no-restore -p:Version=${{ steps.version.outputs.version }}
 
       - name: Pack Gua.Core
-        run: dotnet pack bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release --no-build
+        run: dotnet pack bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release --no-build -p:PackageVersion=${{ steps.version.outputs.version }}
 
       - name: Pack Gua.Testing
-        run: dotnet pack bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release --no-build
+        run: dotnet pack bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release --no-build -p:PackageVersion=${{ steps.version.outputs.version }}
 
       - name: Pack Gua.Testing.Godot
-        run: dotnet pack bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release --no-build
+        run: dotnet pack bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release --no-build -p:PackageVersion=${{ steps.version.outputs.version }}
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4
@@ -92,3 +107,9 @@ jobs:
               --skip-duplicate
           }
           Pop-Location
+
+      - name: Record published version
+        shell: pwsh
+        run: |
+          git tag '${{ steps.version.outputs.tag }}' $env:GITHUB_SHA
+          git push origin '${{ steps.version.outputs.tag }}'


### PR DESCRIPTION
## Summary
- `next-release-version.ps1` を追加し、各リリース対象の次バージョンをタグ履歴から算出するようにした
- Godot Plugin / Inspector / MCP / NuGet の各ワークフローで `workflow_dispatch` の `major` 入力を受け取り、手動のメジャー更新にも対応した
- 生成物名、GitHub Release 名、NuGet パッケージ版数を `vMAJOR.MINOR.0` 形式に揃えた
- MCP と NuGet では公開後にタグを作成して push し、実際に公開した版を記録するようにした

## Testing
- Not run (not requested)