### PR TITLE
Guaのバグハント用スキルとガイドを追加

### DIFF
--- a/.codex/skills/gua-bug-hunt/SKILL.md
+++ b/.codex/skills/gua-bug-hunt/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: gua-bug-hunt
+description: Find and evidence bugs, regressions, race conditions, protocol drift, and missing failure handling in the Gua repository. Use when Codex is asked to audit a change, investigate suspicious behavior, perform a bug sweep, or delegate an independent read-only bug-finding pass to a subagent.
+---
+
+# Gua Bug Hunt
+
+Act as an independent defect investigator. Prefer a small number of reproducible,
+high-confidence findings over a long list of speculative concerns.
+
+## Establish the contract
+
+1. Read the repository `AGENTS.md`, `README.md`, and
+   `protocol/specs/protocol.md`.
+2. Read `.codex/skills/gua-repo/SKILL.md`.
+3. Inspect `git status`, the requested diff or component, and nearby tests.
+4. If the scope crosses a protocol boundary, read the matching schema before
+   judging an implementation.
+5. Use [references/audit-matrix.md](references/audit-matrix.md) to select the
+   smallest relevant audit lanes. Do not scan every lane by default.
+
+## Investigate
+
+1. Trace data and ownership across the complete affected path. For example,
+   follow an action from schema to C ABI, adapter, bridge, MCP or testing client,
+   and observed result.
+2. Form a concrete failure hypothesis with required preconditions and expected
+   observable impact.
+3. Search existing tests before creating a reproducer. Use the repository's
+   narrowest available test or smoke command.
+4. Reproduce the failure when safe. Keep diagnostics and temporary artifacts
+   outside tracked source, and remove them after use.
+5. Check whether concurrent access, reset/session boundaries, stale snapshots,
+   sensitive values, and partial host support change the result.
+6. Discard a concern if source and bounded verification do not support it.
+
+## Respect the investigator boundary
+
+- Default to read-only diagnosis. Do not edit product code unless the user also
+  asks for a fix.
+- Do not report style preferences, broad redesign ideas, or missing features as
+  bugs unless they violate an explicit contract.
+- Do not assume enqueue acceptance means host action completion.
+- Do not make TypeScript a second runtime source of truth. Treat MCP and
+  Inspector as protocol consumers.
+- Do not weaken assertions merely to make a failing test pass.
+- Preserve user changes and ignore unrelated dirty-worktree files.
+
+## Report findings
+
+Order findings by severity. For each confirmed issue include:
+
+- severity and concise title;
+- exact file and tight line range;
+- trigger or reproduction steps;
+- expected versus actual behavior;
+- why the contract proves it is a defect;
+- the narrowest sensible fix direction;
+- verification performed and any remaining uncertainty.
+
+Say explicitly when no actionable bug is found. In that case, list the audited
+surfaces and verification commands, then note only concrete residual risks.
+
+When operating as a subagent, return findings to the parent agent and do not
+modify files. The parent owns deduplication, cross-finding prioritization, and
+any subsequent fix.

--- a/.codex/skills/gua-bug-hunt/agents/openai.yaml
+++ b/.codex/skills/gua-bug-hunt/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gua Bug Hunt"
+  short_description: "Find reproducible bugs across Gua protocol boundaries"
+  default_prompt: "Use $gua-bug-hunt to inspect this Gua change for reproducible bugs and report evidence."

--- a/.codex/skills/gua-bug-hunt/references/audit-matrix.md
+++ b/.codex/skills/gua-bug-hunt/references/audit-matrix.md
@@ -1,0 +1,46 @@
+# Gua defect audit matrix
+
+Select only lanes touched by the requested component or diff.
+
+| Lane | Contract and implementation | High-signal failure classes |
+| --- | --- | --- |
+| Protocol/schema | `protocol/specs`, `protocol/schema`, fixtures | undocumented payload drift, invalid optionality, legacy incompatibility |
+| Core C ABI | `native/gua-core/include`, `native/gua-core/src` | ABI size/version mistakes, staging-frame leaks, queue corruption, lock gaps |
+| Runtime/bridge | `native/gua-runtime`, `native/gua-ws-bridge` | lifetime bugs, stale epoch acceptance, response correlation, disconnect races |
+| C++ helpers | `native/gua-testing` | first-match ambiguity, stale snapshots, timeout and action-completion errors |
+| .NET bindings | `bindings/dotnet/src` | P/Invoke layout mismatch, ownership/disposal, exception masking, reset leakage |
+| ImGui adapter | `native/gua-imgui`, `examples/cpp-imgui` | unstable IDs, missing host events, incorrect visible/enabled/action state |
+| Godot adapters | `native/gua-godot`, `examples/dotnet-godot`, `examples/godot-gdscript` | tree reflection drift, signal duplication, stale DLL/API mismatch, scene teardown |
+| MCP | `packages/mcp` | tool/schema mismatch, unsupported command claims, timeouts, lost bridge errors |
+| Inspector | `packages/inspector` | stale push/poll ordering, incorrect node state rendering, reconnect state leaks |
+| Visual/recording | `Gua.Testing.Visual`, screenshot and recording schemas | implicit resize, mask denominator errors, secret retention, nondeterministic replay |
+
+## Cross-boundary invariants
+
+- A published frame is atomic; readers never observe staging data.
+- `sessionEpoch`, `frameSequence`, and `revision` have distinct meanings.
+- Action success follows `enqueue -> consume -> host action -> observed event`.
+- Request IDs correlate results without consuming unrelated events.
+- Unknown state stays omitted; observed false is not the same as unsupported.
+- Sensitive action values never enter logs, diagnostics, history, or recordings.
+- Strict reset is all-or-nothing and stale remote epochs cannot mutate state.
+- Adapter-owned reflection follows the host UI rather than manual semantic
+  restatement.
+- MCP and Inspector do not own runtime state.
+
+## Bounded verification menu
+
+Choose the smallest commands that exercise the suspected defect:
+
+```powershell
+bun run check
+cmake --preset windows-msvc-debug
+cmake --build --preset windows-msvc-debug --target gua
+ctest --test-dir build/windows-msvc-debug --output-on-failure
+dotnet test bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj
+dotnet test bindings/dotnet/tests/Gua.Visual.Tests/Gua.Visual.Tests.csproj
+```
+
+For adapter defects, prefer the relevant existing sample smoke path. Do not
+launch every engine or package when a narrower target proves or disproves the
+hypothesis.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,6 @@ bot, or full UI framework.
 - Keep generated output, dependency folders, and local build artifacts out of git.
 - When changing schema behavior, update protocol docs and affected clients together.
 - Preserve the monorepo shape unless the user explicitly asks to split packages.
+- For independent defect investigation, use the project-local `$gua-bug-hunt`
+  skill. Keep bug-hunting subagents read-only and require reproducible evidence;
+  fixes are a separate task unless the user explicitly requests them.

--- a/docs/bug-hunting-subagent.md
+++ b/docs/bug-hunting-subagent.md
@@ -1,0 +1,19 @@
+# Bug-hunting subagent
+
+The repository includes the project-local Codex skill `$gua-bug-hunt` for an
+independent, evidence-driven defect pass. It complements `$gua-repo`: the latter
+defines architecture rules, while `$gua-bug-hunt` defines investigation and
+reporting behavior.
+
+Ask the main agent to delegate a bounded component or diff, for example:
+
+```text
+Use $gua-bug-hunt in a subagent to audit packages/mcp for reproducible protocol
+and error-handling bugs. Keep the pass read-only and return file/line evidence,
+reproduction steps, and verification results.
+```
+
+Good delegation scopes are one changed diff, one protocol path, or one adapter.
+For cross-language work, divide by independent boundary (for example core ABI,
+WebSocket/MCP, and Godot) and let the parent agent deduplicate findings. The
+subagent must not edit product files; fixes remain a separate, explicit task.


### PR DESCRIPTION
## Summary
- `$gua-bug-hunt` を新規追加し、独立した不具合調査の手順と報告方針を定義した
- 調査対象の lane を絞る監査マトリクスを追加した
- サブエージェント向けの委任手順を `docs/bug-hunting-subagent.md` に整理した
- `AGENTS.md` にバグハント時の運用ルールを追記した

## Testing
- Not run (not requested)