### PR TITLE
#40 UIフレーム公開とGodotテストAPIを安定化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ host.Click("CenterPanel/Content/ButtonBox/StartButton", nextScene: "game/scenes/
 GuaAssertions.GetByRole(host.Context, "button", "Create").ToBeVisible();
 ```
 
+For v0.2.0 and later, repository-local `GuaLiveAssertions` helpers can migrate
+directly to `WaitForId` / `WaitForText` / `WaitForVisible` / `WaitForEnabled`,
+locator `WaitForCount*`, and correlated node actions such as `ClickAsync`.
+Wait-returned expectations retain the successful completed-frame snapshot;
+use `Refresh()` or `WaitUntil*` when a later frame is required. Repository
+`GodotHostFactory` wrappers should keep only game-specific process and fixture
+policy while `GodotSceneTestHost` owns executable/project discovery, automatic
+loopback ports, rendered/headless startup, bridge diagnostics, and reset policy.
+All APIs are additive over the existing C ABI and WebSocket protocol.
+
 Want to try that in GitHub Actions without wiring every setup step by hand?
 [`link1345/gua-tester`](https://github.com/link1345/gua-tester) provides
 reusable Actions for Godot GDScript projects. It downloads Godot on the runner,

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Text;
+using System.Net;
+using System.Net.Sockets;
 using Gua.Core;
 using Gua.Testing;
 
@@ -9,13 +11,15 @@ public sealed class GodotSceneTestHost : IDisposable
 {
     private readonly GodotSceneTestHostOptions _options;
     private readonly Process _process;
+    private readonly string _bridgeUrl;
     private bool _disposed;
 
-    private GodotSceneTestHost(Process process, GuaRemoteContext context, GodotSceneTestHostOptions options)
+    private GodotSceneTestHost(Process process, GuaRemoteContext context, GodotSceneTestHostOptions options, string bridgeUrl)
     {
         _process = process;
         Context = context;
         _options = options;
+        _bridgeUrl = bridgeUrl;
     }
 
     public IGuaContext Context { get; }
@@ -35,7 +39,7 @@ public sealed class GodotSceneTestHost : IDisposable
             {
                 ["host"] = "Godot",
                 ["processId"] = ProcessId.ToString(),
-                ["bridgeUrl"] = _options.BridgeUrl,
+                ["bridgeUrl"] = _bridgeUrl,
                 ["projectPath"] = _options.ProjectPath ?? string.Empty,
             },
         };
@@ -46,9 +50,11 @@ public sealed class GodotSceneTestHost : IDisposable
         options ??= GodotSceneTestHostOptions.Default;
         var projectPath = ResolveProjectPath(scenePath, options.ProjectPath);
         var godotPath = ResolveGodotExecutable(options.GodotExecutablePath);
-        var process = StartGodot(godotPath, projectPath, ToGodotScenePath(scenePath, projectPath), options);
+        var godotScenePath = ToGodotScenePath(scenePath, projectPath);
+        var bridgeUrl = options.UseAvailableBridgePort ? $"ws://127.0.0.1:{ReserveLoopbackPort()}" : options.BridgeUrl;
+        var process = StartGodot(godotPath, projectPath, godotScenePath, bridgeUrl, options);
         var output = new ProcessOutput(process);
-        var context = new GuaRemoteContext(options.BridgeUrl, options.RequestTimeout);
+        var context = new GuaRemoteContext(bridgeUrl, options.RequestTimeout);
 
         try
         {
@@ -68,16 +74,22 @@ public sealed class GodotSceneTestHost : IDisposable
                 if (!clean.IsClean)
                     throw new InvalidOperationException($"Godot startup reset left queued work: pending={clean.PendingRequestCount}, inFlight={clean.InFlightRequestCount}, events={clean.UnconsumedEventCount}.");
             }
-            return new GodotSceneTestHost(process, context, options);
+            return new GodotSceneTestHost(process, context, options, bridgeUrl);
         }
         catch (Exception error)
         {
             KillProcess(process);
             context.Dispose();
             throw new InvalidOperationException(
-                $"Failed to connect to the Gua bridge at {options.BridgeUrl}. Godot output:\n{output.Read()}",
+                $"Failed to start Godot scene test host. executable='{godotPath}', project='{projectPath}', scene='{godotScenePath}', bridge='{bridgeUrl}'. stdout/stderr:\n{output.Read()}",
                 error);
         }
+    }
+
+    public static GodotSceneTestHost LoadRendered(string scenePath, GodotSceneTestHostOptions? options = null)
+    {
+        options ??= GodotSceneTestHostOptions.Default;
+        return Load(scenePath, CloneWithHeadless(options, false));
     }
 
     public void Click(string nodeId, string? nextScene = null, TimeSpan? timeout = null)
@@ -158,12 +170,27 @@ public sealed class GodotSceneTestHost : IDisposable
             return;
         }
 
+        Exception? teardownError = null;
+        try
+        {
+            if (_options.TeardownReset is { } resetOptions)
+            {
+                var report = ResetContext(resetOptions);
+                if (report.Result != GuaResetResult.Succeeded)
+                    throw new InvalidOperationException($"Godot teardown reset failed: {report.Result}; pending={report.PendingRequestCount}, inFlight={report.InFlightRequestCount}, events={report.UnconsumedEventCount}.");
+            }
+        }
+        catch (Exception error)
+        {
+            teardownError = error;
+        }
         _disposed = true;
         ((IDisposable)Context).Dispose();
         if (_options.KillProcessOnDispose)
         {
             KillProcess(_process);
         }
+        if (teardownError is not null) throw teardownError;
     }
 
     private void ThrowIfDisposed()
@@ -175,6 +202,7 @@ public sealed class GodotSceneTestHost : IDisposable
         string godotPath,
         string projectPath,
         string scenePath,
+        string bridgeUrl,
         GodotSceneTestHostOptions options)
     {
         var arguments = new List<string>();
@@ -207,10 +235,36 @@ public sealed class GodotSceneTestHost : IDisposable
         {
             startInfo.Environment[name] = value;
         }
+        startInfo.Environment["GUA_BRIDGE_PORT"] = new Uri(bridgeUrl).Port.ToString();
 
         return Process.Start(startInfo)
             ?? throw new InvalidOperationException($"Failed to start Godot executable: {godotPath}");
     }
+
+    private static int ReserveLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+
+    private static GodotSceneTestHostOptions CloneWithHeadless(GodotSceneTestHostOptions source, bool headless) => new()
+    {
+        GodotExecutablePath = source.GodotExecutablePath,
+        ProjectPath = source.ProjectPath,
+        BridgeUrl = source.BridgeUrl,
+        UseAvailableBridgePort = source.UseAvailableBridgePort,
+        Headless = headless,
+        KillProcessOnDispose = source.KillProcessOnDispose,
+        ConnectTimeout = source.ConnectTimeout,
+        RequestTimeout = source.RequestTimeout,
+        SceneTimeout = source.SceneTimeout,
+        AdditionalArguments = source.AdditionalArguments,
+        EnvironmentVariables = source.EnvironmentVariables,
+        StartupReset = source.StartupReset,
+        TeardownReset = source.TeardownReset,
+    };
 
     private static string ResolveGodotExecutable(string? configuredPath)
     {

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHostOptions.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHostOptions.cs
@@ -12,6 +12,8 @@ public sealed class GodotSceneTestHostOptions
 
     public string BridgeUrl { get; init; } = "ws://127.0.0.1:8765";
 
+    public bool UseAvailableBridgePort { get; init; }
+
     public bool Headless { get; init; } = true;
 
     public bool KillProcessOnDispose { get; init; } = true;
@@ -27,4 +29,6 @@ public sealed class GodotSceneTestHostOptions
     public IReadOnlyDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();
 
     public GuaResetOptions? StartupReset { get; init; }
+
+    public GuaResetOptions? TeardownReset { get; init; }
 }

--- a/bindings/dotnet/src/Gua.Testing.Godot/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Godot/README.md
@@ -26,6 +26,28 @@ Set `GODOT_EXECUTABLE` or pass `GodotSceneTestHostOptions.GodotExecutablePath`
 when Godot is not on `PATH`. The running game must start a Gua bridge, normally
 at `ws://127.0.0.1:8765`.
 
+For parallel tests, set `UseAvailableBridgePort = true`; the host reserves a
+loopback port, connects to it, and passes it to the child as `GUA_BRIDGE_PORT`.
+`EnvironmentVariables` adds per-test child settings. `LoadRendered(...)` is the
+rendering-enabled shortcut for `Headless = false`. Optional `StartupReset` and
+`TeardownReset` enforce session isolation; a strict teardown reports dirty
+requests/events instead of silently discarding them.
+
+```csharp
+using var host = GodotSceneTestHost.LoadRendered(scene, new()
+{
+    UseAvailableBridgePort = true,
+    EnvironmentVariables = new Dictionary<string, string> { ["GUA_TEST_CASE"] = "servers" },
+    StartupReset = new GuaResetOptions(Strict: true),
+    TeardownReset = new GuaResetOptions(Strict: true),
+});
+```
+
+Repository-specific factories should retain only game concerns such as locating
+API/database fixtures, choosing repository timeouts, and mapping game-relative
+scene names. Executable discovery, `project.godot` discovery, bridge ports,
+process output, rendering mode, and Gua reset policy belong to this package.
+
 When `ProjectPath` is omitted, the host walks up from the scene file to the
 nearest `project.godot` and uses that directory as Godot's `--path`. Pass
 `ProjectPath` explicitly when loading a `res://` scene path.

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -263,6 +263,7 @@ public sealed class GuaNodeExpectation
     private readonly IGuaContext _context;
     private readonly string _id;
     private readonly string _description;
+    private GuaNodeSnapshot? _retainedSnapshot;
 
     internal GuaNodeExpectation(IGuaContext context, string id, string description)
     {
@@ -275,13 +276,20 @@ public sealed class GuaNodeExpectation
 
     public GuaNodeSnapshot Snapshot => GetSnapshotOrFail();
 
+    /// <summary>Discards the retained wait snapshot and captures the node from the latest published frame.</summary>
+    public GuaNodeExpectation Refresh()
+    {
+        _retainedSnapshot = GuaAssertions.TryGetSnapshot(_context, _id);
+        if (_retainedSnapshot is null)
+        {
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to exist after refresh. {GuaAssertions.DescribeTree(_context)}");
+        }
+        return this;
+    }
+
     public GuaNodeExpectation ToExist()
     {
-        if (GuaAssertions.TryGetSnapshot(_context, _id) is null)
-        {
-            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to exist. {GuaAssertions.DescribeTree(_context)}");
-        }
-
+        _ = GetSnapshotOrFail();
         return this;
     }
 
@@ -452,6 +460,7 @@ public sealed class GuaNodeExpectation
         Enqueue(new GuaActionRequest(GuaActionType.PressKey, _id, Key: key, Modifiers: modifiers), "press_key");
 
     public GuaActionEvent FocusAndWait(TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.Focus, _id), timeout, pollInterval);
+    public GuaActionEvent ClickAndWait(TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.Click, _id), timeout, pollInterval);
     public GuaActionEvent SetValueAndWait(string value, bool sensitive = false, TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.SetValue, _id, Value: value, Sensitive: sensitive), timeout, pollInterval);
     public GuaActionEvent SetCheckedAndWait(bool value, TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.SetChecked, _id, BoolValue: value), timeout, pollInterval);
     public GuaActionEvent SelectAndWait(string value, TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.Select, _id, Value: value), timeout, pollInterval);
@@ -459,6 +468,7 @@ public sealed class GuaNodeExpectation
     public GuaActionEvent PressKeyAndWait(string key, uint modifiers = 0, TimeSpan? timeout = null, TimeSpan? pollInterval = null) => Complete(new(GuaActionType.PressKey, _id, Key: key, Modifiers: modifiers), timeout, pollInterval);
 
     public Task<GuaActionEvent> FocusAsync(TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.Focus, _id), timeout, pollInterval, cancellationToken);
+    public Task<GuaActionEvent> ClickAsync(TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.Click, _id), timeout, pollInterval, cancellationToken);
     public Task<GuaActionEvent> SetValueAsync(string value, bool sensitive = false, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.SetValue, _id, Value: value, Sensitive: sensitive), timeout, pollInterval, cancellationToken);
     public Task<GuaActionEvent> SetCheckedAsync(bool value, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.SetChecked, _id, BoolValue: value), timeout, pollInterval, cancellationToken);
     public Task<GuaActionEvent> SelectAsync(string value, TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default) => CompleteAsync(new(GuaActionType.Select, _id, Value: value), timeout, pollInterval, cancellationToken);
@@ -545,13 +555,17 @@ public sealed class GuaNodeExpectation
 
     internal GuaNodeExpectation RequireExistingSnapshot()
     {
-        ToExist();
+        _retainedSnapshot = GuaAssertions.TryGetSnapshot(_context, _id);
+        if (_retainedSnapshot is null)
+        {
+            GuaAssertions.Fail(_context, $"Expected Gua node {_description} to exist. {GuaAssertions.DescribeTree(_context)}");
+        }
         return this;
     }
 
     private GuaNodeSnapshot GetSnapshotOrFail()
     {
-        var snapshot = GuaAssertions.TryGetSnapshot(_context, _id);
+        var snapshot = _retainedSnapshot ?? GuaAssertions.TryGetSnapshot(_context, _id);
         if (snapshot is null)
         {
             GuaAssertions.Fail(_context, $"Expected Gua node {_description} to exist. {GuaAssertions.DescribeTree(_context)}");

--- a/bindings/dotnet/src/Gua.Testing/GuaLocatorQuery.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaLocatorQuery.cs
@@ -1,5 +1,6 @@
 using Gua.Core;
 using System.Text.Json;
+using System.Diagnostics;
 
 namespace Gua.Testing;
 
@@ -68,6 +69,60 @@ public sealed record GuaLocatorQuery
         if (actual != expected)
             GuaAssertions.Fail(_context, $"Expected selector {Describe()} to match {expected} nodes, but matched {actual}.");
         return this;
+    }
+
+    public GuaLocatorQuery WaitForCount(int expected, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForCount(count => count == expected, $"exactly {expected}", timeout, pollInterval);
+
+    public GuaLocatorQuery WaitForMinimumCount(int minimum, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForCount(count => count >= minimum, $"at least {minimum}", timeout, pollInterval);
+
+    public GuaLocatorQuery WaitForCount(
+        Func<int, bool> condition, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
+        WaitForCount(condition, "the requested count condition", timeout, pollInterval);
+
+    public async Task<GuaLocatorQuery> WaitForCountAsync(
+        int expected, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        await WaitForCountAsync(count => count == expected, $"exactly {expected}", timeout, pollInterval, cancellationToken).ConfigureAwait(false);
+
+    public async Task<GuaLocatorQuery> WaitForMinimumCountAsync(
+        int minimum, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        await WaitForCountAsync(count => count >= minimum, $"at least {minimum}", timeout, pollInterval, cancellationToken).ConfigureAwait(false);
+
+    public Task<GuaLocatorQuery> WaitForCountAsync(
+        Func<int, bool> condition, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default) =>
+        WaitForCountAsync(condition, "the requested count condition", timeout, pollInterval, cancellationToken);
+
+    private GuaLocatorQuery WaitForCount(
+        Func<int, bool> condition, string expected, TimeSpan? timeout, TimeSpan? pollInterval) =>
+        WaitForCountAsync(condition, expected, timeout, pollInterval).GetAwaiter().GetResult();
+
+    private async Task<GuaLocatorQuery> WaitForCountAsync(
+        Func<int, bool> condition, string expected, TimeSpan? timeout, TimeSpan? pollInterval,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+        var limit = timeout ?? TimeSpan.FromSeconds(1);
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(10);
+        if (limit < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+        if (interval <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(pollInterval));
+        var stopwatch = Stopwatch.StartNew();
+        var lastCount = 0;
+        do
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lastCount = Execute().Matches.Count;
+            if (condition(lastCount)) return this;
+            if (stopwatch.Elapsed >= limit) break;
+            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+        } while (true);
+
+        GuaAssertions.Fail(_context,
+            $"Timed out after {limit:g} waiting for selector {Describe()} to match {expected}; last count={lastCount}. {GuaAssertions.DescribeSnapshot(_context)}");
+        throw new UnreachableException();
     }
 
     private GuaQueryResult Execute()

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -141,3 +141,21 @@ or cancellation together with request/action/node/error and snapshot metadata.
 Queries can add `Within`, `ByValue`, `WhereFocused`, `WhereSelected`,
 `WhereChecked`, and `ByAction`. Corresponding async state waits re-fetch the
 latest UI tree on every poll instead of holding the first snapshot.
+Wait-returned expectations retain the exact successful node snapshot, including
+`sessionEpoch`, `frameSequence`, and `revision`, so chained assertions evaluate
+one completed frame. Call `Refresh()` or a `WaitUntil*` method to opt into a
+newer published frame. A retained snapshot from an older session epoch remains
+readable evidence but must be refreshed before making current-session decisions.
+
+Locator counts can wait on every selector dimension, including scope, state,
+value, and action:
+
+```csharp
+await GuaAssertions.Query(context).ByRole("listitem").Within("ServerList")
+    .WaitForCountAsync(count => count >= 3, timeout, pollInterval, cancellationToken);
+GuaAssertions.Query(context).ByAction("scroll").WaitForCount(1, timeout, pollInterval);
+```
+
+Node expectations expose correlated sync/async action completion for `click`,
+`focus`, `set_value`, `set_checked`, `select`, `scroll`, and `press_key`. These
+helpers wait for the same `requestId`; unrelated events remain queued.

--- a/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
@@ -156,6 +156,30 @@ public sealed class GodotVisualIntegrationTests
         });
     }
 
+    [Test]
+    public async Task ParallelHostsUseDistinctAutomaticPortsAndExposeOnlyCompleteTrees()
+    {
+        using var first = StartGodotAutoPort();
+        using var second = StartGodotAutoPort();
+        await Task.WhenAll(
+            first.WaitForScreenshotAsync(TimeSpan.FromSeconds(15)),
+            second.WaitForScreenshotAsync(TimeSpan.FromSeconds(15)));
+
+        var observedCounts = new List<int>();
+        for (var sample = 0; sample < 100; sample++)
+        {
+            using var document = JsonDocument.Parse(first.Context.GetUiTreeJson());
+            observedCounts.Add(document.RootElement.GetProperty("nodes").GetArrayLength());
+            await Task.Delay(2);
+        }
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.ProcessId, Is.Not.EqualTo(second.ProcessId));
+            Assert.That(observedCounts, Has.All.EqualTo(observedCounts[0]));
+            Assert.That(observedCounts[0], Is.GreaterThan(10));
+        });
+    }
+
     private static async Task<IReadOnlyList<GuaActionEvent>> WaitForActionEventsAsync(
         IGuaContext context, int count, TimeSpan timeout)
     {
@@ -192,6 +216,27 @@ public sealed class GodotVisualIntegrationTests
                 ["GUA_BRIDGE_PORT"] = port.ToString(),
             },
             AdditionalArguments = ["--display-driver", "windows", "--rendering-method", "gl_compatibility", "--resolution", "1280x720", "--position", "0,0"],
+        });
+    }
+
+    private static GodotSceneTestHost StartGodotAutoPort()
+    {
+        return GodotSceneTestHost.LoadRendered("res://Main.tscn", new GodotSceneTestHostOptions
+        {
+            GodotExecutablePath = Environment.GetEnvironmentVariable("GODOT_EXECUTABLE"),
+            ProjectPath = Path.Combine(FindRepositoryRoot(), "examples", "godot-gdscript"),
+            UseAvailableBridgePort = true,
+            ConnectTimeout = TimeSpan.FromSeconds(15),
+            RequestTimeout = TimeSpan.FromSeconds(10),
+            SceneTimeout = TimeSpan.FromSeconds(15),
+            StartupReset = new GuaResetOptions(Strict: true),
+            TeardownReset = new GuaResetOptions(Strict: true),
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                ["GUA_VISUAL_E2E"] = "1",
+                ["GUA_V2_E2E"] = "1",
+            },
+            AdditionalArguments = ["--display-driver", "windows", "--rendering-method", "gl_compatibility", "--resolution", "1280x720"],
         });
     }
 

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -13,6 +13,32 @@ namespace Gua.Selector.Tests;
 public sealed class SelectorParityTests
 {
     [Test]
+    public async Task WaitExpectationRetainsSnapshotAndCountWaitPollsLatestFrames()
+    {
+        using var context = new GuaContext();
+        context.BeginFrame("first");
+        context.RegisterNode(new GuaNodeDescriptor("item-1", "listitem", "One", new GuaBounds(0, 0, 1, 1)));
+        context.EndFrame();
+
+        var retained = GuaAssertions.WaitForId(context, "item-1");
+        var firstFrame = retained.Snapshot.FrameSequence;
+        Assert.That(firstFrame, Is.Not.Null);
+        context.BeginFrame("second");
+        context.RegisterNode(new GuaNodeDescriptor("item-1", "listitem", "One", new GuaBounds(0, 0, 1, 1), Enabled: false));
+        context.RegisterNode(new GuaNodeDescriptor("item-2", "listitem", "Two", new GuaBounds(0, 1, 1, 1)));
+        context.EndFrame();
+
+        retained.ToExist().ToBeEnabled();
+        Assert.That(retained.Snapshot.FrameSequence, Is.EqualTo(firstFrame));
+        retained.Refresh().ToBeDisabled();
+        Assert.That(retained.Snapshot.FrameSequence, Is.GreaterThan(firstFrame!.Value));
+
+        await GuaAssertions.Query(context).ByRole("listitem")
+            .WaitForCountAsync(count => count >= 2, TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(5));
+        GuaAssertions.Query(context).ByRole("missing").WaitForCount(0, TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
     public async Task V2LocatorAndActionCompletionPreserveUnrelatedEvents()
     {
         using var context = new GuaContext();

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -270,6 +270,10 @@ struct gua_context_t {
     mutable std::mutex mutex;
     std::string screen = "unknown";
     std::vector<Node> nodes;
+    std::string staging_screen = "unknown";
+    std::vector<Node> staging_nodes;
+    bool frame_in_progress = false;
+    bool staging_valid = true;
     std::deque<ActionRequest> action_requests;
     std::deque<ActionRequest> consumed_requests;
     std::deque<Event> events;
@@ -303,12 +307,12 @@ int copy_json_string(const std::string& json, char* out_json, int out_json_size)
     return required_size;
 }
 
-std::string build_semantic_snapshot_json(const gua_context_t& ctx)
+std::string build_semantic_snapshot_json(const std::string& screen, const std::vector<Node>& nodes)
 {
-    std::string json = "{\"screen\":\"" + escape_json(ctx.screen) + "\",\"nodes\":[";
+    std::string json = "{\"screen\":\"" + escape_json(screen) + "\",\"nodes\":[";
 
-    for (std::size_t i = 0; i < ctx.nodes.size(); ++i) {
-        const Node& node = ctx.nodes[i];
+    for (std::size_t i = 0; i < nodes.size(); ++i) {
+        const Node& node = nodes[i];
         if (i > 0) {
             json += ",";
         }
@@ -377,6 +381,11 @@ std::string build_semantic_snapshot_json(const gua_context_t& ctx)
 
     json += "]}";
     return json;
+}
+
+std::string build_semantic_snapshot_json(const gua_context_t& ctx)
+{
+    return build_semantic_snapshot_json(ctx.screen, ctx.nodes);
 }
 
 std::string build_ui_tree_json(const gua_context_t& ctx)
@@ -522,8 +531,10 @@ extern "C" void gua_begin_frame(gua_context_t* ctx, const char* screen)
     }
 
     const std::lock_guard lock(ctx->mutex);
-    ctx->screen = screen != nullptr ? screen : "unknown";
-    ctx->nodes.clear();
+    ctx->staging_screen = screen != nullptr ? screen : "unknown";
+    ctx->staging_nodes.clear();
+    ctx->frame_in_progress = true;
+    ctx->staging_valid = true;
 }
 
 extern "C" void gua_end_frame(gua_context_t* ctx)
@@ -533,7 +544,17 @@ extern "C" void gua_end_frame(gua_context_t* ctx)
     }
 
     const std::lock_guard lock(ctx->mutex);
-    const std::string semantic_snapshot = build_semantic_snapshot_json(*ctx);
+    if (!ctx->frame_in_progress || !ctx->staging_valid) {
+        ctx->staging_nodes.clear();
+        ctx->frame_in_progress = false;
+        ctx->staging_valid = true;
+        return;
+    }
+    const std::string semantic_snapshot = build_semantic_snapshot_json(ctx->staging_screen, ctx->staging_nodes);
+    ctx->screen.swap(ctx->staging_screen);
+    ctx->nodes.swap(ctx->staging_nodes);
+    ctx->staging_nodes.clear();
+    ctx->frame_in_progress = false;
     ++ctx->frame_sequence;
     if (semantic_snapshot != ctx->previous_semantic_snapshot) {
         ++ctx->revision;
@@ -551,12 +572,16 @@ extern "C" void gua_register_node(
     int visible,
     int enabled)
 {
-    if (ctx == nullptr || id == nullptr || role == nullptr) {
+    if (ctx == nullptr) {
         return;
     }
 
     const std::lock_guard lock(ctx->mutex);
-    ctx->nodes.push_back(Node {
+    if (!ctx->frame_in_progress || id == nullptr || role == nullptr) {
+        ctx->staging_valid = false;
+        return;
+    }
+    ctx->staging_nodes.push_back(Node {
         id,
         role,
         label != nullptr ? label : "",
@@ -568,13 +593,17 @@ extern "C" void gua_register_node(
 
 extern "C" int gua_register_node_v2(gua_context_t* ctx, const gua_node_descriptor_v2_t* descriptor)
 {
-    if (ctx == nullptr || descriptor == nullptr || descriptor->struct_size < sizeof(gua_node_descriptor_v2_t) ||
-        descriptor->id == nullptr || descriptor->role == nullptr) {
+    if (ctx == nullptr) {
         return 0;
     }
 
     const std::lock_guard lock(ctx->mutex);
-    ctx->nodes.push_back(Node {
+    if (!ctx->frame_in_progress || descriptor == nullptr || descriptor->struct_size < sizeof(gua_node_descriptor_v2_t) ||
+        descriptor->id == nullptr || descriptor->role == nullptr) {
+        ctx->staging_valid = false;
+        return 0;
+    }
+    ctx->staging_nodes.push_back(Node {
         descriptor->id,
         descriptor->role,
         descriptor->label != nullptr ? descriptor->label : "",
@@ -1095,6 +1124,10 @@ extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* 
     if ((options->flags & GUA_RESET_NODES) != 0U) {
         ctx->screen = "unknown";
         ctx->nodes.clear();
+        ctx->staging_screen = "unknown";
+        ctx->staging_nodes.clear();
+        ctx->frame_in_progress = false;
+        ctx->staging_valid = true;
     }
     if ((options->flags & GUA_RESET_REQUESTS) != 0U) {
         ctx->action_requests.clear();

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -4,6 +4,9 @@
 #include <cstring>
 #include <string>
 #include <cstdint>
+#include <atomic>
+#include <thread>
+#include <vector>
 
 namespace {
 
@@ -36,6 +39,34 @@ int main()
 {
     gua_context_t* context = gua_create_context();
     assert(context != nullptr);
+
+    // A frame is private until end_frame atomically publishes it.
+    gua_context_t* atomic_context = gua_create_context();
+    gua_begin_frame(atomic_context, "initial-staging");
+    gua_register_node(atomic_context, "private", "button", "Private", { 0, 0, 1, 1 }, 1, 1);
+    const std::string before_first_publish = gua_get_ui_tree_json(atomic_context);
+    assert(before_first_publish.find("\"screen\":\"unknown\"") != std::string::npos);
+    assert(before_first_publish.find("private") == std::string::npos);
+    gua_end_frame(atomic_context);
+
+    gua_begin_frame(atomic_context, "second-staging");
+    gua_register_node(atomic_context, "partial", "button", "Partial", { 0, 0, 1, 1 }, 1, 1);
+    const std::string during_second_frame = gua_get_ui_tree_json(atomic_context);
+    assert(during_second_frame.find("initial-staging") != std::string::npos);
+    assert(during_second_frame.find("partial") == std::string::npos);
+    const gua_selector_v1_t private_selector { sizeof(gua_selector_v1_t), "private" };
+    char query_json[512] {};
+    gua_query_nodes_json(atomic_context, &private_selector, query_json, sizeof(query_json));
+    assert(std::string(query_json).find("private") != std::string::npos);
+    assert(std::string(gua_get_diagnostics_json(atomic_context)).find("initial-staging") != std::string::npos);
+    const gua_action_request_descriptor_t published_click { sizeof(gua_action_request_descriptor_t), GUA_ACTION_CLICK, "private" };
+    const gua_action_request_descriptor_t staging_click { sizeof(gua_action_request_descriptor_t), GUA_ACTION_CLICK, "partial" };
+    assert(gua_enqueue_action(atomic_context, &published_click, nullptr) == GUA_ACTION_ACCEPTED);
+    assert(gua_enqueue_action(atomic_context, &staging_click, nullptr) == GUA_ACTION_ERROR_NODE_NOT_FOUND);
+    gua_register_node(atomic_context, nullptr, "button", "Invalid", { 0, 0, 1, 1 }, 1, 1);
+    gua_end_frame(atomic_context);
+    assert(std::string(gua_get_ui_tree_json(atomic_context)) == during_second_frame);
+    gua_destroy_context(atomic_context);
 
     gua_begin_frame(context, "settings");
     register_checkbox(context, false);
@@ -229,6 +260,41 @@ int main()
     assert(preserved_event.action == GUA_ACTION_FOCUS);
 
     gua_destroy_context(other);
+
+    // Readers may observe the old or new complete frame, never a partial node count.
+    gua_context_t* concurrent = gua_create_context();
+    gua_begin_frame(concurrent, "stress");
+    for (int i = 0; i < 8; ++i) {
+        const std::string id = "old-" + std::to_string(i);
+        gua_register_node(concurrent, id.c_str(), "text", id.c_str(), { 0, 0, 1, 1 }, 1, 1);
+    }
+    gua_end_frame(concurrent);
+    std::atomic<bool> stop { false };
+    std::atomic<bool> invalid_count { false };
+    std::vector<std::thread> readers;
+    for (int reader = 0; reader < 4; ++reader) {
+        readers.emplace_back([&] {
+            while (!stop.load()) {
+                gua_context_status_t concurrent_status { sizeof(gua_context_status_t) };
+                assert(gua_get_context_status(concurrent, &concurrent_status) == 1);
+                if (concurrent_status.node_count != 8 && concurrent_status.node_count != 64) invalid_count = true;
+            }
+        });
+    }
+    for (int frame = 0; frame < 100; ++frame) {
+        const int count = (frame % 2 == 0) ? 64 : 8;
+        gua_begin_frame(concurrent, "stress");
+        for (int i = 0; i < count; ++i) {
+            const std::string id = "node-" + std::to_string(i);
+            gua_register_node(concurrent, id.c_str(), "text", id.c_str(), { 0, 0, 1, 1 }, 1, 1);
+            if ((i % 8) == 0) std::this_thread::yield();
+        }
+        gua_end_frame(concurrent);
+    }
+    stop = true;
+    for (auto& reader : readers) reader.join();
+    assert(!invalid_count.load());
+    gua_destroy_context(concurrent);
 
     gua_destroy_context(context);
     return 0;

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -29,6 +29,14 @@ semantic tree in consecutive frames increments `frameSequence` but leaves
 `revision` unchanged. Changing the screen, node membership, hierarchy, bounds,
 text, value, state, or actions increments `revision` at `end_frame`.
 
+Frame construction is transactional. `begin_frame` creates a private staging
+frame, registration functions update only that staging frame, and `end_frame`
+atomically publishes the screen, nodes, `frameSequence`, and `revision` under
+one context lock. Reads, selectors, action validation, diagnostics, and remote
+transports only observe the last completed frame. Before the first successful
+publish they observe the empty `unknown` snapshot. An invalid or abandoned
+staging frame never changes the last completed snapshot or its metadata.
+
 `sessionEpoch` starts at 1. A successful reset starts a new epoch and resets
 `frameSequence` and `revision` to zero. Consumers must use the epoch together
 with frame/revision metadata; values from an older epoch are stale.


### PR DESCRIPTION
Closes #40

## 実装内容

- core の公開済み snapshot と構築中 staging frame を分離し、`end_frame` だけが screen / nodes / frameSequence / revision を同一 lock 内で publish するよう変更
- read、selector query、action validation、diagnostics、WebSocket consumer が完成 snapshot のみを見る契約を protocol docs に追記
- 初回未publish、構築途中、無効frame、同一semantic revision、複数reader/writer競合を native test で固定
- `WaitForId` / `WaitForRole` / `WaitForText` の成功 snapshot を `GuaNodeExpectation` に保持し、chained assertion を同一 frame 上で評価。最新状態は明示 `Refresh()` / `WaitUntil*` で再取得
- locator に exact / minimum / predicate の同期・非同期 count wait を追加。timeout / poll interval / cancellation と selector・最終件数・screen/epoch/frame/revision 診断に対応
- node expectation に requestId 相関の `ClickAndWait` / `ClickAsync` を追加し、既存の focus / set_value / set_checked / select / scroll / press_key と共通 lifecycle に統合
- `GodotSceneTestHost` に自動 loopback port、子process環境変数、`LoadRendered`、startup/teardown reset、詳細起動診断を追加
- v0.2.0以前の独自 helper / GodotHostFactory から標準APIへの移行方針をREADMEへ追記

## Architecture判断

- C ABIの既存シグネチャは変更せず、core内部のstaging/published分離だけで原子性を保証した
- .NETは既存C ABI / WebSocket protocolのconsumerのままとし、独自runtimeやNodeNotFound retryを追加していない
- selector schema/core evaluatorは既存機能でcount wait要件を満たすため変更していない
- Godot側は既存`GUA_BRIDGE_PORT`契約を利用し、repository固有process起動責務は取り込んでいない

## テスト・検証

- `cmake --preset windows-msvc-debug` 成功
- `cmake --build --preset windows-msvc-debug` 成功
- `ctest --test-dir build/windows-msvc-debug -C Debug --output-on-failure` 2/2成功
- `dotnet test bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj -c Release` 5/5成功
- `dotnet test bindings/dotnet/tests/Gua.Visual.Tests/Gua.Visual.Tests.csproj -c Release` 6/6成功
- `dotnet test examples/dotnet-nunit/GuaDotNetNUnitSample.csproj -c Release -p:UseProjectReferences=true` 16/16成功
- `dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj -c Release` 成功、警告0
- `GUA_GODOT_REAL_RENDERER_TEST=1 dotnet test bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/Gua.Godot.Visual.Integration.Tests.csproj -c Release` 3/3成功
- Godot 4.7 headless `gua_smoke.gd` 成功
- `bun run check` 全workspace成功
- `git diff --check` 成功

## 未対応事項

- Issue範囲内の未対応なし
- ThreadSanitizerは必須条件外のため実行していない。Windows MSVCのmulti-reader stress testで検証した
- 新規engine adapter、repository固有process、GPU readback、無条件action retryは非目標のまま
