### PR TITLE
#45 実行中Guaのversionとcapability照会を追加

### DIFF
--- a/.github/workflows/godot-plugin-release.yml
+++ b/.github/workflows/godot-plugin-release.yml
@@ -47,7 +47,17 @@ jobs:
         run: .github/scripts/next-release-version.ps1 -TagPrefix godot-plugin -RequestedMajor $env:REQUESTED_MAJOR
 
       - name: Configure native build
-        run: cmake --preset windows-msvc-debug
+        run: cmake --preset windows-msvc-debug "-DGUA_VERSION=${{ steps.version.outputs.version }}" "-DGUA_GODOT_PLUGIN_VERSION=${{ steps.version.outputs.version }}" "-DGUA_BUILD_ID=${{ github.sha }}"
+
+      - name: Verify injected release metadata
+        shell: pwsh
+        run: |
+          $cache = Get-Content build/windows-msvc-debug/CMakeCache.txt -Raw
+          if ($cache -notmatch 'GUA_VERSION:STRING=${{ steps.version.outputs.version }}' -or
+              $cache -notmatch 'GUA_GODOT_PLUGIN_VERSION:STRING=${{ steps.version.outputs.version }}' -or
+              $cache -notmatch 'GUA_BUILD_ID:STRING=${{ github.sha }}') {
+            throw 'Configured Gua version/build ID does not match the release tag and commit.'
+          }
 
       - name: Build Godot GDExtension
         run: cmake --build --preset windows-msvc-debug --target gua-godot

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -54,7 +54,15 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Configure native runtime
-        run: cmake --preset windows-msvc-release
+        run: cmake --preset windows-msvc-release "-DGUA_VERSION=${{ steps.version.outputs.version }}" "-DGUA_BUILD_ID=${{ github.sha }}"
+
+      - name: Verify injected release metadata
+        shell: pwsh
+        run: |
+          $cache = Get-Content build/windows-msvc-release/CMakeCache.txt -Raw
+          if ($cache -notmatch 'GUA_VERSION:STRING=${{ steps.version.outputs.version }}' -or $cache -notmatch 'GUA_BUILD_ID:STRING=${{ github.sha }}') {
+            throw 'Configured Gua version/build ID does not match the release tag and commit.'
+          }
 
       - name: Build native runtime
         run: cmake --build --preset windows-msvc-release --target gua --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,15 @@ cmake_minimum_required(VERSION 3.20)
 
 project(gua LANGUAGES C CXX)
 
+set(GUA_VERSION "0.5.0-preview.3" CACHE STRING "Gua component version")
+set(GUA_BUILD_ID "development" CACHE STRING "Reproducible Gua build identifier")
+set(GUA_GODOT_PLUGIN_VERSION "0.4.0" CACHE STRING "Gua Godot plugin version")
+add_compile_definitions(
+    GUA_VERSION="${GUA_VERSION}"
+    GUA_BUILD_ID="${GUA_BUILD_ID}"
+    GUA_GODOT_PLUGIN_VERSION="${GUA_GODOT_PLUGIN_VERSION}"
+)
+
 include(CTest)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ project.
 
 ## Native Toolchain
 
+Runtime compatibility can be inspected through the additive C ABI
+`gua_copy_version_json`, the WebSocket `get_version` command, or .NET
+`GetVersion()`. The response follows `protocol/schema/version.schema.json` and
+lists stable capability IDs. Non-Godot runtimes report `godotPluginVersion` as
+`null`; release workflows inject the release version and commit build ID.
+
 Windows native development uses MSVC as the primary toolchain:
 
 ```powershell

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -122,6 +122,12 @@ public sealed class GuaContext : IGuaContext, IDisposable
         return ReadCopiedJson(JsonSource.Diagnostics, _handle);
     }
 
+    public GuaVersion GetVersion()
+    {
+        ThrowIfDisposed();
+        return GuaVersion.Parse(ReadCopiedJson(JsonSource.Version, _handle));
+    }
+
     public void ConfigureDiagnostics(uint historyLimit, string environmentJson = "{}")
     {
         ThrowIfDisposed();
@@ -567,6 +573,7 @@ public sealed class GuaContext : IGuaContext, IDisposable
             JsonSource.Logs => Native.gua_copy_logs_json(handle, buffer, bufferSize),
             JsonSource.Screenshot => Native.gua_copy_screenshot_json(handle, buffer, bufferSize),
             JsonSource.Diagnostics => Native.gua_copy_diagnostics_json(handle, buffer, bufferSize),
+            JsonSource.Version => Native.gua_copy_version_json(buffer, bufferSize),
             _ => throw new ArgumentOutOfRangeException(nameof(source), source, null),
         };
     }
@@ -577,6 +584,7 @@ public sealed class GuaContext : IGuaContext, IDisposable
         Logs,
         Screenshot,
         Diagnostics,
+        Version,
     }
 
     private static readonly System.Text.Json.JsonSerializerOptions QueryJsonOptions = new()

--- a/bindings/dotnet/src/Gua.Core/GuaVersion.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaVersion.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+
+namespace Gua.Core;
+
+public sealed record GuaVersion(
+    string ProtocolSchemaVersion,
+    string CoreVersion,
+    string RuntimeVersion,
+    string? GodotPluginVersion,
+    int AbiVersion,
+    string BuildId,
+    IReadOnlyList<string> Capabilities)
+{
+    public static GuaVersion Parse(string json) =>
+        JsonSerializer.Deserialize<GuaVersion>(json, JsonOptions)
+        ?? throw new InvalidOperationException("Gua returned an empty version response.");
+
+    public void EnsureCompatible(
+        string? protocolSchemaVersion = null,
+        int? abiVersion = null,
+        IEnumerable<string>? requiredCapabilities = null)
+    {
+        var missing = (requiredCapabilities ?? []).Except(Capabilities, StringComparer.Ordinal).ToArray();
+        if ((protocolSchemaVersion is not null && ProtocolSchemaVersion != protocolSchemaVersion) ||
+            (abiVersion is not null && AbiVersion != abiVersion) || missing.Length != 0)
+        {
+            throw new GuaCompatibilityException(
+                $"Incompatible Gua runtime. Expected protocol={protocolSchemaVersion ?? "any"}, ABI={abiVersion?.ToString() ?? "any"}; " +
+                $"actual protocol={ProtocolSchemaVersion}, ABI={AbiVersion}; missing capabilities=[{string.Join(", ", missing)}].",
+                protocolSchemaVersion, abiVersion, this, missing);
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+}
+
+public sealed class GuaCompatibilityException : InvalidOperationException
+{
+    public GuaCompatibilityException(string message, string? expectedProtocolSchemaVersion, int? expectedAbiVersion,
+        GuaVersion actual, IReadOnlyList<string> missingCapabilities) : base(message)
+    {
+        ExpectedProtocolSchemaVersion = expectedProtocolSchemaVersion;
+        ExpectedAbiVersion = expectedAbiVersion;
+        Actual = actual;
+        MissingCapabilities = missingCapabilities;
+    }
+
+    public string? ExpectedProtocolSchemaVersion { get; }
+    public int? ExpectedAbiVersion { get; }
+    public GuaVersion Actual { get; }
+    public IReadOnlyList<string> MissingCapabilities { get; }
+}

--- a/bindings/dotnet/src/Gua.Core/IGuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/IGuaContext.cs
@@ -6,6 +6,8 @@ public interface IGuaContext
 
     string GetDiagnosticsJson() => throw new NotSupportedException("This Gua context does not support diagnostics capture.");
 
+    GuaVersion GetVersion() => throw new NotSupportedException("This Gua context does not support version inspection.");
+
     GuaContextStatus GetContextStatus() => throw new NotSupportedException("This Gua context does not support status inspection.");
 
     GuaResetReport Reset(GuaResetOptions? options = null) => throw new NotSupportedException("This Gua context does not support reset.");

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -324,6 +324,9 @@ internal static partial class Native
     [LibraryImport("gua")]
     internal static unsafe partial int gua_copy_diagnostics_json(nint context, byte* outJson, int outJsonSize);
 
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_copy_version_json(byte* outJson, int outJsonSize);
+
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int gua_get_node_state(nint context, string nodeId, out GuaNodeState state);
 

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -152,6 +152,11 @@ public sealed class GodotSceneTestHost : IDisposable
 
     public GuaContextStatus GetContextStatus() => RemoteContext.GetContextStatus();
 
+    public GuaVersion GetVersion() => RemoteContext.GetVersion();
+
+    public Task<GuaVersion> GetVersionAsync(CancellationToken cancellationToken = default) =>
+        RemoteContext.GetVersionAsync(cancellationToken);
+
     public GuaResetReport ResetContext(GuaResetOptions? options = null)
     {
         ThrowIfDisposed();

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -36,6 +36,17 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
         return RequestRawResult(new { type = "get_diagnostics" });
     }
 
+    public GuaVersion GetVersion()
+    {
+        return GuaVersion.Parse(RequestRawResult(new { type = "get_version" }));
+    }
+
+    public Task<GuaVersion> GetVersionAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.Run(GetVersion, cancellationToken);
+    }
+
     public string GetScreenshotJson()
     {
         return RequestRawResult(new { type = "get_screenshot" });

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -13,6 +13,20 @@ namespace Gua.Selector.Tests;
 public sealed class SelectorParityTests
 {
     [Test]
+    public void VersionModelReportsCapabilitiesAndCompatibilityFailures()
+    {
+        using var context = new GuaContext();
+        var version = context.GetVersion();
+        Assert.That(version.GodotPluginVersion, Is.Null);
+        Assert.That(version.Capabilities, Does.Contain("version_v1"));
+        Assert.DoesNotThrow(() => version.EnsureCompatible("2", 1, ["version_v1"]));
+        var error = Assert.Throws<GuaCompatibilityException>(() =>
+            version.EnsureCompatible("999", 999, ["missing_capability"]));
+        Assert.That(error!.Message, Does.Contain("actual protocol=2"));
+        Assert.That(error.MissingCapabilities, Does.Contain("missing_capability"));
+    }
+
+    [Test]
     public async Task WaitExpectationRetainsSnapshotAndCountWaitPollsLatestFrames()
     {
         using var context = new GuaContext();
@@ -118,6 +132,16 @@ public sealed class SelectorParityTests
             var localResult = local.Query(selector);
             Assert.That(remoteResult.Matches.Select(match => match.Id),
                 Is.EqualTo(localResult.Matches.Select(match => match.Id)));
+            var remoteVersion = remote.GetVersion();
+            var localVersion = local.GetVersion();
+            Assert.Multiple(() =>
+            {
+                Assert.That(remoteVersion.ProtocolSchemaVersion, Is.EqualTo(localVersion.ProtocolSchemaVersion));
+                Assert.That(remoteVersion.AbiVersion, Is.EqualTo(localVersion.AbiVersion));
+                Assert.That(remoteVersion.BuildId, Is.EqualTo(localVersion.BuildId));
+                Assert.That(remoteVersion.Capabilities, Is.EqualTo(localVersion.Capabilities));
+            });
+            Assert.That(remoteVersion.Capabilities, Does.Contain("version_v1"));
 
             var invalid = new GuaSelector(Text: "[", TextMatch: GuaMatchMode.Regex);
             Assert.Multiple(() =>
@@ -131,6 +155,7 @@ public sealed class SelectorParityTests
                 Assert.That(diagnostics.RootElement.GetProperty("schemaVersion").GetInt32(), Is.EqualTo(1));
                 Assert.That(diagnostics.RootElement.GetProperty("uiTree").GetProperty("screen").GetString(), Is.EqualTo("fixture"));
                 Assert.That(diagnostics.RootElement.GetProperty("screenshot").ValueKind, Is.EqualTo(JsonValueKind.Null));
+                Assert.That(diagnostics.RootElement.GetProperty("version").GetProperty("abiVersion").GetInt32(), Is.EqualTo(1));
             });
         }
         finally

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -284,6 +284,8 @@ int gua_set_diagnostics_environment_json(gua_context_t* ctx, const char* environ
 const char* gua_get_diagnostics_json(gua_context_t* ctx);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
 int gua_copy_diagnostics_json(gua_context_t* ctx, char* out_json, int out_json_size);
+/* Returns version/capability JSON. The required byte size includes the trailing NUL. */
+int gua_copy_version_json(char* out_json, int out_json_size);
 int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state);
 /* Returns 0 rather than a partial state when a v2 string does not fit its fixed output buffer. */
 int gua_get_node_state_v2(gua_context_t* ctx, const char* node_id, gua_node_state_v2_t* out_state);

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -14,6 +14,26 @@
 
 namespace {
 
+std::string escape_json(const std::string& value);
+
+#ifndef GUA_VERSION
+#define GUA_VERSION "0.0.0-development"
+#endif
+#ifndef GUA_BUILD_ID
+#define GUA_BUILD_ID "development"
+#endif
+
+std::string build_version_json(const char* godot_plugin_version = nullptr)
+{
+    const std::string plugin = godot_plugin_version == nullptr
+        ? "null"
+        : "\"" + escape_json(godot_plugin_version) + "\"";
+    return "{\"protocolSchemaVersion\":\"2\",\"coreVersion\":\"" GUA_VERSION
+        "\",\"runtimeVersion\":\"" GUA_VERSION "\",\"godotPluginVersion\":" + plugin +
+        ",\"abiVersion\":1,\"buildId\":\"" GUA_BUILD_ID
+        "\",\"capabilities\":[\"semantic_ui_tree_v2\",\"semantic_actions_v2\",\"context_reset_v1\",\"diagnostics_v1\",\"version_v1\"]}";
+}
+
 struct Node {
     std::string id;
     std::string role;
@@ -504,7 +524,7 @@ std::string build_diagnostics_json(const gua_context_t& ctx)
         ",\"pendingRequestCount\":" + std::to_string(ctx.action_requests.size()) +
         ",\"inFlightRequestCount\":" + std::to_string(ctx.consumed_requests.size()) +
         ",\"unconsumedEventCount\":" + std::to_string(ctx.events.size()) +
-        ",\"environment\":" + ctx.diagnostics_environment_json +
+        ",\"environment\":" + ctx.diagnostics_environment_json + ",\"version\":" + build_version_json() +
         ",\"uiTree\":" + build_ui_tree_json(ctx) + ",\"pendingRequests\":" + pending +
         ",\"operations\":" + build_history_json(ctx.operation_history) +
         ",\"events\":" + build_history_json(ctx.event_history) +
@@ -751,6 +771,11 @@ extern "C" int gua_copy_diagnostics_json(gua_context_t* ctx, char* out_json, int
     if (ctx == nullptr) return copy_json_string("{}", out_json, out_json_size);
     const std::lock_guard lock(ctx->mutex);
     return copy_json_string(build_diagnostics_json(*ctx), out_json, out_json_size);
+}
+
+extern "C" int gua_copy_version_json(char* out_json, int out_json_size)
+{
+    return copy_json_string(build_version_json(), out_json, out_json_size);
 }
 
 extern "C" int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state)

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -37,6 +37,12 @@ void register_checkbox(gua_context_t* context, bool checked)
 
 int main()
 {
+    const int version_size = gua_copy_version_json(nullptr, 0);
+    assert(version_size > 1);
+    std::vector<char> version(static_cast<std::size_t>(version_size));
+    assert(gua_copy_version_json(version.data(), version_size) == version_size);
+    assert(std::string(version.data()).find("\"godotPluginVersion\":null") != std::string::npos);
+    assert(std::string(version.data()).find("\"version_v1\"") != std::string::npos);
     gua_context_t* context = gua_create_context();
     assert(context != nullptr);
 

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -28,6 +28,7 @@ public:
     bool register_node_v2(const Dictionary& descriptor);
 
     String get_ui_tree_json() const;
+    String get_version_json() const;
     void set_screenshot(const String& data_uri, int width, int height);
     String get_screenshot_json() const;
     bool enqueue_click(const String& node_id);

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -74,6 +74,7 @@ namespace godot {
 GuaContext::GuaContext()
     : runtime_(gua_runtime_create())
 {
+    gua_runtime_set_godot_plugin_version(runtime_, GUA_GODOT_PLUGIN_VERSION);
     if (runtime_ == nullptr) {
         UtilityFunctions::push_error(
             "GuaContext failed to create a Gua runtime. Check that the Gua native library and dependent DLLs are available.");
@@ -193,6 +194,13 @@ bool GuaContext::register_node_v2(const Dictionary& source)
 String GuaContext::get_ui_tree_json() const
 {
     return copy_runtime_json(runtime_, gua_runtime_copy_ui_tree_json);
+}
+
+String GuaContext::get_version_json() const
+{
+    char json[2048] {};
+    gua_runtime_copy_version_json(runtime_, json, static_cast<int>(sizeof(json)));
+    return String::utf8(json);
 }
 
 bool GuaContext::enqueue_click(const String& node_id)
@@ -387,6 +395,7 @@ void GuaContext::_bind_methods()
         DEFVAL(true));
     ClassDB::bind_method(D_METHOD("register_node_v2", "descriptor"), &GuaContext::register_node_v2);
     ClassDB::bind_method(D_METHOD("get_ui_tree_json"), &GuaContext::get_ui_tree_json);
+    ClassDB::bind_method(D_METHOD("get_version_json"), &GuaContext::get_version_json);
     ClassDB::bind_method(D_METHOD("set_screenshot", "data_uri", "width", "height"), &GuaContext::set_screenshot);
     ClassDB::bind_method(D_METHOD("get_screenshot_json"), &GuaContext::get_screenshot_json);
     ClassDB::bind_method(D_METHOD("enqueue_click", "node_id"), &GuaContext::enqueue_click);

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -39,6 +39,8 @@ int gua_runtime_set_diagnostics_history_limit(gua_runtime_t* runtime, uint32_t h
 int gua_runtime_set_diagnostics_environment_json(gua_runtime_t* runtime, const char* environment_json);
 const char* gua_runtime_get_diagnostics_json(gua_runtime_t* runtime);
 int gua_runtime_copy_diagnostics_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
+int gua_runtime_copy_version_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
+void gua_runtime_set_godot_plugin_version(gua_runtime_t* runtime, const char* version);
 int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* node_id, gua_node_state_t* out_state);
 int gua_runtime_get_node_state_v2(gua_runtime_t* runtime, const char* node_id, gua_node_state_v2_t* out_state);
 int gua_runtime_find_node_by_id(gua_runtime_t* runtime, const char* node_id, char* out_node_id, int out_node_id_size);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -20,6 +20,7 @@ struct gua_runtime_t {
     std::string logs_json;
     std::string screenshot_json;
     std::string diagnostics_json;
+    std::string godot_plugin_version;
 };
 
 std::string escape_json(std::string_view value);
@@ -61,7 +62,30 @@ std::string copy_screenshot_json(gua_runtime_t* runtime)
 std::string copy_diagnostics_json(gua_runtime_t* runtime)
 {
     const std::lock_guard lock(runtime->context_mutex);
-    return gua_get_diagnostics_json(runtime->context);
+    std::string json = gua_get_diagnostics_json(runtime->context);
+    if (!runtime->godot_plugin_version.empty()) {
+        const std::string marker = "\"godotPluginVersion\":null";
+        const auto position = json.find(marker);
+        if (position != std::string::npos) {
+            json.replace(position, marker.size(), "\"godotPluginVersion\":\"" + escape_json(runtime->godot_plugin_version) + "\"");
+        }
+    }
+    return json;
+}
+
+std::string copy_version_json(gua_runtime_t* runtime)
+{
+    char buffer[2048] {};
+    gua_copy_version_json(buffer, static_cast<int>(sizeof(buffer)));
+    std::string json = buffer;
+    if (!runtime->godot_plugin_version.empty()) {
+        const std::string marker = "\"godotPluginVersion\":null";
+        const auto position = json.find(marker);
+        if (position != std::string::npos) {
+            json.replace(position, marker.size(), "\"godotPluginVersion\":\"" + escape_json(runtime->godot_plugin_version) + "\"");
+        }
+    }
+    return json;
 }
 
 std::string status_json(gua_runtime_t* runtime)
@@ -292,6 +316,19 @@ extern "C" int gua_runtime_copy_diagnostics_json(gua_runtime_t* runtime, char* o
     return copy_json_string(copy_diagnostics_json(runtime), out_json, out_json_size);
 }
 
+extern "C" int gua_runtime_copy_version_json(gua_runtime_t* runtime, char* out_json, int out_json_size)
+{
+    if (!valid_runtime(runtime)) return copy_json_string("{}", out_json, out_json_size);
+    return copy_json_string(copy_version_json(runtime), out_json, out_json_size);
+}
+
+extern "C" void gua_runtime_set_godot_plugin_version(gua_runtime_t* runtime, const char* version)
+{
+    if (!valid_runtime(runtime)) return;
+    const std::lock_guard lock(runtime->context_mutex);
+    runtime->godot_plugin_version = version == nullptr ? "" : version;
+}
+
 extern "C" int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* node_id, gua_node_state_t* out_state)
 {
     if (!valid_runtime(runtime)) {
@@ -482,6 +519,9 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
         },
         .get_diagnostics_json = [runtime] {
             return copy_diagnostics_json(runtime);
+        },
+        .get_version_json = [runtime] {
+            return copy_version_json(runtime);
         },
         .query_nodes_json = [runtime](const gua::ws::QuerySelector& selector) {
             gua_selector_v1_t native {

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -40,6 +40,7 @@ struct BridgeHandlers {
     std::function<std::string()> get_logs_json;
     std::function<std::string()> get_screenshot_json;
     std::function<std::string()> get_diagnostics_json;
+    std::function<std::string()> get_version_json;
     std::function<std::string(const QuerySelector& selector)> query_nodes_json;
     std::function<std::string()> get_context_status_json;
     std::function<std::string(unsigned long long expected_epoch, unsigned int flags, bool strict)> reset_context_json;

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -822,6 +822,11 @@ private:
                     ? ok_response(command.id, handlers_.get_diagnostics_json())
                     : error_response(command.id, "get_diagnostics is not supported by this bridge");
             }
+            if (command.type == "get_version") {
+                return handlers_.get_version_json
+                    ? ok_response(command.id, handlers_.get_version_json())
+                    : error_response(command.id, "get_version is not supported by this bridge");
+            }
             if (command.type == "query_nodes") {
                 if (!handlers_.query_nodes_json) {
                     return error_response(command.id, "query_nodes is not supported by this bridge");

--- a/protocol/fixtures/diagnostics-v1.json
+++ b/protocol/fixtures/diagnostics-v1.json
@@ -8,6 +8,7 @@
   "inFlightRequestCount": 0,
   "unconsumedEventCount": 0,
   "environment": { "testName": "fixture" },
+  "version": { "protocolSchemaVersion": "2", "coreVersion": "0.5.0-preview.3", "runtimeVersion": "0.5.0-preview.3", "godotPluginVersion": null, "abiVersion": 1, "buildId": "development", "capabilities": ["version_v1"] },
   "uiTree": { "schemaVersion": 2, "sessionEpoch": 1, "frameSequence": 1, "revision": 1, "screen": "title", "nodes": [] },
   "pendingRequests": [],
   "operations": [],

--- a/protocol/fixtures/version-v1.json
+++ b/protocol/fixtures/version-v1.json
@@ -1,0 +1,9 @@
+{
+  "protocolSchemaVersion": "2",
+  "coreVersion": "0.5.0-preview.3",
+  "runtimeVersion": "0.5.0-preview.3",
+  "godotPluginVersion": null,
+  "abiVersion": 1,
+  "buildId": "development",
+  "capabilities": ["semantic_ui_tree_v2", "semantic_actions_v2", "context_reset_v1", "diagnostics_v1", "version_v1"]
+}

--- a/protocol/schema/commands.schema.json
+++ b/protocol/schema/commands.schema.json
@@ -132,7 +132,7 @@
       "additionalProperties": false,
       "properties": {
         "type": {
-          "enum": ["get_screenshot", "get_logs", "get_diagnostics", "get_context_status", "poll_events"]
+          "enum": ["get_screenshot", "get_logs", "get_diagnostics", "get_version", "get_context_status", "poll_events"]
         }
       }
     }

--- a/protocol/schema/diagnostics.schema.json
+++ b/protocol/schema/diagnostics.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://gua.dev/schema/diagnostics.schema.json",
   "title": "Gua diagnostics snapshot",
   "type": "object",
-  "required": ["schemaVersion", "sessionEpoch", "frameSequence", "revision", "historyLimit", "pendingRequestCount", "inFlightRequestCount", "unconsumedEventCount", "environment", "uiTree", "pendingRequests", "operations", "events", "logs", "screenshot"],
+  "required": ["schemaVersion", "sessionEpoch", "frameSequence", "revision", "historyLimit", "pendingRequestCount", "inFlightRequestCount", "unconsumedEventCount", "environment", "version", "uiTree", "pendingRequests", "operations", "events", "logs", "screenshot"],
   "properties": {
     "schemaVersion": { "const": 1 },
     "sessionEpoch": { "type": "integer", "minimum": 1 },
@@ -14,6 +14,7 @@
     "inFlightRequestCount": { "type": "integer", "minimum": 0 },
     "unconsumedEventCount": { "type": "integer", "minimum": 0 },
     "environment": { "type": "object" },
+    "version": { "$ref": "version.schema.json" },
     "uiTree": { "$ref": "ui-tree.schema.json" },
     "pendingRequests": { "type": "array", "items": { "$ref": "#/$defs/request" } },
     "operations": { "type": "array", "items": { "$ref": "#/$defs/history" } },

--- a/protocol/schema/version.schema.json
+++ b/protocol/schema/version.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gua.dev/schema/version.schema.json",
+  "title": "Gua runtime version and capabilities",
+  "type": "object",
+  "required": ["protocolSchemaVersion", "coreVersion", "runtimeVersion", "godotPluginVersion", "abiVersion", "buildId", "capabilities"],
+  "properties": {
+    "protocolSchemaVersion": { "type": "string", "minLength": 1 },
+    "coreVersion": { "type": "string", "minLength": 1 },
+    "runtimeVersion": { "type": "string", "minLength": 1 },
+    "godotPluginVersion": { "type": ["string", "null"] },
+    "abiVersion": { "type": "integer", "minimum": 1 },
+    "buildId": { "type": "string", "minLength": 1 },
+    "capabilities": { "type": "array", "uniqueItems": true, "items": { "type": "string", "pattern": "^[a-z0-9_]+$" } }
+  },
+  "additionalProperties": false
+}

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -211,6 +211,7 @@ Key modifiers use a transport-neutral bit mask: Shift is `1`, Alt is `2`, Contro
 - `get_screenshot`
 - `get_logs`
 - `get_diagnostics`
+- `get_version`
 - `poll_events`
 - `get_context_status`
 - `reset_context` with `expectedSessionEpoch`, optional reset `flags`, and optional `strict`
@@ -260,6 +261,7 @@ Initial MCP tools:
 - `get_screenshot`: returns the latest screenshot payload
 - `get_logs`: returns ordered runtime logs
 - `get_diagnostics`: returns the versioned best-effort diagnostics snapshot
+- `get_version`: returns `version.schema.json` for the components actually loaded. `godotPluginVersion` is `null` outside Godot. Capability IDs are stable public identifiers; new IDs are additive.
 - `run_test`: executes a small list of `wait_for_node` and `click_node` steps
 
 The MCP server uses stdio JSON-RPC for MCP clients and the existing Gua


### PR DESCRIPTION
## 対応 Issue

- Closes #45

## 実装内容

- `protocol/schema/version.schema.json` と fixture を source of truth として追加
- protocol/core/runtime/Godot plugin/ABI/build ID と安定 capability ID を同一モデルで公開
- additive C ABI `gua_copy_version_json` と runtime API、WebSocket `get_version` を追加
- Godot GDExtension が実ロード plugin version を runtime/diagnostics に反映
- `Gua.Core` / `Gua.Testing.Godot` に型付き `GuaVersion`、`GetVersion` / `GetVersionAsync`、互換性検査と詳細例外を追加
- diagnostics v1 に同じ version model を後方互換に追加
- NuGet / Godot release workflow で release version・commit SHA build ID を注入し、CMake cache と tag-derived version の一致を検証

## Architecture 判断

- protocol schema を言語横断の契約とし、既存 C ABI と既存 WebSocket command は変更せず additive API にした。
- 非 Godot 経路は `godotPluginVersion: null`、Godot 経路だけ adapter 初期化時に plugin version を設定する。
- capability ID は公開契約として snake_case の安定文字列に固定し、追加を互換変更として扱う。
- compile-time package version ではなく、実ロード native binary が返す JSON を .NET が型付き deserialize する。

## テスト・検証

- `cmake --preset windows-msvc-debug` 成功
- `cmake --build --preset windows-msvc-debug` 成功（core/runtime/Godot/examples を含む）
- `ctest --test-dir build/windows-msvc-debug -C Debug --output-on-failure` 成功: 2/2
- `dotnet build bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj --configuration Release --no-restore` 成功: 警告0 / エラー0
- `dotnet vstest bindings/dotnet/tests/Gua.Selector.Tests/bin/Release/net10.0/Gua.Selector.Tests.dll` 成功: 6/6（local/remote version parity を含む）
- `bun run check` 成功: 3 workspace
- AJV: `version-v1.json` / `diagnostics-v1.json` fixture とも schema validation 成功
- CMake release metadata injection の再現確認成功
- `git diff --check` 成功

## 互換性

- 既存 ABI export と command は維持し、新規 export/command のみ追加した。
- diagnostics は既存 schemaVersion 1 を維持した additive field で、既存 reader の挙動を変更しない。

## 未対応事項

- #45 範囲内の未完了なし。
- screenshot、詳細 semantic state、高水準 diagnostics session、teardown 運用は後続 #46〜#49 の責務として変更していない。
