### PR TITLE
#38 Gua.Testing.Godot v2操作・状態・診断APIを追加する

### DIFF
--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -20,6 +20,8 @@ public sealed class GodotSceneTestHost : IDisposable
 
     public IGuaContext Context { get; }
 
+    public GuaRemoteContext RemoteContext => (GuaRemoteContext)Context;
+
     public int ProcessId => _process.Id;
 
     public GuaDiagnosticOptions CreateDiagnosticOptions(string testName, string? outputDirectory = null)
@@ -52,6 +54,20 @@ public sealed class GodotSceneTestHost : IDisposable
         {
             output.Start();
             context.WaitUntilAvailable(options.ConnectTimeout);
+            if (options.StartupReset is { } resetOptions)
+            {
+                var status = context.GetContextStatus();
+                var report = context.Reset(resetOptions with { ExpectedSessionEpoch = status.SessionEpoch });
+                if (report.Result == GuaResetResult.StaleEpoch)
+                    throw new InvalidOperationException($"Godot startup reset rejected stale session epoch {status.SessionEpoch}.");
+                if (report.Result == GuaResetResult.Dirty)
+                    throw new InvalidOperationException($"Godot startup strict reset rejected dirty context: pending={report.PendingRequestCount}, inFlight={report.InFlightRequestCount}, events={report.UnconsumedEventCount}.");
+                if (report.Result != GuaResetResult.Succeeded)
+                    throw new InvalidOperationException($"Godot startup reset failed: {report.Result}.");
+                var clean = context.GetContextStatus();
+                if (!clean.IsClean)
+                    throw new InvalidOperationException($"Godot startup reset left queued work: pending={clean.PendingRequestCount}, inFlight={clean.InFlightRequestCount}, events={clean.UnconsumedEventCount}.");
+            }
             return new GodotSceneTestHost(process, context, options);
         }
         catch (Exception error)
@@ -99,6 +115,40 @@ public sealed class GodotSceneTestHost : IDisposable
             await Task.Delay(25, cancellationToken).ConfigureAwait(false);
         } while (DateTimeOffset.UtcNow < deadline);
         throw new TimeoutException($"Godot did not publish an opt-in viewport screenshot within {limit:g}.");
+    }
+
+    public GuaScreenshot GetScreenshot()
+    {
+        ThrowIfDisposed();
+        return GuaScreenshot.Parse(RemoteContext.GetScreenshotJson());
+    }
+
+    public GuaSavedScreenshot SaveScreenshot(string directory, string testName)
+    {
+        ThrowIfDisposed();
+        ArgumentException.ThrowIfNullOrWhiteSpace(directory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(testName);
+        var screenshot = GetScreenshot();
+        var bytes = screenshot.DecodePng();
+        var absoluteDirectory = Path.GetFullPath(directory);
+        Directory.CreateDirectory(absoluteDirectory);
+        var safeName = string.Concat(testName.Select(character => Path.GetInvalidFileNameChars().Contains(character) ? '_' : character));
+        var path = Path.Combine(absoluteDirectory, $"{safeName}-{DateTime.UtcNow:yyyyMMdd-HHmmssfff}-{Guid.NewGuid():N}.png");
+        File.WriteAllBytes(path, bytes);
+        return new GuaSavedScreenshot(screenshot.Width, screenshot.Height, Path.GetFullPath(path));
+    }
+
+    public GuaContextStatus GetContextStatus() => RemoteContext.GetContextStatus();
+
+    public GuaResetReport ResetContext(GuaResetOptions? options = null)
+    {
+        ThrowIfDisposed();
+        var status = RemoteContext.GetContextStatus();
+        var requested = options ?? new GuaResetOptions();
+        var report = RemoteContext.Reset(requested with { ExpectedSessionEpoch = requested.ExpectedSessionEpoch ?? status.SessionEpoch });
+        if (report.Result == GuaResetResult.Succeeded && !RemoteContext.GetContextStatus().IsClean)
+            throw new InvalidOperationException("Godot context reset succeeded but pending requests or events remain.");
+        return report;
     }
 
     public void Dispose()
@@ -151,6 +201,11 @@ public sealed class GodotSceneTestHost : IDisposable
         foreach (var argument in arguments)
         {
             startInfo.ArgumentList.Add(argument);
+        }
+
+        foreach (var (name, value) in options.EnvironmentVariables)
+        {
+            startInfo.Environment[name] = value;
         }
 
         return Process.Start(startInfo)

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHostOptions.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHostOptions.cs
@@ -1,5 +1,7 @@
 namespace Gua.Testing.Godot;
 
+using Gua.Core;
+
 public sealed class GodotSceneTestHostOptions
 {
     public static GodotSceneTestHostOptions Default { get; } = new();
@@ -21,4 +23,8 @@ public sealed class GodotSceneTestHostOptions
     public TimeSpan SceneTimeout { get; init; } = TimeSpan.FromSeconds(3);
 
     public IReadOnlyList<string> AdditionalArguments { get; init; } = [];
+
+    public IReadOnlyDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();
+
+    public GuaResetOptions? StartupReset { get; init; }
 }

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaScreenshot.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaScreenshot.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+
+namespace Gua.Testing.Godot;
+
+public enum GuaScreenshotError
+{
+    NotPublished,
+    InvalidDataUri,
+    InvalidPng,
+}
+
+public sealed class GuaScreenshotException : Exception
+{
+    public GuaScreenshotException(GuaScreenshotError error, string message, Exception? inner = null) : base(message, inner) => Error = error;
+    public GuaScreenshotError Error { get; }
+}
+
+public sealed record GuaScreenshot(string DataUri, int Width, int Height)
+{
+    private static readonly byte[] PngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
+
+    internal static GuaScreenshot Parse(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        return new GuaScreenshot(
+            root.GetProperty("dataUri").GetString() ?? string.Empty,
+            root.GetProperty("width").GetInt32(),
+            root.GetProperty("height").GetInt32());
+    }
+
+    public byte[] DecodePng()
+    {
+        if (string.IsNullOrEmpty(DataUri))
+            throw new GuaScreenshotException(GuaScreenshotError.NotPublished, "The Godot adapter has not published a screenshot.");
+        const string prefix = "data:image/png;base64,";
+        if (!DataUri.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            throw new GuaScreenshotException(GuaScreenshotError.InvalidDataUri, "The Gua screenshot is not a PNG data URI.");
+        try
+        {
+            var bytes = Convert.FromBase64String(DataUri[prefix.Length..]);
+            if (bytes.Length < PngSignature.Length || !bytes.AsSpan(0, PngSignature.Length).SequenceEqual(PngSignature))
+                throw new GuaScreenshotException(GuaScreenshotError.InvalidPng, "The Gua screenshot payload is not a valid PNG stream.");
+            return bytes;
+        }
+        catch (FormatException error)
+        {
+            throw new GuaScreenshotException(GuaScreenshotError.InvalidDataUri, "The Gua screenshot data URI contains invalid base64.", error);
+        }
+    }
+}
+
+public sealed record GuaSavedScreenshot(int Width, int Height, string AbsolutePath);

--- a/bindings/dotnet/src/Gua.Testing.Godot/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Godot/README.md
@@ -39,3 +39,40 @@ screen names instead of resource paths.
 For failure artifacts, `host.CreateDiagnosticOptions(testName)` includes the
 Godot process id, bridge URL, and project metadata. The remote context captures
 the same versioned diagnostics JSON as an in-process context.
+
+## Protocol v2 form testing
+
+Typed operations wait for the correlated action result, not merely enqueue
+acceptance. Request-id-specific polling leaves unrelated results and ordinary
+events queued. Async methods accept timeout, poll interval, and cancellation.
+
+```csharp
+using var host = GodotSceneTestHost.Load("res://Main.tscn", new GodotSceneTestHostOptions
+{
+    ProjectPath = projectPath,
+    StartupReset = new GuaResetOptions(Strict: true), // opt-in
+});
+
+var userName = GuaAssertions.Query(host.Context)
+    .ByRole("textbox").Within("LoginForm").ByAction("set_value").Get();
+await userName.SetValueAsync("alice");
+await userName.FocusAsync();
+await GuaAssertions.PressKeyAsync(host.Context, "Enter"); // current focus
+await GuaAssertions.GetById(host.Context, "ProviderOption").SelectAsync("google");
+await GuaAssertions.GetById(host.Context, "RememberMe").SetCheckedAsync(true);
+await GuaAssertions.GetById(host.Context, "ManagementContent").ScrollAsync(0, 500);
+await userName.WaitForValueAsync("alice");
+await userName.WaitUntilFocusedAsync();
+
+var saved = host.SaveScreenshot(TestContext.CurrentContext.WorkDirectory,
+    TestContext.CurrentContext.Test.Name);
+TestContext.AddTestAttachment(saved.AbsolutePath, $"{saved.Width}x{saved.Height}");
+```
+
+Use `SetValueAsync(value, sensitive: true)` for secrets. Plaintext is redacted
+from action results, logs, diagnostics, and snapshots for adapter-marked
+sensitive controls. A screenshot can still contain a rendered secret: saving,
+attaching, retaining, and publishing PNG files is the caller's responsibility.
+`SaveScreenshot` creates a collision-resistant absolute path and distinguishes
+unpublished, malformed data-URI, and invalid-PNG payloads. A headless renderer
+without viewport capture is reported as unpublished rather than an empty file.

--- a/bindings/dotnet/src/Gua.Testing/GuaActionCompletion.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaActionCompletion.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using Gua.Core;
+
+namespace Gua.Testing;
+
+public enum GuaActionFailureKind
+{
+    Rejected,
+    Failed,
+    TimedOut,
+    Cancelled,
+}
+
+public sealed class GuaActionException : Exception
+{
+    public GuaActionException(
+        GuaActionFailureKind kind,
+        ulong requestId,
+        GuaActionType action,
+        string? nodeId,
+        GuaActionError error,
+        string message,
+        Exception? innerException = null) : base(message, innerException)
+    {
+        Kind = kind;
+        RequestId = requestId;
+        Action = action;
+        NodeId = nodeId;
+        Error = error;
+    }
+
+    public GuaActionFailureKind Kind { get; }
+    public ulong RequestId { get; }
+    public GuaActionType Action { get; }
+    public string? NodeId { get; }
+    public GuaActionError Error { get; }
+}
+
+public static class GuaActionCompletion
+{
+    public static TimeSpan DefaultTimeout { get; set; } = TimeSpan.FromSeconds(1);
+    public static TimeSpan DefaultPollInterval { get; set; } = TimeSpan.FromMilliseconds(10);
+
+    public static GuaActionEvent EnqueueAndWait(
+        IGuaContext context,
+        GuaActionRequest request,
+        TimeSpan? timeout = null,
+        TimeSpan? pollInterval = null) =>
+        EnqueueAndWaitAsync(context, request, timeout, pollInterval).GetAwaiter().GetResult();
+
+    public static async Task<GuaActionEvent> EnqueueAndWaitAsync(
+        IGuaContext context,
+        GuaActionRequest request,
+        TimeSpan? timeout = null,
+        TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var limit = timeout ?? DefaultTimeout;
+        var interval = pollInterval ?? DefaultPollInterval;
+        if (limit < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+        if (interval <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(pollInterval));
+
+        var error = context.EnqueueAction(request, out var requestId);
+        if (error != GuaActionError.None)
+        {
+            throw Create(context, GuaActionFailureKind.Rejected, requestId, request.Action, request.NodeId, error,
+                $"Gua action was rejected: requestId={requestId}, action={request.Action}, nodeId='{request.NodeId ?? "<focused>"}', error={error}.");
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            do
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (context.TryPollActionEvent(requestId, out var result))
+                {
+                    if (!result.Succeeded)
+                    {
+                        throw Create(context, GuaActionFailureKind.Failed, requestId, request.Action, request.NodeId, result.Error,
+                            $"Gua action failed: requestId={requestId}, action={request.Action}, nodeId='{request.NodeId ?? "<focused>"}', error={result.Error}.");
+                    }
+                    return result;
+                }
+                if (stopwatch.Elapsed >= limit) break;
+                await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+            }
+            while (true);
+        }
+        catch (OperationCanceledException cancellationError) when (cancellationToken.IsCancellationRequested)
+        {
+            throw Create(context, GuaActionFailureKind.Cancelled, requestId, request.Action, request.NodeId, GuaActionError.None,
+                $"Gua action wait was cancelled: requestId={requestId}, action={request.Action}, nodeId='{request.NodeId ?? "<focused>"}'.", cancellationError);
+        }
+
+        throw Create(context, GuaActionFailureKind.TimedOut, requestId, request.Action, request.NodeId, GuaActionError.None,
+            $"Timed out after {limit:g} waiting for Gua action: requestId={requestId}, action={request.Action}, nodeId='{request.NodeId ?? "<focused>"}'.");
+    }
+
+    private static GuaActionException Create(
+        IGuaContext context, GuaActionFailureKind kind, ulong requestId, GuaActionType action,
+        string? nodeId, GuaActionError error, string message, Exception? inner = null)
+    {
+        var suffix = GuaAssertions.DescribeSnapshot(context);
+        return new GuaActionException(kind, requestId, action, nodeId, error, $"{message} {suffix}", inner);
+    }
+}

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -197,6 +197,33 @@ public static partial class GuaAssertions
         }
     }
 
+    internal static string DescribeSnapshot(IGuaContext context)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(context.GetUiTreeJson());
+            var root = document.RootElement;
+            string Metadata(string name) => root.TryGetProperty(name, out var value) ? value.GetRawText() : "<unknown>";
+            var screen = root.TryGetProperty("screen", out var screenValue) ? screenValue.GetString() : "<unknown>";
+            return $"Last screen='{screen}', frameSequence={Metadata("frameSequence")}, revision={Metadata("revision")}. {DescribeTree(context)}";
+        }
+        catch (JsonException)
+        {
+            return "Last UI tree could not be parsed.";
+        }
+    }
+
+    public static GuaActionEvent PressKey(
+        IGuaContext context, string key, uint modifiers = 0, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        GuaActionCompletion.EnqueueAndWait(context,
+            new GuaActionRequest(GuaActionType.PressKey, Key: key, Modifiers: modifiers), timeout, pollInterval);
+
+    public static Task<GuaActionEvent> PressKeyAsync(
+        IGuaContext context, string key, uint modifiers = 0, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        GuaActionCompletion.EnqueueAndWaitAsync(context,
+            new GuaActionRequest(GuaActionType.PressKey, Key: key, Modifiers: modifiers), timeout, pollInterval, cancellationToken);
+
     private static GuaNodeExpectation WaitForQuery(IGuaContext context, Func<GuaNodeExpectation> query, string description, TimeSpan? timeout, TimeSpan? pollInterval)
     {
         var initialUiTreeJson = context.GetUiTreeJson();
@@ -348,6 +375,28 @@ public sealed class GuaNodeExpectation
         return this;
     }
 
+    public GuaNodeExpectation ToBeFocused(bool expected = true) => AssertOptionalState("focused", GetSnapshotOrFail().Focused, expected);
+    public GuaNodeExpectation ToBeSelected(bool expected = true) => AssertOptionalState("selected", GetSnapshotOrFail().Selected, expected);
+    public GuaNodeExpectation ToBeChecked(bool expected = true) => AssertOptionalState("checked", GetSnapshotOrFail().Checked, expected);
+
+    public GuaNodeExpectation ToHaveText(string expected)
+    {
+        ArgumentNullException.ThrowIfNull(expected);
+        var actual = GetSnapshotOrFail().Text;
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to have text '{expected}', but it had '{actual ?? "<unknown>"}'.");
+        return this;
+    }
+
+    public GuaNodeExpectation ToHaveValue(string expected)
+    {
+        ArgumentNullException.ThrowIfNull(expected);
+        var actual = GetSnapshotOrFail().Value;
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to have value '{expected}', but it had '{actual ?? "<unknown>"}'.");
+        return this;
+    }
+
     public GuaNodeExpectation Click()
     {
         ToBeVisible();
@@ -401,6 +450,20 @@ public sealed class GuaNodeExpectation
 
     public ulong PressKey(string key, uint modifiers = 0) =>
         Enqueue(new GuaActionRequest(GuaActionType.PressKey, _id, Key: key, Modifiers: modifiers), "press_key");
+
+    public GuaActionEvent FocusAndWait(TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.Focus, _id), timeout, pollInterval);
+    public GuaActionEvent SetValueAndWait(string value, bool sensitive = false, TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.SetValue, _id, Value: value, Sensitive: sensitive), timeout, pollInterval);
+    public GuaActionEvent SetCheckedAndWait(bool value, TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.SetChecked, _id, BoolValue: value), timeout, pollInterval);
+    public GuaActionEvent SelectAndWait(string value, TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.Select, _id, Value: value), timeout, pollInterval);
+    public GuaActionEvent ScrollAndWait(float deltaX, float deltaY, int unit = 0, TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.Scroll, _id, DeltaX: deltaX, DeltaY: deltaY, ScrollUnit: unit), timeout, pollInterval);
+    public GuaActionEvent PressKeyAndWait(string key, uint modifiers = 0, TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.PressKey, _id, Key: key, Modifiers: modifiers), timeout, pollInterval);
+
+    public Task<GuaActionEvent> FocusAsync(TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.Focus, _id), timeout, pollInterval, cancellationToken);
+    public Task<GuaActionEvent> SetValueAsync(string value, bool sensitive = false, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.SetValue, _id, Value: value, Sensitive: sensitive), timeout, pollInterval, cancellationToken);
+    public Task<GuaActionEvent> SetCheckedAsync(bool value, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.SetChecked, _id, BoolValue: value), timeout, pollInterval, cancellationToken);
+    public Task<GuaActionEvent> SelectAsync(string value, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.Select, _id, Value: value), timeout, pollInterval, cancellationToken);
+    public Task<GuaActionEvent> ScrollAsync(float deltaX, float deltaY, int unit = 0, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.Scroll, _id, DeltaX: deltaX, DeltaY: deltaY, ScrollUnit: unit), timeout, pollInterval, cancellationToken);
+    public Task<GuaActionEvent> PressKeyAsync(string key, uint modifiers = 0, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.PressKey, _id, Key: key, Modifiers: modifiers), timeout, pollInterval, cancellationToken);
 
     public GuaNodeExpectation WaitForAction(ulong requestId, TimeSpan? timeout = null)
     {
@@ -462,6 +525,24 @@ public sealed class GuaNodeExpectation
     public Task<GuaNodeExpectation> WaitForValueAsync(string expected, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) =>
         GuaAssertions.WaitForValueAsync(_context, _id, expected, timeout, pollInterval, cancellationToken);
 
+    public GuaNodeExpectation WaitUntilFocused(bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        GuaAssertions.WaitForFocused(_context, _id, expected, timeout, pollInterval);
+
+    public GuaNodeExpectation WaitUntilSelected(bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        GuaAssertions.WaitForSelected(_context, _id, expected, timeout, pollInterval);
+
+    public GuaNodeExpectation WaitUntilChecked(bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        GuaAssertions.WaitForChecked(_context, _id, expected, timeout, pollInterval);
+
+    public Task<GuaNodeExpectation> WaitUntilFocusedAsync(bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) =>
+        GuaAssertions.WaitForFocusedAsync(_context, _id, expected, timeout, pollInterval, cancellationToken);
+
+    public Task<GuaNodeExpectation> WaitUntilSelectedAsync(bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) =>
+        GuaAssertions.WaitForSelectedAsync(_context, _id, expected, timeout, pollInterval, cancellationToken);
+
+    public Task<GuaNodeExpectation> WaitUntilCheckedAsync(bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) =>
+        GuaAssertions.WaitForCheckedAsync(_context, _id, expected, timeout, pollInterval, cancellationToken);
+
     internal GuaNodeExpectation RequireExistingSnapshot()
     {
         ToExist();
@@ -488,5 +569,22 @@ public sealed class GuaNodeExpectation
         var error = _context.EnqueueAction(request, out var requestId);
         if (error != GuaActionError.None) GuaAssertions.Fail(_context, $"Failed to enqueue {action} for Gua node {_description}: {error}.");
         return requestId;
+    }
+
+    private GuaNodeExpectation AssertOptionalState(string name, bool? actual, bool expected)
+    {
+        if (actual != expected)
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to have {name}={expected}, but it was {actual?.ToString() ?? "<unknown>"}.");
+        return this;
+    }
+
+    private GuaActionEvent Complete(GuaActionRequest request, TimeSpan? timeout, TimeSpan? pollInterval)
+    {
+        return GuaActionCompletion.EnqueueAndWait(_context, request, timeout, pollInterval);
+    }
+
+    private Task<GuaActionEvent> CompleteAsync(GuaActionRequest request, TimeSpan? timeout, TimeSpan? pollInterval, CancellationToken cancellationToken)
+    {
+        return GuaActionCompletion.EnqueueAndWaitAsync(_context, request, timeout, pollInterval, cancellationToken);
     }
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaLocatorQuery.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaLocatorQuery.cs
@@ -1,4 +1,5 @@
 using Gua.Core;
+using System.Text.Json;
 
 namespace Gua.Testing;
 
@@ -6,11 +7,26 @@ public sealed record GuaLocatorQuery
 {
     private readonly IGuaContext _context;
     private readonly GuaSelector _selector;
+    private readonly string? _value;
+    private readonly GuaMatchMode _valueMatch;
+    private readonly bool? _focused;
+    private readonly bool? _selected;
+    private readonly bool? _checked;
+    private readonly string? _action;
 
-    internal GuaLocatorQuery(IGuaContext context, GuaSelector? selector = null)
+    internal GuaLocatorQuery(
+        IGuaContext context, GuaSelector? selector = null, string? value = null,
+        GuaMatchMode valueMatch = GuaMatchMode.Exact, bool? focused = null,
+        bool? selected = null, bool? @checked = null, string? action = null)
     {
         _context = context;
         _selector = selector ?? new GuaSelector();
+        _value = value;
+        _valueMatch = valueMatch;
+        _focused = focused;
+        _selected = selected;
+        _checked = @checked;
+        _action = action;
     }
 
     public GuaLocatorQuery ById(string id, GuaMatchMode match = GuaMatchMode.Exact) => Next(_selector with { Id = id, IdMatch = match });
@@ -20,6 +36,11 @@ public sealed record GuaLocatorQuery
     public GuaLocatorQuery Within(string parentId, bool directChild = false) => Next(_selector with { ParentId = parentId, DirectChild = directChild });
     public GuaLocatorQuery WhereVisible(bool visible = true) => Next(_selector with { Visible = visible ? GuaStateFilter.True : GuaStateFilter.False });
     public GuaLocatorQuery WhereEnabled(bool enabled = true) => Next(_selector with { Enabled = enabled ? GuaStateFilter.True : GuaStateFilter.False });
+    public GuaLocatorQuery ByValue(string value, GuaMatchMode match = GuaMatchMode.Exact) => Copy(value: value, valueMatch: match);
+    public GuaLocatorQuery WhereFocused(bool focused = true) => Copy(focused: focused);
+    public GuaLocatorQuery WhereSelected(bool selected = true) => Copy(selected: selected);
+    public GuaLocatorQuery WhereChecked(bool @checked = true) => Copy(@checked: @checked);
+    public GuaLocatorQuery ByAction(string action) => Copy(action: action);
 
     public IReadOnlyList<GuaNodeExpectation> QueryAll()
     {
@@ -31,7 +52,7 @@ public sealed record GuaLocatorQuery
     {
         var result = Execute();
         if (result.Matches.Count == 0)
-            GuaAssertions.Fail(_context, $"Strict Gua selector matched no nodes: {Describe()}.");
+            GuaAssertions.Fail(_context, $"Strict Gua selector matched no nodes: {Describe()}. Candidates: {DescribeAllCandidates()}.");
         if (result.Matches.Count > 1)
         {
             var candidates = string.Join("; ", result.Matches.Select(match =>
@@ -67,7 +88,9 @@ public sealed record GuaLocatorQuery
         }
         if (!result.Valid)
             GuaAssertions.Fail(_context, $"Invalid Gua selector {Describe()}: {result.Error ?? "unknown syntax error"}");
-        return result;
+        if (_value is null && _focused is null && _selected is null && _checked is null && _action is null) return result;
+        var matches = result.Matches.Where(match => MatchesV2(GuaAssertions.TryGetSnapshot(_context, match.Id))).ToArray();
+        return result with { Matches = matches };
     }
 
     private bool CanUseLegacyFallback() =>
@@ -77,7 +100,32 @@ public sealed record GuaLocatorQuery
         _selector.NameMatch == GuaMatchMode.Exact && _selector.TextMatch == GuaMatchMode.Exact &&
         (_selector.Id is not null || _selector.Role is not null || _selector.Text is not null);
 
-    private GuaLocatorQuery Next(GuaSelector selector) => new(_context, selector);
+    private GuaLocatorQuery Next(GuaSelector selector) => new(_context, selector, _value, _valueMatch, _focused, _selected, _checked, _action);
+
+    private GuaLocatorQuery Copy(
+        string? value = null, GuaMatchMode? valueMatch = null, bool? focused = null,
+        bool? selected = null, bool? @checked = null, string? action = null) =>
+        new(_context, _selector, value ?? _value, valueMatch ?? _valueMatch,
+            focused ?? _focused, selected ?? _selected, @checked ?? _checked, action ?? _action);
+
+    private bool MatchesV2(GuaNodeSnapshot? node)
+    {
+        if (node is null) return false;
+        if (_value is not null && !Matches(node.Value, _value, _valueMatch)) return false;
+        if (_focused is not null && node.Focused != _focused) return false;
+        if (_selected is not null && node.Selected != _selected) return false;
+        if (_checked is not null && node.Checked != _checked) return false;
+        return _action is null || node.Actions.Contains(_action, StringComparer.Ordinal);
+    }
+
+    private static bool Matches(string? actual, string expected, GuaMatchMode mode) => mode switch
+    {
+        GuaMatchMode.Exact => string.Equals(actual, expected, StringComparison.Ordinal),
+        GuaMatchMode.Contains => actual?.Contains(expected, StringComparison.Ordinal) == true,
+        GuaMatchMode.Regex => actual is not null && System.Text.RegularExpressions.Regex.IsMatch(actual, expected,
+            System.Text.RegularExpressions.RegexOptions.CultureInvariant),
+        _ => false,
+    };
 
     private string Describe()
     {
@@ -89,6 +137,26 @@ public sealed record GuaLocatorQuery
         if (_selector.ParentId is not null) fields.Add($"scope={_selector.ParentId} ({(_selector.DirectChild ? "direct children" : "descendants")})");
         if (_selector.Visible != GuaStateFilter.Any) fields.Add($"visible={_selector.Visible == GuaStateFilter.True}");
         if (_selector.Enabled != GuaStateFilter.Any) fields.Add($"enabled={_selector.Enabled == GuaStateFilter.True}");
+        if (_value is not null) fields.Add($"value={_valueMatch}:{_value}");
+        if (_focused is not null) fields.Add($"focused={_focused}");
+        if (_selected is not null) fields.Add($"selected={_selected}");
+        if (_checked is not null) fields.Add($"checked={_checked}");
+        if (_action is not null) fields.Add($"action={_action}");
         return "{" + string.Join(", ", fields) + "}";
+    }
+
+    private string DescribeAllCandidates()
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(_context.GetUiTreeJson());
+            if (!document.RootElement.TryGetProperty("nodes", out var nodes) || nodes.GetArrayLength() == 0) return "<none>";
+            return string.Join("; ", nodes.EnumerateArray().Take(12).Select(node =>
+                $"{node.GetProperty("id").GetString()} ({node.GetProperty("role").GetString()}, '{node.GetProperty("label").GetString()}', parentId='{(node.TryGetProperty("parentId", out var parent) ? parent.GetString() : "<root>")}')"));
+        }
+        catch (JsonException)
+        {
+            return "<UI tree could not be parsed>";
+        }
     }
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaWaits.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWaits.cs
@@ -41,6 +41,24 @@ public static partial class GuaAssertions
         WaitForNodeAsync(context, id, node => string.Equals(node?.Value, expected, StringComparison.Ordinal),
             $"have value '{expected}'", timeout, pollInterval, cancellationToken);
 
+    public static Task<GuaNodeExpectation> WaitForFocusedAsync(
+        IGuaContext context, string id, bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        WaitForNodeAsync(context, id, node => node?.Focused == expected,
+            $"have focused={expected}", timeout, pollInterval, cancellationToken);
+
+    public static Task<GuaNodeExpectation> WaitForSelectedAsync(
+        IGuaContext context, string id, bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        WaitForNodeAsync(context, id, node => node?.Selected == expected,
+            $"have selected={expected}", timeout, pollInterval, cancellationToken);
+
+    public static Task<GuaNodeExpectation> WaitForCheckedAsync(
+        IGuaContext context, string id, bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        WaitForNodeAsync(context, id, node => node?.Checked == expected,
+            $"have checked={expected}", timeout, pollInterval, cancellationToken);
+
     public static GuaNodeExpectation WaitForVisible(IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
         WaitForVisibleAsync(context, id, timeout, pollInterval).GetAwaiter().GetResult();
 
@@ -58,6 +76,15 @@ public static partial class GuaAssertions
 
     public static GuaNodeExpectation WaitForValue(IGuaContext context, string id, string expected, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
         WaitForValueAsync(context, id, expected, timeout, pollInterval).GetAwaiter().GetResult();
+
+    public static GuaNodeExpectation WaitForFocused(IGuaContext context, string id, bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForFocusedAsync(context, id, expected, timeout, pollInterval).GetAwaiter().GetResult();
+
+    public static GuaNodeExpectation WaitForSelected(IGuaContext context, string id, bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForSelectedAsync(context, id, expected, timeout, pollInterval).GetAwaiter().GetResult();
+
+    public static GuaNodeExpectation WaitForChecked(IGuaContext context, string id, bool expected = true, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForCheckedAsync(context, id, expected, timeout, pollInterval).GetAwaiter().GetResult();
 
     public static async Task WaitUntilAsync(
         Func<bool> condition, string description, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
@@ -197,7 +224,7 @@ public static partial class GuaAssertions
     private static string Format(ulong? value) => value?.ToString() ?? "<unknown>";
     private static string DescribeNode(GuaNodeSnapshot? node) => node is null
         ? "<removed or not found>"
-        : $"visible={node.Visible}, enabled={node.Enabled}, text='{node.Text ?? "<unknown>"}', value='{node.Value ?? "<unknown>"}'";
+        : $"visible={node.Visible}, enabled={node.Enabled}, focused={node.Focused?.ToString() ?? "<unknown>"}, selected={node.Selected?.ToString() ?? "<unknown>"}, checked={node.Checked?.ToString() ?? "<unknown>"}, text='{node.Text ?? "<unknown>"}', value='{node.Value ?? "<unknown>"}'";
 
     private sealed record WaitSnapshot(ulong? SessionEpoch, ulong? FrameSequence, ulong? Revision, IReadOnlyList<GuaNodeSnapshot> Nodes);
 }

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -131,3 +131,13 @@ writes its initial tree and a deterministic node-id diff. Sensitive action
 values are redacted before the writer receives them. If capture fails, the
 original assertion delegate still determines the exception type and a secondary
 capture error is appended to its message.
+
+Protocol v2 operations have one-step sync and async completion APIs for focus,
+set value, set checked, select, scroll, and key press. They return the correlated
+`GuaActionEvent`; `GuaActionException` exposes rejection, host failure, timeout,
+or cancellation together with request/action/node/error and snapshot metadata.
+`GuaAssertions.PressKeyAsync(context, key)` targets the adapter's current focus.
+
+Queries can add `Within`, `ByValue`, `WhereFocused`, `WhereSelected`,
+`WhereChecked`, and `ByAction`. Corresponding async state waits re-fetch the
+latest UI tree on every poll instead of holding the first snapshot.

--- a/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using Gua.Core;
 using Gua.Testing.Godot;
+using Gua.Testing;
 using Gua.Testing.Visual;
 using NUnit.Framework;
 
@@ -109,6 +110,52 @@ public sealed class GodotVisualIntegrationTests
             Assert.That(Encoding.UTF8.GetString(File.ReadAllBytes(path)), Does.Not.Contain(Secret));
     }
 
+    [Test]
+    public async Task V2TestingApisOperateRealGodotControlsThroughTheBridge()
+    {
+        const string secret = "v2-sensitive-secret-marker";
+        using var host = StartGodot(diff: false, v2: true);
+        await host.WaitForScreenshotAsync(TimeSpan.FromSeconds(15));
+
+        var userName = GuaAssertions.GetById(host.Context, "v2-user-name");
+        var setValue = await userName.SetValueAsync("alice", timeout: TimeSpan.FromSeconds(5));
+        var focus = await userName.FocusAsync(timeout: TimeSpan.FromSeconds(5));
+        var key = await GuaAssertions.PressKeyAsync(host.Context, "Enter", timeout: TimeSpan.FromSeconds(5));
+        var select = await GuaAssertions.GetById(host.Context, "v2-provider").SelectAsync("google", timeout: TimeSpan.FromSeconds(5));
+        var check = GuaAssertions.GetById(host.Context, "v2-remember").SetCheckedAndWait(true, TimeSpan.FromSeconds(5));
+        var scroll = await GuaAssertions.GetById(host.Context, "v2-scroll").ScrollAsync(0, 50, timeout: TimeSpan.FromSeconds(5));
+        var sensitive = await GuaAssertions.GetById(host.Context, "v2-secret").SetValueAsync(secret, sensitive: true, timeout: TimeSpan.FromSeconds(5));
+
+        await userName.WaitForValueAsync("alice", TimeSpan.FromSeconds(5));
+        await userName.WaitUntilFocusedAsync(timeout: TimeSpan.FromSeconds(5));
+        await GuaAssertions.GetById(host.Context, "v2-remember").WaitUntilCheckedAsync(timeout: TimeSpan.FromSeconds(5));
+
+        var scoped = GuaAssertions.Query(host.Context).ByRole("textbox").Within("v2-form").ByValue("alice").WhereFocused().Get();
+        var selected = GuaAssertions.Query(host.Context).ByRole("combobox").ByValue("google").ByAction("select").Get();
+        var checkedNode = GuaAssertions.Query(host.Context).WhereChecked().Get();
+        var screenshot = host.SaveScreenshot(Path.Combine(_root, "attachments"), TestContext.CurrentContext.Test.Name);
+        TestContext.AddTestAttachment(screenshot.AbsolutePath, "Godot v2 fixture screenshot");
+
+        var status = host.GetContextStatus();
+        var reset = host.ResetContext(new GuaResetOptions(Strict: true));
+        Assert.Multiple(() =>
+        {
+            Assert.That(new[] { setValue, focus, key, select, check, scroll, sensitive }, Has.All.Property(nameof(GuaActionEvent.Succeeded)).True);
+            Assert.That(key.NodeId, Is.Empty);
+            Assert.That(sensitive.Value, Is.Empty);
+            Assert.That(scoped.Id, Is.EqualTo("v2-user-name"));
+            Assert.That(selected.Id, Is.EqualTo("v2-provider"));
+            Assert.That(checkedNode.Id, Is.EqualTo("v2-remember"));
+            Assert.That(host.Context.GetUiTreeJson(), Does.Not.Contain(secret));
+            Assert.That(host.Context.GetDiagnosticsJson(), Does.Not.Contain(secret));
+            Assert.That(screenshot.Width, Is.GreaterThan(0));
+            Assert.That(screenshot.Height, Is.GreaterThan(0));
+            Assert.That(Path.IsPathFullyQualified(screenshot.AbsolutePath), Is.True);
+            Assert.That(status.IsClean, Is.True);
+            Assert.That(reset.Result, Is.EqualTo(GuaResetResult.Succeeded));
+        });
+    }
+
     private static async Task<IReadOnlyList<GuaActionEvent>> WaitForActionEventsAsync(
         IGuaContext context, int count, TimeSpan timeout)
     {
@@ -123,7 +170,7 @@ public sealed class GodotVisualIntegrationTests
         return events;
     }
 
-    private static GodotSceneTestHost StartGodot(bool diff)
+    private static GodotSceneTestHost StartGodot(bool diff, bool v2 = false)
     {
         const int port = 18765;
         Environment.SetEnvironmentVariable("GUA_VISUAL_E2E", "1");
@@ -138,6 +185,12 @@ public sealed class GodotVisualIntegrationTests
             ConnectTimeout = TimeSpan.FromSeconds(15),
             RequestTimeout = TimeSpan.FromSeconds(10),
             SceneTimeout = TimeSpan.FromSeconds(15),
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                ["GUA_VISUAL_E2E"] = "1",
+                ["GUA_V2_E2E"] = v2 ? "1" : "0",
+                ["GUA_BRIDGE_PORT"] = port.ToString(),
+            },
             AdditionalArguments = ["--display-driver", "windows", "--rendering-method", "gl_compatibility", "--resolution", "1280x720", "--position", "0,0"],
         });
     }

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -13,6 +13,57 @@ namespace Gua.Selector.Tests;
 public sealed class SelectorParityTests
 {
     [Test]
+    public async Task V2LocatorAndActionCompletionPreserveUnrelatedEvents()
+    {
+        using var context = new GuaContext();
+        context.BeginFrame("form");
+        context.RegisterNode(new GuaNodeDescriptor("form", "panel", "Form", new GuaBounds(0, 0, 10, 10)));
+        context.RegisterNode(new GuaNodeDescriptor("name", "textbox", "Name", new GuaBounds(0, 0, 1, 1),
+            ParentId: "form", Text: "User", Value: "alice", Focused: true));
+        context.RegisterNode(new GuaNodeDescriptor("remember", "checkbox", "Remember", new GuaBounds(0, 1, 1, 1),
+            ParentId: "form", Checked: false));
+        context.EndFrame();
+
+        var located = GuaAssertions.Query(context).ByRole("textbox").Within("form").ByValue("alice").WhereFocused().ByAction("set_value").Get();
+        Assert.That(located.Id, Is.EqualTo("name"));
+        Assert.That(GuaAssertions.Query(context).WhereChecked(false).Get().Id, Is.EqualTo("remember"));
+
+        var completion = located.SetValueAsync("bob", timeout: TimeSpan.FromSeconds(2));
+        Assert.That(context.TryConsumeAction(GuaActionType.SetValue, "name", out var request), Is.True);
+        var otherId = located.Focus();
+        Assert.That(context.TryConsumeAction(GuaActionType.Focus, "name", out var other), Is.True);
+        Assert.That(context.EmitActionResult(new GuaActionEvent(otherId, GuaActionType.Focus, true, GuaActionError.None, "name", "", false)), Is.True);
+        Assert.That(context.EmitActionResult(new GuaActionEvent(request.RequestId, GuaActionType.SetValue, true, GuaActionError.None, "name", "bob", false)), Is.True);
+
+        var result = await completion;
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.RequestId, Is.EqualTo(request.RequestId));
+            Assert.That(result.Action, Is.EqualTo(GuaActionType.SetValue));
+            Assert.That(context.TryPollActionEvent(otherId, out var preserved), Is.True);
+            Assert.That(preserved.Action, Is.EqualTo(GuaActionType.Focus));
+        });
+    }
+
+    [Test]
+    public void TypedActionReportsRejectionDetails()
+    {
+        using var context = new GuaContext();
+        context.BeginFrame("form");
+        context.RegisterNode(new GuaNodeDescriptor("disabled", "textbox", "Disabled", new GuaBounds(0, 0, 1, 1), Enabled: false));
+        context.EndFrame();
+
+        var error = Assert.Throws<GuaActionException>(() =>
+            GuaAssertions.GetById(context, "disabled").SetValueAndWait("value"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(error!.Kind, Is.EqualTo(GuaActionFailureKind.Rejected));
+            Assert.That(error.Error, Is.EqualTo(GuaActionError.Disabled));
+            Assert.That(error.Message, Does.Contain("requestId=0").And.Contain("screen='form'").And.Contain("frameSequence="));
+        });
+    }
+
+    [Test]
     public void LocalAndRemoteContextsUseTheSameNativeSelectorEvaluator()
     {
         var port = ReservePort();

--- a/examples/godot-gdscript/scripts/main.gd
+++ b/examples/godot-gdscript/scripts/main.gd
@@ -12,11 +12,13 @@ var start_button: Button
 var settings_button: Button
 var loading_label: Label
 var visual_e2e := false
+var v2_e2e := false
 var visual_e2e_update_elapsed := 0.0
 
 
 func _ready() -> void:
 	visual_e2e = OS.get_environment("GUA_VISUAL_E2E") == "1"
+	v2_e2e = OS.get_environment("GUA_V2_E2E") == "1"
 	if OS.has_environment("GUA_BRIDGE_PORT"):
 		inspector_bridge_port = int(OS.get_environment("GUA_BRIDGE_PORT"))
 	_build_ui()
@@ -73,6 +75,8 @@ func _build_ui() -> void:
 
 	if visual_e2e:
 		_build_visual_e2e_controls()
+	if v2_e2e:
+		_build_v2_e2e_controls()
 
 
 func _build_visual_e2e_controls() -> void:
@@ -105,6 +109,76 @@ func _build_visual_e2e_controls() -> void:
 	select.position = Vector2(512, 568)
 	select.size = Vector2(256, 40)
 	add_child(select)
+
+
+func _build_v2_e2e_controls() -> void:
+	var form := VBoxContainer.new()
+	form.name = "V2Form"
+	form.set_meta("gua_id", "v2-form")
+	form.position = Vector2(32, 32)
+	form.size = Vector2(360, 620)
+	add_child(form)
+
+	var user_name := LineEdit.new()
+	user_name.name = "UserNameLine"
+	user_name.set_meta("gua_id", "v2-user-name")
+	user_name.placeholder_text = "User name"
+	form.add_child(user_name)
+
+	var secret := LineEdit.new()
+	secret.name = "SecretLine"
+	secret.set_meta("gua_id", "v2-secret")
+	secret.set_meta("gua_sensitive", true)
+	secret.secret = true
+	form.add_child(secret)
+
+	var notes := TextEdit.new()
+	notes.name = "NotesText"
+	notes.set_meta("gua_id", "v2-notes")
+	notes.custom_minimum_size = Vector2(340, 80)
+	form.add_child(notes)
+
+	var provider := OptionButton.new()
+	provider.name = "ProviderOption"
+	provider.set_meta("gua_id", "v2-provider")
+	provider.add_item("local")
+	provider.add_item("google")
+	form.add_child(provider)
+
+	var remember := CheckBox.new()
+	remember.name = "RememberMe"
+	remember.set_meta("gua_id", "v2-remember")
+	remember.text = "Remember me"
+	form.add_child(remember)
+
+	var servers := ItemList.new()
+	servers.name = "ServerList"
+	servers.set_meta("gua_id", "v2-servers")
+	servers.add_item("Tokyo")
+	servers.add_item("Osaka")
+	servers.custom_minimum_size = Vector2(340, 80)
+	form.add_child(servers)
+
+	var tabs := TabContainer.new()
+	tabs.name = "SettingsTabs"
+	tabs.set_meta("gua_id", "v2-tabs")
+	tabs.custom_minimum_size = Vector2(340, 90)
+	var general := Control.new()
+	general.name = "General"
+	tabs.add_child(general)
+	var advanced := Control.new()
+	advanced.name = "Advanced"
+	tabs.add_child(advanced)
+	form.add_child(tabs)
+
+	var scroll := ScrollContainer.new()
+	scroll.name = "ManagementContent"
+	scroll.set_meta("gua_id", "v2-scroll")
+	scroll.custom_minimum_size = Vector2(340, 100)
+	var content := Control.new()
+	content.custom_minimum_size = Vector2(700, 700)
+	scroll.add_child(content)
+	form.add_child(scroll)
 
 
 func _capture_visual_e2e() -> void:

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -264,6 +264,11 @@ boundaries. External commands such as `click_node` are requests first; adapters
 consume them and emit events only after the corresponding host UI action has
 been applied.
 
+Testing clients may combine enqueue and request-id-specific polling in one
+convenience operation. Such helpers must not consume unrelated results or
+ordinary events, must preserve sensitive-value redaction, and should report the
+final screen/frame/revision when completion fails.
+
 Initial event types:
 
 - `click`


### PR DESCRIPTION
## 対応 Issue

Closes #38

## 実装内容

- focus / set value / set checked / select / scroll / press key を、enqueue から requestId 対応の action result まで待つ同期・非同期 API として追加
- node-less `press_key`、既定/個別 timeout、poll interval、CancellationToken、型付き結果と rejection / failure / timeout / cancellation 例外を追加
- requestId 指定 poll を利用し、他の action result / 通常 event を消費しないことをテスト
- `Within` / text / value / focused / selected / checked / action / visible / enabled のv2 locatorと、最新treeを再取得する同期・非同期wait/状態assertionを追加
- `GodotSceneTestHost` にtyped screenshot取得、PNG保存、衝突しない絶対パス、typed error、status/reset、opt-in起動resetを追加
- Godot実Control fixture（LineEdit / TextEdit / OptionButton / ItemList / TabContainer / CheckBox / ScrollContainer）と実renderer/WebSocket統合テストを追加
- protocol testing-client規約とGua.Testing/Godot READMEの実用例・sensitive/screenshot注意事項を更新

## Architecture判断

既存のprotocol v2、C ABI、`IGuaContext`、WebSocket bridge、Godot adapter-owned reflectionをそのまま正とし、runtimeを二重実装していません。操作完了は既存requestId指定poll、v2状態filterはnative selectorの結果と最新semantic snapshotを組み合わせる.NET testing層のadditive拡張です。C ABI変更はありません。

## 受け入れ条件対応

- 6操作のsync/async型付きAPI、node-less key、requestId相関: 対応
- rejection / host failure / timeout / cancelled、詳細診断: 対応
- sensitive非露出: unit + 実Godot bridgeでtree/result/diagnosticsを検証
- hierarchy/state/action locatorと最新snapshot wait: 対応
- typed screenshot保存、並列衝突回避、absolute path: 対応
- epoch-safe status/reset、opt-in startup reset: 対応
- 実Godot Control / bridge integration: 対応
- protocol/既存C++/.NET/WebSocket互換: 関連build/testで確認

## 検証

- `cmake --preset windows-msvc-debug` 成功
- `cmake --build --preset windows-msvc-debug` 成功
- `ctest --output-on-failure -C Debug` 成功（2/2）
- `dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release` 成功、警告0
- `dotnet test bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj --configuration Release` 成功（4/4）
- `dotnet test bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/Gua.Godot.Visual.Integration.Tests.csproj --configuration Release` 通常実行はopt-in 2件skip、失敗0
- `GUA_GODOT_REAL_RENDERER_TEST=1` で同integration tests成功（2/2、Godot 4.7 Windows real renderer）
- Godot 4.7 headless `gua_smoke.gd` 成功
- `bun run check` 成功（3 workspaces）
- `git diff --check` 成功

## 未対応事項

Issue範囲内の未対応はありません。C ABI/protocol actionやbridgeを再設計せず、Inspector/MCP、画像マスキング、他engine adapter、公開フローは変更していません。スクリーンショット内に描画された秘密情報の保存・公開責任は呼び出し側にあることをREADMEへ明記しています。