### PR TITLE
Guaの選択・キー入力アクションを拡張する

### DIFF
--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -32,6 +32,7 @@ var context: Object
 var root: Control
 var buttons_by_id: Dictionary = {}
 var tabs_by_id: Dictionary = {}
+var list_items_by_id: Dictionary = {}
 var controls_by_id: Dictionary = {}
 var connected_buttons: Dictionary = {}
 var suppressed_clicks: Dictionary = {}
@@ -55,6 +56,7 @@ func update(screen: String) -> void:
 	context.begin_frame(screen)
 	buttons_by_id.clear()
 	tabs_by_id.clear()
+	list_items_by_id.clear()
 	controls_by_id.clear()
 	_collect_control(root, "")
 	context.end_frame()
@@ -138,6 +140,7 @@ func reset_context(options: Dictionary = {}) -> Dictionary:
 	if report.get("result", -1) == 1:
 		buttons_by_id.clear()
 		tabs_by_id.clear()
+		list_items_by_id.clear()
 		controls_by_id.clear()
 		suppressed_clicks.clear()
 	return report
@@ -240,8 +243,10 @@ func _collect_control(control: Control, parent_id: String) -> void:
 func _collect_item_list_items(item_list: ItemList, parent_id: String) -> void:
 	for index in range(item_list.item_count):
 		var label := item_list.get_item_text(index)
+		var id := "%s$item:%d" % [parent_id, index]
+		list_items_by_id[id] = {"list": item_list, "index": index}
 		context.register_node_v2({
-			"id": "%s$item:%d" % [parent_id, index],
+			"id": id,
 			"parent_id": parent_id,
 			"role": "listitem",
 			"label": label,
@@ -297,7 +302,7 @@ func _dispatch_click_requests() -> void:
 func _dispatch_action_requests() -> void:
 	for id in controls_by_id.keys():
 		var control := controls_by_id[id] as Control
-		for action in ["focus", "set_value", "set_checked", "select", "scroll", "press_key"]:
+		for action in ["click", "focus", "set_value", "set_checked", "select", "scroll", "press_key"]:
 			while true:
 				var request: Dictionary = context.consume_action_request(action, id)
 				if request.is_empty():
@@ -312,6 +317,10 @@ func _dispatch_action_requests() -> void:
 					"value": request.get("value", ""),
 					"sensitive": request.get("sensitive", false),
 				})
+	for id in list_items_by_id.keys():
+		_dispatch_derived_select_requests(id, list_items_by_id[id])
+	for id in tabs_by_id.keys():
+		_dispatch_derived_select_requests(id, tabs_by_id[id])
 	while true:
 		var request: Dictionary = context.consume_action_request("press_key", "")
 		if request.is_empty():
@@ -330,8 +339,19 @@ func _apply_action(control: Control, action: String, request: Dictionary) -> int
 	if not _control_enabled(control):
 		return -4
 	match action:
+		"click":
+			if control is BaseButton:
+				var button := control as BaseButton
+				suppressed_clicks[_control_id(button)] = true
+				button.emit_signal("pressed")
+			else:
+				return -5
 		"focus":
+			if control.focus_mode == Control.FOCUS_NONE:
+				return -5
 			control.grab_focus()
+			if not control.has_focus():
+				return -5
 		"set_value":
 			var value = request.get("value", "")
 			if request.get("sensitive", false):
@@ -360,12 +380,63 @@ func _apply_action(control: Control, action: String, request: Dictionary) -> int
 			else:
 				return -5
 		"press_key":
+			if control.focus_mode == Control.FOCUS_NONE:
+				return -5
+			if not control.has_focus():
+				control.grab_focus()
+			if not control.has_focus():
+				return -5
 			var event := InputEventKey.new()
 			event.keycode = OS.find_keycode_from_string(str(request.get("key", "")))
+			if event.keycode == KEY_NONE:
+				return -6
+			var modifiers := int(request.get("modifiers", 0))
+			event.shift_pressed = (modifiers & 1) != 0
+			event.alt_pressed = (modifiers & 2) != 0
+			event.ctrl_pressed = (modifiers & 4) != 0
+			event.meta_pressed = (modifiers & 8) != 0
 			event.pressed = true
-			control.gui_input.emit(event)
+			control.get_viewport().push_input(event, true)
+			var release := event.duplicate() as InputEventKey
+			release.pressed = false
+			control.get_viewport().push_input(release, true)
 		_:
 			return -5
+	return 0
+
+
+func _dispatch_derived_select_requests(id: String, target: Dictionary) -> void:
+	while true:
+		var request: Dictionary = context.consume_action_request("select", id)
+		if request.is_empty():
+			break
+		var error_code := _select_derived_item(target)
+		context.emit_action_result({
+			"request_id": request.get("request_id", 0),
+			"action": "select",
+			"node_id": id,
+			"succeeded": error_code == 0,
+			"error_code": error_code,
+		})
+
+
+func _select_derived_item(target: Dictionary) -> int:
+	var index := int(target["index"])
+	if target.has("list"):
+		var item_list := target["list"] as ItemList
+		if not item_list.is_visible_in_tree():
+			return -3
+		if item_list.is_item_disabled(index):
+			return -4
+		item_list.select(index)
+		item_list.item_selected.emit(index)
+		return 0
+	var tab_container := target["container"] as TabContainer
+	if not tab_container.is_visible_in_tree():
+		return -3
+	if tab_container.is_tab_disabled(index):
+		return -4
+	tab_container.current_tab = index
 	return 0
 
 
@@ -492,6 +563,8 @@ func _control_enabled(control: Control) -> bool:
 		return (control as LineEdit).editable
 	if control is TextEdit:
 		return (control as TextEdit).editable
+	if control is SpinBox:
+		return (control as SpinBox).editable
 	if control is ItemList:
 		return true
 	if control is TabContainer:

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -22,6 +22,11 @@ func _run() -> void:
 	button.size = Vector2(256, 56)
 	button.pressed.connect(_on_start_pressed)
 	screen.add_child(button)
+	var nonfocus_button := Button.new()
+	nonfocus_button.name = "nonfocus"
+	nonfocus_button.text = "No Focus"
+	nonfocus_button.focus_mode = Control.FOCUS_NONE
+	screen.add_child(nonfocus_button)
 
 	var checkbox := CheckBox.new()
 	checkbox.name = "remember"
@@ -33,6 +38,11 @@ func _run() -> void:
 	line_edit.name = "name"
 	line_edit.text = "Gua"
 	screen.add_child(line_edit)
+	var key_events := []
+	line_edit.gui_input.connect(func(event):
+		if event is InputEventKey:
+			key_events.append(event)
+	)
 	var text_edit := TextEdit.new()
 	text_edit.name = "notes"
 	text_edit.text = "Old"
@@ -41,6 +51,10 @@ func _run() -> void:
 	slider.name = "volume"
 	slider.value = 10
 	screen.add_child(slider)
+	var locked_spin_box := SpinBox.new()
+	locked_spin_box.name = "locked_count"
+	locked_spin_box.editable = false
+	screen.add_child(locked_spin_box)
 
 	var option := OptionButton.new()
 	option.name = "difficulty"
@@ -108,6 +122,10 @@ func _run() -> void:
 	if not tree_json.contains("servers$item:0") or not tree_json.contains("tabs$tab:1"):
 		_fail("Gua smoke did not publish stable ItemList/TabContainer semantic children: %s" % tree_json)
 		return
+	var locked_spin_node = _find_node(tree, "locked_count")
+	if locked_spin_node == null or locked_spin_node.get("enabled", true):
+		_fail("Gua smoke exposed a read-only SpinBox as enabled: %s" % tree_json)
+		return
 
 	var first_revision = tree.get("revision", 0)
 	ui.update("title")
@@ -153,6 +171,34 @@ func _run() -> void:
 	if pressed_count != 1:
 		_fail("Gua smoke expected one Button.pressed signal, got %d." % pressed_count)
 		return
+	var action_click := ui.enqueue_action({"action": "click", "node_id": "start"})
+	ui.update("title")
+	var action_click_event := ui.poll_event_v2()
+	if pressed_count != 2 or action_click_event.get("request_id", 0) != action_click.get("request_id", 0) or not action_click_event.get("succeeded", false):
+		_fail("Gua smoke did not drain and apply a v2 click request: %s" % action_click_event)
+		return
+	var list_item_select := ui.enqueue_action({"action": "select", "node_id": "servers$item:1"})
+	ui.update("title")
+	var list_item_event := ui.poll_event_v2()
+	if not item_list.is_selected(1) or list_item_event.get("request_id", 0) != list_item_select.get("request_id", 0) or not list_item_event.get("succeeded", false):
+		_fail("Gua smoke did not route a synthetic list item selection: %s / %s" % [list_item_select, list_item_event])
+		return
+	var tab_item_select := ui.enqueue_action({"action": "select", "node_id": "tabs$tab:0"})
+	ui.update("title")
+	var tab_item_event := ui.poll_event_v2()
+	if tabs.current_tab != 0 or tab_item_event.get("request_id", 0) != tab_item_select.get("request_id", 0) or not tab_item_event.get("succeeded", false):
+		_fail("Gua smoke did not route a synthetic tab selection: %s" % tab_item_event)
+		return
+	var locked_spin_action := ui.enqueue_action({"action": "set_value", "node_id": "locked_count", "value": "3"})
+	if locked_spin_action.get("error_code", 0) != -4:
+		_fail("Gua smoke accepted set_value for a read-only SpinBox: %s" % locked_spin_action)
+		return
+	var invalid_focus := ui.enqueue_action({"action": "focus", "node_id": "nonfocus"})
+	ui.update("title")
+	var invalid_focus_event := ui.poll_event_v2()
+	if invalid_focus_event.get("request_id", 0) != invalid_focus.get("request_id", 0) or invalid_focus_event.get("succeeded", true) or invalid_focus_event.get("error_code", 0) != -5:
+		_fail("Gua smoke reported success for a non-focusable control: %s" % invalid_focus_event)
+		return
 	var action_checkbox := CheckBox.new()
 	action_checkbox.name = "action_check"
 	screen.add_child(action_checkbox)
@@ -168,7 +214,7 @@ func _run() -> void:
 		[{"action": "select", "node_id": "servers", "value": "Osaka"}, func(): return item_list.is_selected(1)],
 		[{"action": "select", "node_id": "tabs", "value": "General"}, func(): return tabs.current_tab == 0],
 		[{"action": "scroll", "node_id": "scroll", "delta_x": 25.0, "delta_y": 30.0}, func(): return scroll.scroll_horizontal == 25 and scroll.scroll_vertical == 30],
-		[{"action": "press_key", "node_id": "name", "key": "A"}, func(): return true],
+		[{"action": "press_key", "node_id": "name", "key": "A", "modifiers": 5}, func(): return key_events.size() == 2 and key_events[0].pressed and not key_events[1].pressed and key_events[0].shift_pressed and key_events[0].ctrl_pressed],
 	]
 	for action_case in action_cases:
 		var accepted: Dictionary = ui.enqueue_action(action_case[0])

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -912,17 +912,19 @@ extern "C" int gua_enqueue_action(gua_context_t* ctx, const gua_action_request_d
     const std::string node_id = descriptor->node_id != nullptr ? descriptor->node_id : "";
     const std::string value = descriptor->value != nullptr ? descriptor->value : "";
     const std::string key = descriptor->key != nullptr ? descriptor->key : "";
-    if ((descriptor->action != GUA_ACTION_PRESS_KEY && node_id.empty()) ||
-        (descriptor->action == GUA_ACTION_PRESS_KEY && key.empty()) ||
-        (descriptor->action == GUA_ACTION_SELECT && value.empty()) ||
-        (descriptor->action == GUA_ACTION_SCROLL && (!std::isfinite(descriptor->delta_x) || !std::isfinite(descriptor->delta_y)))) {
+	if ((descriptor->action != GUA_ACTION_PRESS_KEY && node_id.empty()) ||
+		(descriptor->action == GUA_ACTION_PRESS_KEY && key.empty()) ||
+		(descriptor->action == GUA_ACTION_SCROLL && (!std::isfinite(descriptor->delta_x) || !std::isfinite(descriptor->delta_y)))) {
         return GUA_ACTION_ERROR_INVALID_VALUE;
     }
 
     const std::lock_guard lock(ctx->mutex);
     if (!node_id.empty()) {
-        const auto node = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& candidate) { return candidate.id == node_id; });
-        if (node == ctx->nodes.end()) return GUA_ACTION_ERROR_NODE_NOT_FOUND;
+		const auto node = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& candidate) { return candidate.id == node_id; });
+		if (node == ctx->nodes.end()) return GUA_ACTION_ERROR_NODE_NOT_FOUND;
+		if (descriptor->action == GUA_ACTION_SELECT && value.empty() && node->role != "listitem" && node->role != "tab") {
+			return GUA_ACTION_ERROR_INVALID_VALUE;
+		}
         if (!node->visible) return GUA_ACTION_ERROR_HIDDEN;
         if (!node->enabled) return GUA_ACTION_ERROR_DISABLED;
         if (!supports_action(*node, descriptor->action)) return GUA_ACTION_ERROR_UNSUPPORTED;

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -101,7 +101,8 @@ int main()
     };
     assert(gua_register_node_v2(context, &textbox) == 1);
     register_checkbox(context, false);
-    gua_register_node(context, "difficulty", "combobox", "Difficulty", { 0, 0, 100, 20 }, 1, 1);
+	gua_register_node(context, "difficulty", "combobox", "Difficulty", { 0, 0, 100, 20 }, 1, 1);
+	gua_register_node(context, "difficulty$item:0", "listitem", "Easy", { 0, 0, 100, 20 }, 1, 1);
     gua_register_node(context, "content", "scrollarea", "Content", { 0, 0, 100, 100 }, 1, 1);
     gua_end_frame(context);
 
@@ -118,13 +119,15 @@ int main()
 
     const gua_action_request_descriptor_t focus { sizeof(gua_action_request_descriptor_t), GUA_ACTION_FOCUS, "name" };
     const gua_action_request_descriptor_t checked { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SET_CHECKED, "remember", nullptr, 0, 0, 1 };
-    const gua_action_request_descriptor_t select { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SELECT, "difficulty", "hard" };
+	const gua_action_request_descriptor_t select { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SELECT, "difficulty", "hard" };
+	const gua_action_request_descriptor_t select_item { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SELECT, "difficulty$item:0" };
     const gua_action_request_descriptor_t scroll { sizeof(gua_action_request_descriptor_t), GUA_ACTION_SCROLL, "content", nullptr, 2, 3 };
     const gua_action_request_descriptor_t key { sizeof(gua_action_request_descriptor_t), GUA_ACTION_PRESS_KEY, "name", nullptr, 0, 0, 0, "A" };
     std::uint64_t action_ids[5] {};
     assert(gua_enqueue_action(context, &focus, &action_ids[0]) == GUA_ACTION_ACCEPTED);
     assert(gua_enqueue_action(context, &checked, &action_ids[1]) == GUA_ACTION_ACCEPTED);
-    assert(gua_enqueue_action(context, &select, &action_ids[2]) == GUA_ACTION_ACCEPTED);
+	assert(gua_enqueue_action(context, &select, &action_ids[2]) == GUA_ACTION_ACCEPTED);
+	assert(gua_enqueue_action(context, &select_item, nullptr) == GUA_ACTION_ACCEPTED);
     assert(gua_enqueue_action(context, &scroll, &action_ids[3]) == GUA_ACTION_ACCEPTED);
     assert(gua_enqueue_action(context, &key, &action_ids[4]) == GUA_ACTION_ACCEPTED);
     for (std::size_t i = 1; i < 5; ++i) assert(action_ids[i] > action_ids[i - 1]);
@@ -171,7 +174,7 @@ int main()
     gua_context_status_t status { sizeof(gua_context_status_t) };
     assert(gua_get_context_status(context, &status) == 1);
     assert(status.session_epoch == 1);
-    assert(status.pending_request_count == 4);
+    assert(status.pending_request_count == 5);
     assert(status.in_flight_request_count == 1);
     assert(status.unconsumed_event_count == 0);
     assert(status.first_pending_action == GUA_ACTION_SET_CHECKED);
@@ -181,11 +184,11 @@ int main()
     const gua_reset_options_t strict_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 1, 1 };
     assert(gua_reset_context(context, &strict_reset, &report) == GUA_RESET_ERROR_DIRTY);
     assert(report.session_epoch == 1);
-    assert(report.pending_request_count == 4);
+    assert(report.pending_request_count == 5);
     assert(report.in_flight_request_count == 1);
     assert(report.discarded_pending_request_count == 0);
     assert(gua_get_context_status(context, &status) == 1);
-    assert(status.pending_request_count == 4);
+    assert(status.pending_request_count == 5);
     assert(status.in_flight_request_count == 1);
 
     gua_context_t* other = gua_create_context();
@@ -202,7 +205,7 @@ int main()
     const gua_reset_options_t reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 1 };
     assert(gua_reset_context(context, &reset, &report) == GUA_RESET_SUCCEEDED);
     assert(report.previous_session_epoch == 1 && report.session_epoch == 2);
-    assert(report.discarded_pending_request_count == 4);
+    assert(report.discarded_pending_request_count == 5);
     assert(report.discarded_in_flight_request_count == 1);
     assert(gua_get_context_status(context, &status) == 1);
     assert(status.session_epoch == 2 && status.frame_sequence == 0 && status.revision == 0);

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -196,6 +196,7 @@ Semantic actions follow `enqueue -> consume -> host action -> observed event`. E
 The v1 action names map directly to the additive C ABI action enum: `click`, `focus`, `set_value`, `set_checked`, `select`, `scroll`, and `press_key`. Enqueue validation distinguishes `node_not_found`, `hidden`, `disabled`, `unsupported`, and `invalid_value`. Existing click functions remain compatibility wrappers over the generic queue.
 
 `sensitive=true` permits the adapter to receive the requested value, but event values, logs, diagnostics, and recordings must use an empty or redacted representation. `scrollUnit=0` means host pixels and `scrollUnit=1` means semantic lines. A key request may omit `nodeId` to target the host's current focus; when a node is provided it must expose `press_key`.
+Key modifiers use a transport-neutral bit mask: Shift is `1`, Alt is `2`, Control is `4`, and Meta/Command is `8`. Adapters must route both key-down and key-up through the host input pipeline and report success only after accepting the complete key gesture.
 - `text_input`
 - `move_gamepad`
 - `wait_for_node`


### PR DESCRIPTION
## Summary
- Godotアダプタで `click` / `select` / `press_key` の実処理を拡張し、ItemList と TabContainer の派生選択を扱えるようにした
- 読み取り専用の `SpinBox` を無効扱いにし、非フォーカス可能な制御への `focus` を拒否するようにした
- キー修飾子のビットマスク仕様をプロトコルに明記し、C ABI 側の `select` 入力検証と状態モデルテストを更新した

## Testing
- `gua_smoke.gd` により、派生 `select`、`click`、無効な `focus`、`SpinBox` の無効判定、修飾子付き `press_key` の挙動を検証する回帰を追加
- `state_model_tests.cpp` を更新し、派生 listitem の選択と pending request 数の変化を確認するようにした