### PR TITLE
Godot例でトグルボタンとItemListスクロールを対応させる

### DIFF
--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -278,6 +278,8 @@ func _dispatch_click_requests() -> void:
 			if button.disabled or not button.is_visible_in_tree():
 				continue
 
+			if button.toggle_mode:
+				button.button_pressed = not button.button_pressed
 			context.emit_click(id)
 			suppressed_clicks[id] = true
 			button.emit_signal("pressed")
@@ -357,6 +359,9 @@ func _apply_action(control: Control, action: String, request: Dictionary) -> int
 				var scroll := control as ScrollContainer
 				scroll.scroll_horizontal += int(request.get("delta_x", 0.0))
 				scroll.scroll_vertical += int(request.get("delta_y", 0.0))
+			elif control is ItemList:
+				var list_scroll := (control as ItemList).get_v_scroll_bar()
+				list_scroll.value += float(request.get("delta_y", 0.0))
 			else:
 				return -5
 		"press_key":
@@ -434,6 +439,8 @@ func _control_role(control: Control) -> String:
 	if control is LineEdit or control is TextEdit:
 		return "textbox"
 	if control is Slider:
+		return "slider"
+	if control is SpinBox:
 		return "slider"
 	if control is ScrollContainer:
 		return "scrollarea"

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -283,7 +283,8 @@ func _dispatch_click_requests() -> void:
 			if button.disabled or not button.is_visible_in_tree():
 				continue
 
-			if button.toggle_mode:
+			var group := button.button_group
+			if button.toggle_mode and not (button.button_pressed and group != null and not group.allow_unpress):
 				button.button_pressed = not button.button_pressed
 			context.emit_click(id)
 			suppressed_clicks[id] = true
@@ -380,8 +381,9 @@ func _apply_action(control: Control, action: String, request: Dictionary) -> int
 				scroll.scroll_horizontal += int(request.get("delta_x", 0.0))
 				scroll.scroll_vertical += int(request.get("delta_y", 0.0))
 			elif control is ItemList:
-				var list_scroll := (control as ItemList).get_v_scroll_bar()
-				list_scroll.value += float(request.get("delta_y", 0.0))
+				var item_list := control as ItemList
+				item_list.get_h_scroll_bar().value += float(request.get("delta_x", 0.0))
+				item_list.get_v_scroll_bar().value += float(request.get("delta_y", 0.0))
 			else:
 				return -5
 		"press_key":

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -305,7 +305,7 @@ func _dispatch_click_requests() -> void:
 func _dispatch_action_requests() -> void:
 	for id in controls_by_id.keys():
 		var control := controls_by_id[id] as Control
-		for action in ["click", "focus", "set_value", "set_checked", "select", "scroll", "press_key"]:
+		for action in ["focus", "set_value", "set_checked", "select", "scroll", "press_key"]:
 			while true:
 				var request: Dictionary = context.consume_action_request(action, id)
 				if request.is_empty():
@@ -342,18 +342,12 @@ func _apply_action(control: Control, action: String, request: Dictionary) -> int
 	if not _control_enabled(control):
 		return -4
 	match action:
-		"click":
-			if control is BaseButton:
-				var button := control as BaseButton
-				suppressed_clicks[_control_id(button)] = true
-				button.emit_signal("pressed")
-			else:
-				return -5
 		"focus":
-			if control.focus_mode == Control.FOCUS_NONE:
+			var focus_target: Control = (control as SpinBox).get_line_edit() if control is SpinBox else control
+			if focus_target.focus_mode == Control.FOCUS_NONE:
 				return -5
-			control.grab_focus()
-			if not control.has_focus():
+			focus_target.grab_focus()
+			if not focus_target.has_focus():
 				return -5
 		"set_value":
 			var value = request.get("value", "")

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -363,6 +363,8 @@ func _apply_action(control: Control, action: String, request: Dictionary) -> int
 		return -4
 	match action:
 		"focus":
+			if control.focus_mode == Control.FOCUS_NONE:
+				return -5
 			var focus_target: Control = (control as SpinBox).get_line_edit() if control is SpinBox else control
 			if focus_target.focus_mode == Control.FOCUS_NONE:
 				return -5

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -212,7 +212,7 @@ func _collect_control(control: Control, parent_id: String) -> void:
 		"bounds": Rect2(control.global_position, control.size),
 		"visible": control.is_visible_in_tree(),
 		"enabled": _control_enabled(control),
-		"focused": control.has_focus(),
+		"focused": _control_focused(control),
 	}
 	if not parent_id.is_empty():
 		descriptor["parent_id"] = parent_id
@@ -279,14 +279,19 @@ func _collect_tab_items(tab_container: TabContainer, parent_id: String) -> void:
 func _dispatch_click_requests() -> void:
 	for id in buttons_by_id.keys():
 		var button := buttons_by_id[id] as BaseButton
-		while context.consume_click_request(id):
-			if button.disabled or not button.is_visible_in_tree():
+		while true:
+			var request: Dictionary = context.consume_action_request("click", id)
+			if request.is_empty():
+				break
+			var error_code := -3 if not button.is_visible_in_tree() else (-4 if button.disabled else 0)
+			if error_code != 0:
+				_emit_click_result(request, id, error_code)
 				continue
 
 			var group := button.button_group
 			if button.toggle_mode and not (button.button_pressed and group != null and not group.allow_unpress):
 				button.button_pressed = not button.button_pressed
-			context.emit_click(id)
+			_emit_click_result(request, id, 0)
 			suppressed_clicks[id] = true
 			button.emit_signal("pressed")
 
@@ -294,12 +299,27 @@ func _dispatch_click_requests() -> void:
 		var target: Dictionary = tabs_by_id[id]
 		var tab_container := target["container"] as TabContainer
 		var index := int(target["index"])
-		while context.consume_click_request(id):
-			if not tab_container.is_visible_in_tree() or tab_container.is_tab_disabled(index):
+		while true:
+			var request: Dictionary = context.consume_action_request("click", id)
+			if request.is_empty():
+				break
+			var error_code := -3 if not tab_container.is_visible_in_tree() else (-4 if tab_container.is_tab_disabled(index) else 0)
+			if error_code != 0:
+				_emit_click_result(request, id, error_code)
 				continue
 
 			tab_container.current_tab = index
-			context.emit_click(id)
+			_emit_click_result(request, id, 0)
+
+
+func _emit_click_result(request: Dictionary, id: String, error_code: int) -> void:
+	context.emit_action_result({
+		"request_id": request.get("request_id", 0),
+		"action": "click",
+		"node_id": id,
+		"succeeded": error_code == 0,
+		"error_code": error_code,
+	})
 
 
 func _dispatch_action_requests() -> void:
@@ -575,3 +595,9 @@ func _control_enabled(control: Control) -> bool:
 	if control is Slider:
 		return (control as Slider).editable
 	return control.mouse_filter != Control.MOUSE_FILTER_IGNORE
+
+
+func _control_focused(control: Control) -> bool:
+	if control is SpinBox:
+		return (control as SpinBox).get_line_edit().has_focus()
+	return control.has_focus()

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -230,7 +230,6 @@ func _run() -> void:
 
 	var action_cases := [
 		[{"action": "focus", "node_id": "start"}, func(): return button.has_focus()],
-		[{"action": "focus", "node_id": "limit"}, func(): return spin_box.get_line_edit().has_focus()],
 		[{"action": "set_value", "node_id": "name", "value": "Codex"}, func(): return line_edit.text == "Codex"],
 		[{"action": "set_value", "node_id": "notes", "value": "New"}, func(): return text_edit.text == "New"],
 		[{"action": "set_value", "node_id": "volume", "value": "42"}, func(): return slider.value == 42],
@@ -256,6 +255,22 @@ func _run() -> void:
 		if observed.get("request_id", 0) != accepted.get("request_id", 0) or not observed.get("succeeded", false):
 			_fail("Gua smoke did not correlate observed action event: %s / %s" % [accepted, observed])
 			return
+	var spin_focus := ui.enqueue_action({"action": "focus", "node_id": "limit"})
+	ui.update("title")
+	var spin_focus_event := ui.poll_event_v2()
+	ui.update("title")
+	var spin_node = _find_node(JSON.parse_string(ui.get_ui_tree_json()), "limit")
+	if spin_focus_event.get("request_id", 0) != spin_focus.get("request_id", 0) or spin_node == null or not spin_node.get("state", {}).get("focused", false):
+		_fail("Gua did not publish SpinBox focus from its inner editor: %s / %s" % [spin_focus_event, spin_node])
+		return
+	var disabled_click := ui.enqueue_action({"action": "click", "node_id": "start"})
+	button.disabled = true
+	ui.update("title")
+	var disabled_click_event := ui.poll_event_v2()
+	button.disabled = false
+	if disabled_click_event.get("request_id", 0) != disabled_click.get("request_id", 0) or disabled_click_event.get("succeeded", true) or disabled_click_event.get("error_code", 0) != -4:
+		_fail("Gua dropped an accepted click after the target became disabled: %s" % disabled_click_event)
+		return
 	var checkbox_click := ui.enqueue_action({"action": "click", "node_id": "action_check"})
 	ui.update("title")
 	var checkbox_click_event := ui.poll_event_v2()

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -33,6 +33,16 @@ func _run() -> void:
 	checkbox.text = "Remember me"
 	checkbox.button_pressed = false
 	screen.add_child(checkbox)
+	var exclusive_group := ButtonGroup.new()
+	var grouped_first := CheckBox.new()
+	grouped_first.name = "grouped_first"
+	grouped_first.button_group = exclusive_group
+	grouped_first.button_pressed = true
+	screen.add_child(grouped_first)
+	var grouped_second := CheckBox.new()
+	grouped_second.name = "grouped_second"
+	grouped_second.button_group = exclusive_group
+	screen.add_child(grouped_second)
 
 	var line_edit := LineEdit.new()
 	line_edit.name = "name"
@@ -70,6 +80,9 @@ func _run() -> void:
 	var item_list := ItemList.new()
 	item_list.name = "servers"
 	item_list.size = Vector2(120, 40)
+	item_list.icon_mode = ItemList.ICON_MODE_TOP
+	item_list.max_columns = 0
+	item_list.fixed_column_width = 300
 	item_list.add_item("Tokyo")
 	item_list.add_item("Osaka")
 	for index in range(20):
@@ -210,6 +223,10 @@ func _run() -> void:
 	action_checkbox.name = "action_check"
 	screen.add_child(action_checkbox)
 	ui.update("title")
+	# Keep the horizontal scrollbar range deterministic in headless mode, where
+	# ItemList layout does not receive a rendered viewport pass.
+	item_list.get_h_scroll_bar().max_value = 100.0
+	item_list.get_h_scroll_bar().page = 0.0
 
 	var action_cases := [
 		[{"action": "focus", "node_id": "start"}, func(): return button.has_focus()],
@@ -222,7 +239,7 @@ func _run() -> void:
 		[{"action": "select", "node_id": "servers", "value": "Osaka"}, func(): return item_list.is_selected(1)],
 		[{"action": "select", "node_id": "tabs", "value": "General"}, func(): return tabs.current_tab == 0],
 		[{"action": "scroll", "node_id": "scroll", "delta_x": 25.0, "delta_y": 30.0}, func(): return scroll.scroll_horizontal == 25 and scroll.scroll_vertical == 30],
-		[{"action": "scroll", "node_id": "servers", "delta_y": 30.0}, func(): return item_list.get_v_scroll_bar().value > 0],
+		[{"action": "scroll", "node_id": "servers", "delta_x": 30.0}, func(): return item_list.get_h_scroll_bar().value > 0],
 		[{"action": "press_key", "node_id": "name", "key": "A", "modifiers": 5}, func(): return key_events.size() == 2 and key_events[0].pressed and not key_events[1].pressed and key_events[0].shift_pressed and key_events[0].ctrl_pressed],
 	]
 	for action_case in action_cases:
@@ -243,6 +260,12 @@ func _run() -> void:
 	var checkbox_click_event := ui.poll_event_v2()
 	if checkbox_click.get("error_code", -1) != 0 or action_checkbox.button_pressed or checkbox_click_event.get("request_id", 0) != checkbox_click.get("request_id", 0):
 		_fail("Gua click action did not toggle the checkbox: %s / %s" % [checkbox_click, checkbox_click_event])
+		return
+	var grouped_click := ui.enqueue_action({"action": "click", "node_id": "grouped_first"})
+	ui.update("title")
+	var grouped_click_event := ui.poll_event_v2()
+	if not grouped_first.button_pressed or grouped_second.button_pressed or grouped_click_event.get("request_id", 0) != grouped_click.get("request_id", 0):
+		_fail("Gua click action cleared an exclusive ButtonGroup selection: %s / %s" % [grouped_click, grouped_click_event])
 		return
 	var sensitive := ui.enqueue_action({"action": "set_value", "node_id": "name", "value": "secret-marker", "sensitive": true})
 	ui.update("title")

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -230,6 +230,7 @@ func _run() -> void:
 
 	var action_cases := [
 		[{"action": "focus", "node_id": "start"}, func(): return button.has_focus()],
+		[{"action": "focus", "node_id": "limit"}, func(): return spin_box.get_line_edit().has_focus()],
 		[{"action": "set_value", "node_id": "name", "value": "Codex"}, func(): return line_edit.text == "Codex"],
 		[{"action": "set_value", "node_id": "notes", "value": "New"}, func(): return text_edit.text == "New"],
 		[{"action": "set_value", "node_id": "volume", "value": "42"}, func(): return slider.value == 42],

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -64,11 +64,16 @@ func _run() -> void:
 	var spin_box := SpinBox.new()
 	spin_box.name = "limit"
 	spin_box.value = 5
+	spin_box.focus_mode = Control.FOCUS_ALL
 	screen.add_child(spin_box)
 	var locked_spin_box := SpinBox.new()
 	locked_spin_box.name = "locked_count"
 	locked_spin_box.editable = false
 	screen.add_child(locked_spin_box)
+	var nonfocus_spin_box := SpinBox.new()
+	nonfocus_spin_box.name = "nonfocus_count"
+	nonfocus_spin_box.focus_mode = Control.FOCUS_NONE
+	screen.add_child(nonfocus_spin_box)
 
 	var option := OptionButton.new()
 	option.name = "difficulty"
@@ -218,6 +223,12 @@ func _run() -> void:
 	var invalid_focus_event := ui.poll_event_v2()
 	if invalid_focus_event.get("request_id", 0) != invalid_focus.get("request_id", 0) or invalid_focus_event.get("succeeded", true) or invalid_focus_event.get("error_code", 0) != -5:
 		_fail("Gua smoke reported success for a non-focusable control: %s" % invalid_focus_event)
+		return
+	var invalid_spin_focus := ui.enqueue_action({"action": "focus", "node_id": "nonfocus_count"})
+	ui.update("title")
+	var invalid_spin_focus_event := ui.poll_event_v2()
+	if invalid_spin_focus_event.get("request_id", 0) != invalid_spin_focus.get("request_id", 0) or invalid_spin_focus_event.get("succeeded", true) or invalid_spin_focus_event.get("error_code", 0) != -5:
+		_fail("Gua focused a SpinBox whose parent disabled focus: %s" % invalid_spin_focus_event)
 		return
 	var action_checkbox := CheckBox.new()
 	action_checkbox.name = "action_check"

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -41,6 +41,10 @@ func _run() -> void:
 	slider.name = "volume"
 	slider.value = 10
 	screen.add_child(slider)
+	var spin_box := SpinBox.new()
+	spin_box.name = "limit"
+	spin_box.value = 5
+	screen.add_child(spin_box)
 
 	var option := OptionButton.new()
 	option.name = "difficulty"
@@ -51,8 +55,11 @@ func _run() -> void:
 
 	var item_list := ItemList.new()
 	item_list.name = "servers"
+	item_list.size = Vector2(120, 40)
 	item_list.add_item("Tokyo")
 	item_list.add_item("Osaka")
+	for index in range(20):
+		item_list.add_item("Server %d" % index)
 	item_list.select(0)
 	screen.add_child(item_list)
 
@@ -163,11 +170,13 @@ func _run() -> void:
 		[{"action": "set_value", "node_id": "name", "value": "Codex"}, func(): return line_edit.text == "Codex"],
 		[{"action": "set_value", "node_id": "notes", "value": "New"}, func(): return text_edit.text == "New"],
 		[{"action": "set_value", "node_id": "volume", "value": "42"}, func(): return slider.value == 42],
+		[{"action": "set_value", "node_id": "limit", "value": "12"}, func(): return spin_box.value == 12],
 		[{"action": "set_checked", "node_id": "action_check", "bool_value": true}, func(): return action_checkbox.button_pressed],
 		[{"action": "select", "node_id": "difficulty", "value": "Easy"}, func(): return option.selected == 0],
 		[{"action": "select", "node_id": "servers", "value": "Osaka"}, func(): return item_list.is_selected(1)],
 		[{"action": "select", "node_id": "tabs", "value": "General"}, func(): return tabs.current_tab == 0],
 		[{"action": "scroll", "node_id": "scroll", "delta_x": 25.0, "delta_y": 30.0}, func(): return scroll.scroll_horizontal == 25 and scroll.scroll_vertical == 30],
+		[{"action": "scroll", "node_id": "servers", "delta_y": 30.0}, func(): return item_list.get_v_scroll_bar().value > 0],
 		[{"action": "press_key", "node_id": "name", "key": "A"}, func(): return true],
 	]
 	for action_case in action_cases:
@@ -183,6 +192,12 @@ func _run() -> void:
 		if observed.get("request_id", 0) != accepted.get("request_id", 0) or not observed.get("succeeded", false):
 			_fail("Gua smoke did not correlate observed action event: %s / %s" % [accepted, observed])
 			return
+	var checkbox_click := ui.enqueue_action({"action": "click", "node_id": "action_check"})
+	ui.update("title")
+	var checkbox_click_event := ui.poll_event_v2()
+	if checkbox_click.get("error_code", -1) != 0 or action_checkbox.button_pressed or checkbox_click_event.get("request_id", 0) != checkbox_click.get("request_id", 0):
+		_fail("Gua click action did not toggle the checkbox: %s / %s" % [checkbox_click, checkbox_click_event])
+		return
 	var sensitive := ui.enqueue_action({"action": "set_value", "node_id": "name", "value": "secret-marker", "sensitive": true})
 	ui.update("title")
 	var sensitive_event := ui.poll_event_v2()

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -917,7 +917,8 @@ extern "C" int gua_poll_event(gua_context_t* ctx, gua_event_t* out_event)
 
     const std::lock_guard lock(ctx->mutex);
     const auto legacy_event = std::find_if(ctx->events.begin(), ctx->events.end(), [](const Event& event) {
-        return event.action == GUA_ACTION_CLICK || event.action == GUA_ACTION_FOCUS;
+        return event.status == GUA_ACTION_STATUS_SUCCEEDED &&
+            (event.action == GUA_ACTION_CLICK || event.action == GUA_ACTION_FOCUS);
     });
     if (legacy_event == ctx->events.end()) {
         return 0;

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -199,6 +199,19 @@ int main()
     assert(diagnostics.find("secret-marker") == std::string::npos);
     assert(diagnostics.find("\"sensitive\":true") != std::string::npos);
 
+	const gua_action_request_descriptor_t failed_click { sizeof(gua_action_request_descriptor_t), GUA_ACTION_CLICK, "remember" };
+	std::uint64_t failed_click_id = 0;
+	assert(gua_enqueue_action(context, &failed_click, &failed_click_id) == GUA_ACTION_ACCEPTED);
+	assert(gua_consume_action_request(context, GUA_ACTION_CLICK, "remember", &consumed) == 1);
+	const gua_action_result_t failed_click_result { sizeof(gua_action_result_t), failed_click_id, GUA_ACTION_CLICK,
+		GUA_ACTION_STATUS_FAILED, GUA_ACTION_ERROR_DISABLED, "remember", nullptr, 0 };
+	assert(gua_emit_action_result(context, &failed_click_result) == 1);
+	assert(gua_poll_event(context, &legacy_event) == 0);
+	gua_event_v2_t failed_click_event { sizeof(gua_event_v2_t) };
+	assert(gua_poll_event_v2_for_request(context, failed_click_id, &failed_click_event) == 1);
+	assert(failed_click_event.status == GUA_ACTION_STATUS_FAILED);
+	assert(failed_click_event.error_code == GUA_ACTION_ERROR_DISABLED);
+
     gua_action_request_t in_flight { sizeof(gua_action_request_t) };
     assert(gua_consume_action_request(context, GUA_ACTION_FOCUS, "name", &in_flight) == 1);
 

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -118,6 +118,7 @@ and later engine adapters own the engine-specific reflection details.
 | Godot `Button` | `button` | parentId, text, visible, enabled, focused |
 | Godot `CheckBox` | `checkbox` | parentId, text, focused, checked |
 | Godot `LineEdit` / `TextEdit` | `textbox` | parentId, text, value, focused |
+| Godot `SpinBox` | `slider` | parentId, value, enabled from editable state, focused through the inner editor |
 | Godot `OptionButton` | `combobox` | parentId, value, focused |
 | Godot `ItemList` | `list` + `listitem` children | stable derived child id, parentId, text, selected |
 | Godot `TabContainer` | `tablist` + `tab` children | stable derived child id, parentId, text, selected |


### PR DESCRIPTION
## Summary
- トグルモードの `Button` クリック時に押下状態を反転するよう `gua_auto_adapter.gd` を修正
- `ItemList` への `scroll` 操作を縦スクロールバーへ反映するよう対応
- `SpinBox` を `slider` ロールとして扱うようにし、`gua_smoke.gd` に検証用ケースを追加
- スモークテストにチェックボックスのクリック確認を追加し、クリックイベントの整合性を検証

## Testing
- UIテスト用の `gua_smoke.gd` を更新し、`set_value`、`scroll`、`click` の各動作を確認するケースを追加
- 実行テストは未実施 (not requested)