### PR TITLE
Guaのイベント処理とJSONエスケープを修正する

### DIFF
--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -291,9 +291,9 @@ func _dispatch_click_requests() -> void:
 			var group := button.button_group
 			if button.toggle_mode and not (button.button_pressed and group != null and not group.allow_unpress):
 				button.button_pressed = not button.button_pressed
-			_emit_click_result(request, id, 0)
 			suppressed_clicks[id] = true
 			button.emit_signal("pressed")
+			_emit_click_result(request, id, 0)
 
 	for id in tabs_by_id.keys():
 		var target: Dictionary = tabs_by_id[id]

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -3,6 +3,9 @@ extends SceneTree
 const GuaAutoAdapterScript := preload("res://addons/gua/gua_auto_adapter.gd")
 
 var pressed_count := 0
+var adapter: Variant
+var expected_click_request_id := 0
+var click_completed_before_handler := false
 
 
 func _initialize() -> void:
@@ -115,6 +118,7 @@ func _run() -> void:
 	await process_frame
 
 	var ui := GuaAutoAdapterScript.new()
+	adapter = ui
 	var missing_methods := ui._missing_context_methods(RefCounted.new())
 	if not missing_methods.has("consume_click_request"):
 		_fail("Gua smoke did not detect missing consume_click_request on an incompatible context.")
@@ -197,9 +201,13 @@ func _run() -> void:
 		_fail("Gua smoke expected one Button.pressed signal, got %d." % pressed_count)
 		return
 	var action_click := ui.enqueue_action({"action": "click", "node_id": "start"})
+	expected_click_request_id = action_click.get("request_id", 0)
 	ui.update("title")
 	var action_click_event := ui.poll_event_v2()
-	if pressed_count != 2 or action_click_event.get("request_id", 0) != action_click.get("request_id", 0) or not action_click_event.get("succeeded", false):
+	if click_completed_before_handler:
+		_fail("Gua completed a v2 click before the pressed handler returned.")
+		return
+	if pressed_count != 2 or action_click_event.get("request_id", 0) != expected_click_request_id or not action_click_event.get("succeeded", false):
 		_fail("Gua smoke did not drain and apply a v2 click request: %s" % action_click_event)
 		return
 	var list_item_select := ui.enqueue_action({"action": "select", "node_id": "servers$item:1"})
@@ -331,6 +339,9 @@ func _run() -> void:
 
 
 func _on_start_pressed() -> void:
+	if expected_click_request_id != 0:
+		var premature: Dictionary = adapter.poll_event_v2()
+		click_completed_before_handler = premature.get("request_id", 0) == expected_click_request_id
 	pressed_count += 1
 
 

--- a/examples/native-bridge/main.cpp
+++ b/examples/native-bridge/main.cpp
@@ -124,7 +124,15 @@ std::string escape_json(std::string_view value)
             out += "\\t";
             break;
         default:
-            out += ch;
+            if (static_cast<unsigned char>(ch) < 0x20U) {
+                constexpr char hex[] = "0123456789abcdef";
+                const unsigned char byte = static_cast<unsigned char>(ch);
+                out += "\\u00";
+                out += hex[byte >> 4U];
+                out += hex[byte & 0x0fU];
+            } else {
+                out += ch;
+            }
             break;
         }
     }

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -140,7 +140,15 @@ std::string escape_json(const std::string& value)
             out += "\\t";
             break;
         default:
-            out += ch;
+            if (static_cast<unsigned char>(ch) < 0x20U) {
+                constexpr char hex[] = "0123456789abcdef";
+                const unsigned char byte_value = static_cast<unsigned char>(ch);
+                out += "\\u00";
+                out += hex[byte_value >> 4U];
+                out += hex[byte_value & 0x0fU];
+            } else {
+                out += ch;
+            }
             break;
         }
     }
@@ -941,20 +949,24 @@ extern "C" int gua_poll_event(gua_context_t* ctx, gua_event_t* out_event)
     }
 
     const std::lock_guard lock(ctx->mutex);
-    const auto legacy_event = std::find_if(ctx->events.begin(), ctx->events.end(), [](const Event& event) {
-        return event.status == GUA_ACTION_STATUS_SUCCEEDED &&
-            (event.action == GUA_ACTION_CLICK || event.action == GUA_ACTION_FOCUS);
-    });
-    if (legacy_event == ctx->events.end()) {
-        return 0;
+    while (true) {
+        const auto legacy_event = std::find_if(ctx->events.begin(), ctx->events.end(), [](const Event& event) {
+            return event.action == GUA_ACTION_CLICK || event.action == GUA_ACTION_FOCUS;
+        });
+        if (legacy_event == ctx->events.end()) {
+            return 0;
+        }
+
+        const Event event = *legacy_event;
+        ctx->events.erase(legacy_event);
+        if (event.status != GUA_ACTION_STATUS_SUCCEEDED) {
+            continue;
+        }
+
+        out_event->type = event.action;
+        std::snprintf(out_event->node_id, sizeof(out_event->node_id), "%s", event.node_id.c_str());
+        return 1;
     }
-
-    const Event event = *legacy_event;
-    ctx->events.erase(legacy_event);
-
-    out_event->type = event.action;
-    std::snprintf(out_event->node_id, sizeof(out_event->node_id), "%s", event.node_id.c_str());
-    return 1;
 }
 
 extern "C" int gua_enqueue_action(gua_context_t* ctx, const gua_action_request_descriptor_t* descriptor, uint64_t* out_request_id)

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -86,6 +86,11 @@ int main()
     assert(first.find("\"checked\":false") != std::string::npos);
     assert(first.find("\"selected\"") == std::string::npos);
 
+    gua_add_log(context, GUA_LOG_INFO, "control\bcharacter");
+    const std::string escaped_logs = gua_get_logs_json(context);
+    assert(escaped_logs.find("control\\u0008character") != std::string::npos);
+    assert(escaped_logs.find('\b') == std::string::npos);
+
     gua_node_state_v2_t state {};
     state.struct_size = sizeof(state);
     assert(gua_get_node_state_v2(context, "remember", &state) == 1);
@@ -213,10 +218,11 @@ int main()
 		GUA_ACTION_STATUS_FAILED, GUA_ACTION_ERROR_DISABLED, "remember", nullptr, 0 };
 	assert(gua_emit_action_result(context, &failed_click_result) == 1);
 	assert(gua_poll_event(context, &legacy_event) == 0);
+	gua_context_status_t failed_click_status { sizeof(gua_context_status_t) };
+	assert(gua_get_context_status(context, &failed_click_status) == 1);
+	assert(failed_click_status.unconsumed_event_count == 0);
 	gua_event_v2_t failed_click_event { sizeof(gua_event_v2_t) };
-	assert(gua_poll_event_v2_for_request(context, failed_click_id, &failed_click_event) == 1);
-	assert(failed_click_event.status == GUA_ACTION_STATUS_FAILED);
-	assert(failed_click_event.error_code == GUA_ACTION_ERROR_DISABLED);
+	assert(gua_poll_event_v2_for_request(context, failed_click_id, &failed_click_event) == 0);
 
     gua_action_request_t in_flight { sizeof(gua_action_request_t) };
     assert(gua_consume_action_request(context, GUA_ACTION_FOCUS, "name", &in_flight) == 1);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -441,7 +441,17 @@ std::string escape_json(std::string_view value)
         case '\n': escaped += "\\n"; break;
         case '\r': escaped += "\\r"; break;
         case '\t': escaped += "\\t"; break;
-        default: escaped.push_back(ch); break;
+        default:
+            if (static_cast<unsigned char>(ch) < 0x20U) {
+                constexpr char hex[] = "0123456789abcdef";
+                const unsigned char byte_value = static_cast<unsigned char>(ch);
+                escaped += "\\u00";
+                escaped += hex[byte_value >> 4U];
+                escaped += hex[byte_value & 0x0fU];
+            } else {
+                escaped.push_back(ch);
+            }
+            break;
         }
     }
     return escaped;

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -150,7 +150,15 @@ std::string escape_json(std::string_view value)
             out += "\\t";
             break;
         default:
-            out += ch;
+            if (static_cast<unsigned char>(ch) < 0x20U) {
+                constexpr char hex[] = "0123456789abcdef";
+                const unsigned char byte = static_cast<unsigned char>(ch);
+                out += "\\u00";
+                out += hex[byte >> 4U];
+                out += hex[byte & 0x0fU];
+            } else {
+                out += ch;
+            }
             break;
         }
     }
@@ -437,11 +445,72 @@ std::optional<std::string> json_string_field(std::string_view json, std::string_
         return std::nullopt;
     }
 
+    const auto hex_value = [](char ch) -> int {
+        if (ch >= '0' && ch <= '9') return ch - '0';
+        if (ch >= 'a' && ch <= 'f') return ch - 'a' + 10;
+        if (ch >= 'A' && ch <= 'F') return ch - 'A' + 10;
+        return -1;
+    };
+    const auto append_utf8 = [](std::string& out, std::uint32_t codepoint) {
+        if (codepoint <= 0x7fU) {
+            out.push_back(static_cast<char>(codepoint));
+        } else if (codepoint <= 0x7ffU) {
+            out.push_back(static_cast<char>(0xc0U | (codepoint >> 6U)));
+            out.push_back(static_cast<char>(0x80U | (codepoint & 0x3fU)));
+        } else if (codepoint <= 0xffffU) {
+            out.push_back(static_cast<char>(0xe0U | (codepoint >> 12U)));
+            out.push_back(static_cast<char>(0x80U | ((codepoint >> 6U) & 0x3fU)));
+            out.push_back(static_cast<char>(0x80U | (codepoint & 0x3fU)));
+        } else {
+            out.push_back(static_cast<char>(0xf0U | (codepoint >> 18U)));
+            out.push_back(static_cast<char>(0x80U | ((codepoint >> 12U) & 0x3fU)));
+            out.push_back(static_cast<char>(0x80U | ((codepoint >> 6U) & 0x3fU)));
+            out.push_back(static_cast<char>(0x80U | (codepoint & 0x3fU)));
+        }
+    };
+    const auto read_hex_quad = [&](std::size_t start, std::uint32_t& result) -> bool {
+        if (start + 4U > json.size()) return false;
+        result = 0;
+        for (std::size_t offset = 0; offset < 4U; ++offset) {
+            const int digit = hex_value(json[start + offset]);
+            if (digit < 0) return false;
+            result = (result << 4U) | static_cast<std::uint32_t>(digit);
+        }
+        return true;
+    };
+
     std::string value;
     for (std::size_t i = quote + 1U; i < json.size(); ++i) {
         const char ch = json[i];
-        if (ch == '\\' && i + 1U < json.size()) {
-            value.push_back(json[++i]);
+        if (ch == '\\') {
+            if (++i >= json.size()) return std::nullopt;
+            switch (json[i]) {
+            case '"': value.push_back('"'); break;
+            case '\\': value.push_back('\\'); break;
+            case '/': value.push_back('/'); break;
+            case 'b': value.push_back('\b'); break;
+            case 'f': value.push_back('\f'); break;
+            case 'n': value.push_back('\n'); break;
+            case 'r': value.push_back('\r'); break;
+            case 't': value.push_back('\t'); break;
+            case 'u': {
+                std::uint32_t codepoint = 0;
+                if (!read_hex_quad(i + 1U, codepoint)) return std::nullopt;
+                i += 4U;
+                if (codepoint >= 0xd800U && codepoint <= 0xdbffU) {
+                    if (i + 6U >= json.size() || json[i + 1U] != '\\' || json[i + 2U] != 'u') return std::nullopt;
+                    std::uint32_t low = 0;
+                    if (!read_hex_quad(i + 3U, low) || low < 0xdc00U || low > 0xdfffU) return std::nullopt;
+                    codepoint = 0x10000U + ((codepoint - 0xd800U) << 10U) + (low - 0xdc00U);
+                    i += 6U;
+                } else if (codepoint >= 0xdc00U && codepoint <= 0xdfffU) {
+                    return std::nullopt;
+                }
+                append_utf8(value, codepoint);
+                break;
+            }
+            default: return std::nullopt;
+            }
             continue;
         }
         if (ch == '"') {
@@ -652,12 +721,21 @@ public:
         }
         {
             const std::lock_guard lock(clients_mutex_);
-            for (const ClientConnection& client : clients_) {
-                shutdown(client.socket, SD_BOTH);
+            for (const SOCKET client_socket : active_client_sockets_) {
+                shutdown(client_socket, SD_BOTH);
             }
         }
         if (thread_.joinable()) {
             thread_.join();
+        }
+        {
+            const std::lock_guard lock(client_threads_mutex_);
+            for (std::thread& client_thread : client_threads_) {
+                if (client_thread.joinable()) {
+                    client_thread.join();
+                }
+            }
+            client_threads_.clear();
         }
     }
 
@@ -743,14 +821,35 @@ private:
                     }
                     break;
                 }
-
-                try {
-                    serve_client(client.get());
-                } catch (const std::exception& error) {
-                    if (running_.load()) {
-                        std::cerr << "Gua bridge client error: " << error.what() << std::endl;
-                    }
+                if (!running_.load()) {
+                    break;
                 }
+
+                const SOCKET client_socket = client.release();
+                {
+                    const std::lock_guard clients_lock(clients_mutex_);
+                    active_client_sockets_.push_back(client_socket);
+                }
+                const std::lock_guard lock(client_threads_mutex_);
+                client_threads_.emplace_back([this, client_socket]() {
+                    Socket owned_client(client_socket);
+                    try {
+                        serve_client(owned_client.get());
+                    } catch (const std::exception& error) {
+                        if (running_.load()) {
+                            std::cerr << "Gua bridge client error: " << error.what() << std::endl;
+                        }
+                    }
+                    const std::lock_guard clients_lock(clients_mutex_);
+                    clients_.erase(
+                        std::remove_if(clients_.begin(), clients_.end(), [&](const ClientConnection& entry) {
+                            return entry.socket == client_socket;
+                        }),
+                        clients_.end());
+                    active_client_sockets_.erase(
+                        std::remove(active_client_sockets_.begin(), active_client_sockets_.end(), client_socket),
+                        active_client_sockets_.end());
+                });
             }
 
             listen_socket_ = INVALID_SOCKET;
@@ -890,6 +989,9 @@ private:
     std::atomic<SOCKET> listen_socket_ = INVALID_SOCKET;
     std::mutex clients_mutex_;
     std::vector<ClientConnection> clients_;
+    std::vector<SOCKET> active_client_sockets_;
+    std::mutex client_threads_mutex_;
+    std::vector<std::thread> client_threads_;
 };
 
 BridgeServer::BridgeServer(BridgeHandlers handlers, BridgeOptions options)


### PR DESCRIPTION
## Summary
- v2 の click 完了通知を `pressed` ハンドラの後に送るようにして、完了イベントが先に見える順序問題を解消する
- 制御文字を JSON 文字列で `\u00XX` として正しくエスケープするよう統一する
- `gua_poll_event` が失敗済みの legacy イベントを消費しつつ、成功イベントのみ返すよう整理する
- Win32 ブリッジの JSON 文字列パースを拡張し、`` などの制御文字とサロゲートペアを復元できるようにする
- ブリッジのクライアント処理を接続ごとのスレッドに分離し、終了時に確実に回収する
- GDScript の smoke テストと C++ の state model テストを更新し、順序とエスケープの回帰を検出できるようにする

## Testing
- 追加・更新した単体テストで、制御文字エスケープと失敗済みイベントの取り扱いを検証
- GDScript smoke テストで、`pressed` ハンドラ完了前に v2 click 完了が見えないことを確認
- 既存の C++/Godot 経路に対する回帰チェックを実施