### PR TITLE
#46 Godot viewportをオンデマンド取得する

### DIFF
--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -135,6 +135,23 @@ public sealed class GodotSceneTestHost : IDisposable
         return GuaScreenshot.Parse(RemoteContext.GetScreenshotJson());
     }
 
+    public async Task<GuaScreenshot> CaptureScreenshotAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        var limit = timeout ?? _options.SceneTimeout;
+        var status = RemoteContext.GetContextStatus();
+        using var captureContext = new GuaRemoteContext(_bridgeUrl, limit + TimeSpan.FromSeconds(1));
+        using var registration = cancellationToken.Register(captureContext.Dispose);
+        try
+        {
+            return await Task.Run(() => captureContext.CaptureScreenshot(limit, status.FrameSequence), cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
+    }
+
     public GuaSavedScreenshot SaveScreenshot(string directory, string testName)
     {
         ThrowIfDisposed();

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -52,6 +52,29 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
         return RequestRawResult(new { type = "get_screenshot" });
     }
 
+    public GuaScreenshot CaptureScreenshot(TimeSpan timeout, ulong? afterFrameSequence = null)
+    {
+        try
+        {
+            return GuaScreenshot.Parse(RequestRawResult(new
+            {
+                type = "capture_screenshot",
+                afterFrameSequence,
+                timeoutMs = Math.Max(1, (int)timeout.TotalMilliseconds),
+            }));
+        }
+        catch (InvalidOperationException error) when (error.Message.Contains("headless", StringComparison.Ordinal))
+        { throw new GuaScreenshotException(GuaScreenshotError.Headless, "Godot viewport capture is unavailable in headless mode.", error); }
+        catch (InvalidOperationException error) when (error.Message.Contains("rendering_disabled", StringComparison.Ordinal))
+        { throw new GuaScreenshotException(GuaScreenshotError.RenderingDisabled, "Godot viewport rendering is disabled.", error); }
+        catch (InvalidOperationException error) when (error.Message.Contains("unsupported", StringComparison.Ordinal))
+        { throw new GuaScreenshotException(GuaScreenshotError.Unsupported, "The connected adapter does not support viewport capture.", error); }
+        catch (InvalidOperationException error) when (error.Message.Contains("timed out", StringComparison.Ordinal))
+        { throw new GuaScreenshotException(GuaScreenshotError.Timeout, $"Godot viewport capture timed out after {timeout:g}.", error); }
+        catch (InvalidOperationException error) when (error.Message.Contains("stale_session", StringComparison.Ordinal))
+        { throw new GuaScreenshotException(GuaScreenshotError.StaleSession, "The screenshot request belongs to a stale Gua session epoch.", error); }
+    }
+
     public GuaContextStatus GetContextStatus()
     {
         var status = Request<ContextStatusResult>(new { type = "get_context_status" });

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaScreenshot.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaScreenshot.cs
@@ -7,6 +7,11 @@ public enum GuaScreenshotError
     NotPublished,
     InvalidDataUri,
     InvalidPng,
+    Headless,
+    RenderingDisabled,
+    Unsupported,
+    Timeout,
+    StaleSession,
 }
 
 public sealed class GuaScreenshotException : Exception
@@ -15,7 +20,7 @@ public sealed class GuaScreenshotException : Exception
     public GuaScreenshotError Error { get; }
 }
 
-public sealed record GuaScreenshot(string DataUri, int Width, int Height)
+public sealed record GuaScreenshot(string DataUri, int Width, int Height, ulong RequestId = 0, ulong SessionEpoch = 0, ulong FrameSequence = 0)
 {
     private static readonly byte[] PngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
 
@@ -26,7 +31,10 @@ public sealed record GuaScreenshot(string DataUri, int Width, int Height)
         return new GuaScreenshot(
             root.GetProperty("dataUri").GetString() ?? string.Empty,
             root.GetProperty("width").GetInt32(),
-            root.GetProperty("height").GetInt32());
+            root.GetProperty("height").GetInt32(),
+            root.TryGetProperty("requestId", out var requestId) ? requestId.GetUInt64() : 0,
+            root.TryGetProperty("sessionEpoch", out var epoch) ? epoch.GetUInt64() : 0,
+            root.TryGetProperty("frameSequence", out var frame) ? frame.GetUInt64() : 0);
     }
 
     public byte[] DecodePng()

--- a/bindings/dotnet/src/Gua.Testing.Godot/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Godot/README.md
@@ -98,3 +98,9 @@ attaching, retaining, and publishing PNG files is the caller's responsibility.
 `SaveScreenshot` creates a collision-resistant absolute path and distinguishes
 unpublished, malformed data-URI, and invalid-PNG payloads. A headless renderer
 without viewport capture is reported as unpublished rather than an empty file.
+`GodotSceneTestHost.CaptureScreenshotAsync` requests a new PNG from the next
+drawable frame and returns its request ID, session epoch, and frame sequence.
+Headless, rendering-disabled, unsupported, timeout, and cancellation outcomes are
+distinct. Requests arriving together may share one viewport readback. The older
+`GetScreenshot`/`WaitForScreenshotAsync` APIs keep reading the latest published
+image. Rendered secrets are not automatically redacted.

--- a/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
@@ -180,6 +180,49 @@ public sealed class GodotVisualIntegrationTests
         });
     }
 
+    [Test]
+    public async Task OnDemandCaptureReturnsANewerCorrelatedFrameAndCoalescesConcurrentRequests()
+    {
+        using var host = StartGodotAutoPort();
+        var before = host.GetContextStatus();
+        var captures = await Task.WhenAll(
+            host.CaptureScreenshotAsync(TimeSpan.FromSeconds(15)),
+            host.CaptureScreenshotAsync(TimeSpan.FromSeconds(15)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(captures[0].RequestId, Is.Not.EqualTo(captures[1].RequestId));
+            Assert.That(captures, Has.All.Property(nameof(GuaScreenshot.SessionEpoch)).EqualTo(before.SessionEpoch));
+            Assert.That(captures, Has.All.Property(nameof(GuaScreenshot.FrameSequence)).GreaterThan(before.FrameSequence));
+            Assert.That(captures[0].DataUri, Is.EqualTo(captures[1].DataUri));
+            Assert.That(captures, Has.All.Property(nameof(GuaScreenshot.Width)).GreaterThan(0));
+            Assert.That(captures, Has.All.Property(nameof(GuaScreenshot.Height)).GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public async Task OnDemandCaptureDistinguishesHeadlessAndCancellation()
+    {
+        using var headless = GodotSceneTestHost.Load("res://Main.tscn", new GodotSceneTestHostOptions
+        {
+            GodotExecutablePath = Environment.GetEnvironmentVariable("GODOT_EXECUTABLE"),
+            ProjectPath = Path.Combine(FindRepositoryRoot(), "examples", "godot-gdscript"),
+            UseAvailableBridgePort = true,
+            Headless = true,
+            ConnectTimeout = TimeSpan.FromSeconds(15),
+            RequestTimeout = TimeSpan.FromSeconds(10),
+            SceneTimeout = TimeSpan.FromSeconds(15),
+        });
+        var unavailable = Assert.ThrowsAsync<GuaScreenshotException>(() =>
+            headless.CaptureScreenshotAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(unavailable!.Error, Is.EqualTo(GuaScreenshotError.Headless));
+
+        using var rendered = StartGodotAutoPort();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.ThrowsAsync<OperationCanceledException>(() =>
+            rendered.CaptureScreenshotAsync(TimeSpan.FromSeconds(5), cancellation.Token));
+    }
+
     private static async Task<IReadOnlyList<GuaActionEvent>> WaitForActionEventsAsync(
         IGuaContext context, int count, TimeSpan timeout)
     {

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -197,6 +197,30 @@ public sealed class SelectorParityTests
         }
     }
 
+    [Test]
+    public void OnDemandScreenshotTimeoutIsTypedAndDoesNotReturnTheStaleLatestImage()
+    {
+        var port = ReservePort();
+        var runtime = Native.gua_runtime_create();
+        Assert.That(runtime, Is.Not.EqualTo(nint.Zero));
+        try
+        {
+            Native.gua_runtime_begin_frame(runtime, "fixture");
+            Native.gua_runtime_end_frame(runtime);
+            Assert.That(Native.gua_runtime_start_inspector_bridge(runtime, port), Is.EqualTo(1));
+            using var remote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            var error = Assert.Throws<GuaScreenshotException>(() =>
+                remote.CaptureScreenshot(TimeSpan.FromMilliseconds(30), afterFrameSequence: 1));
+            Assert.That(error!.Error, Is.EqualTo(GuaScreenshotError.Timeout));
+        }
+        finally
+        {
+            Native.gua_runtime_stop_inspector_bridge(runtime);
+            Native.gua_runtime_destroy(runtime);
+        }
+    }
+
     private static int ReservePort()
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
+++ b/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
@@ -10,6 +10,7 @@ public sealed class GuaGodotRuntime : IDisposable
     private readonly Dictionary<string, BaseButton> _buttonsById = new(StringComparer.Ordinal);
     private readonly HashSet<ulong> _connectedButtons = new();
     private readonly HashSet<string> _suppressedButtonSignals = new(StringComparer.Ordinal);
+    private bool _screenshotCaptureRunning;
 
     public GuaGodotRuntime()
     {
@@ -109,6 +110,7 @@ public sealed class GuaGodotRuntime : IDisposable
         CollectControl(_attachedRoot, _attachedRoot);
         EndFrame();
         DispatchClickRequests();
+        ScheduleScreenshotCapture();
     }
 
     public bool EnqueueClick(string id)
@@ -246,6 +248,50 @@ public sealed class GuaGodotRuntime : IDisposable
                 _suppressedButtonSignals.Add(id);
                 button.EmitSignal(BaseButton.SignalName.Pressed);
             }
+        }
+    }
+
+    private void ScheduleScreenshotCapture()
+    {
+        if (_screenshotCaptureRunning || _attachedRoot is null) return;
+        var request = new GuaRuntimeNative.ScreenshotRequest
+        {
+            StructSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<GuaRuntimeNative.ScreenshotRequest>()
+        };
+        if (GuaRuntimeNative.gua_runtime_consume_screenshot_request(_runtime, ref request) == 0) return;
+        if (DisplayServer.GetName() == "headless")
+        {
+            GuaRuntimeNative.gua_runtime_complete_screenshot_request(_runtime, request.RequestId, -1, string.Empty, 0, 0);
+            return;
+        }
+        _screenshotCaptureRunning = true;
+        CaptureScreenshotAfterDrawAsync(request.RequestId);
+    }
+
+    private async void CaptureScreenshotAfterDrawAsync(ulong requestId)
+    {
+        try
+        {
+            if (DisplayServer.GetName() == "headless")
+            {
+                GuaRuntimeNative.gua_runtime_complete_screenshot_request(_runtime, requestId, -1, string.Empty, 0, 0);
+                return;
+            }
+            await _attachedRoot!.ToSignal(RenderingServer.Singleton, RenderingServer.SignalName.FramePostDraw);
+            using var image = _attachedRoot.GetViewport().GetTexture().GetImage();
+            if (image is null || image.IsEmpty())
+            {
+                GuaRuntimeNative.gua_runtime_complete_screenshot_request(_runtime, requestId, -2, string.Empty, 0, 0);
+                return;
+            }
+            var png = image.SavePngToBuffer();
+            var uri = "data:image/png;base64," + Convert.ToBase64String(png);
+            GuaRuntimeNative.gua_runtime_complete_screenshot_request(_runtime, requestId, 1, uri, image.GetWidth(), image.GetHeight());
+        }
+        finally
+        {
+            _screenshotCaptureRunning = false;
+            ScheduleScreenshotCapture();
         }
     }
 

--- a/examples/dotnet-godot/addons/gua/GuaRuntimeNative.cs
+++ b/examples/dotnet-godot/addons/gua/GuaRuntimeNative.cs
@@ -14,6 +14,15 @@ internal static class GuaRuntimeNative
         public fixed byte NodeId[NodeIdBufferSize];
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ScreenshotRequest
+    {
+        public uint StructSize;
+        public ulong RequestId;
+        public ulong SessionEpoch;
+        public ulong AfterFrameSequence;
+    }
+
     static GuaRuntimeNative()
     {
         NativeLibrary.SetDllImportResolver(typeof(GuaRuntimeNative).Assembly, ResolveRuntimeLibrary);
@@ -122,6 +131,13 @@ internal static class GuaRuntimeNative
 
     [DllImport("gua_runtime")]
     internal static unsafe extern int gua_runtime_poll_event(nint runtime, NativeEvent* outEvent);
+
+    [DllImport("gua_runtime")]
+    internal static extern int gua_runtime_consume_screenshot_request(nint runtime, ref ScreenshotRequest request);
+
+    [DllImport("gua_runtime")]
+    internal static extern int gua_runtime_complete_screenshot_request(
+        nint runtime, ulong requestId, int result, [MarshalAs(UnmanagedType.LPUTF8Str)] string dataUri, int width, int height);
 
     [DllImport("gua_runtime")]
     internal static extern int gua_runtime_start_inspector_bridge(nint runtime, int port);

--- a/examples/godot-gdscript/README.md
+++ b/examples/godot-gdscript/README.md
@@ -6,7 +6,9 @@ This sample uses the Gua Godot GDExtension from GDScript.
 
 `GuaAutoAdapter.capture_viewport_screenshot()` reads the current viewport after a
 rendered frame, encodes it as PNG, and publishes it through the existing Gua
-screenshot payload. It is never called automatically. The headless smoke covers
+screenshot payload. It is never called automatically by polling. An explicit
+`capture_screenshot` bridge request schedules one readback after the next drawn
+frame; concurrent pending requests share that readback. The headless smoke covers
 button, text input, checkbox, and select semantics plus PNG capture; managed
 `Gua.Testing.Visual` tests own baseline compare and recording/replay policy.
 Because Godot's dummy headless renderer has no viewport texture, the smoke injects

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -14,6 +14,8 @@ const REQUIRED_CONTEXT_METHODS := [
 	"get_ui_tree_json",
 	"set_screenshot",
 	"get_screenshot_json",
+	"consume_screenshot_request",
+	"complete_screenshot_request",
 	"enqueue_click",
 	"consume_click_request",
 	"emit_click",
@@ -38,6 +40,7 @@ var connected_buttons: Dictionary = {}
 var suppressed_clicks: Dictionary = {}
 var gdextension_resource: Resource
 var unavailable := false
+var screenshot_capture_scheduled := false
 
 
 func attach(root_control: Control) -> void:
@@ -62,6 +65,7 @@ func update(screen: String) -> void:
 	context.end_frame()
 	_dispatch_click_requests()
 	_dispatch_action_requests()
+	_schedule_screenshot_capture()
 
 
 func capture_viewport_screenshot(image_override: Image = null) -> Dictionary:
@@ -75,6 +79,45 @@ func capture_viewport_screenshot(image_override: Image = null) -> Dictionary:
 	var png := image.save_png_to_buffer()
 	context.set_screenshot("data:image/png;base64," + Marshalls.raw_to_base64(png), image.get_width(), image.get_height())
 	return {"ok": true, "width": image.get_width(), "height": image.get_height()}
+
+
+func _schedule_screenshot_capture() -> void:
+	if screenshot_capture_scheduled:
+		return
+	var request: Dictionary = context.consume_screenshot_request()
+	if request.is_empty():
+		return
+	if DisplayServer.get_name() == "headless":
+		context.complete_screenshot_request({"request_id": request.get("request_id", 0), "unavailable": "headless"})
+		return
+	screenshot_capture_scheduled = true
+	_capture_requested_screenshot.call_deferred(request)
+
+
+func _capture_requested_screenshot(request: Dictionary) -> void:
+	while context.get_context_status().get("session_epoch", 0) == request.get("session_epoch", 0) and context.get_context_status().get("frame_sequence", 0) <= request.get("after_frame_sequence", 0):
+		await root.get_tree().process_frame
+	if context.get_context_status().get("session_epoch", 0) != request.get("session_epoch", 0):
+		context.complete_screenshot_request({"request_id": request.get("request_id", 0), "unavailable": "unsupported"})
+		screenshot_capture_scheduled = false
+		_schedule_screenshot_capture()
+		return
+	await RenderingServer.frame_post_draw
+	var result := {"request_id": request.get("request_id", 0)}
+	if DisplayServer.get_name() == "headless":
+		result["unavailable"] = "headless"
+	else:
+		var image := root.get_viewport().get_texture().get_image() if root != null else null
+		if image == null or image.is_empty():
+			result["unavailable"] = "rendering_disabled"
+		else:
+			var png := image.save_png_to_buffer()
+			result["data_uri"] = "data:image/png;base64," + Marshalls.raw_to_base64(png)
+			result["width"] = image.get_width()
+			result["height"] = image.get_height()
+	context.complete_screenshot_request(result)
+	screenshot_capture_scheduled = false
+	_schedule_screenshot_capture()
 
 
 func start_inspector_bridge(port: int = 8765) -> bool:

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -31,7 +31,7 @@ std::string build_version_json(const char* godot_plugin_version = nullptr)
     return "{\"protocolSchemaVersion\":\"2\",\"coreVersion\":\"" GUA_VERSION
         "\",\"runtimeVersion\":\"" GUA_VERSION "\",\"godotPluginVersion\":" + plugin +
         ",\"abiVersion\":1,\"buildId\":\"" GUA_BUILD_ID
-        "\",\"capabilities\":[\"semantic_ui_tree_v2\",\"semantic_actions_v2\",\"context_reset_v1\",\"diagnostics_v1\",\"version_v1\"]}";
+        "\",\"capabilities\":[\"semantic_ui_tree_v2\",\"semantic_actions_v2\",\"context_reset_v1\",\"diagnostics_v1\",\"version_v1\",\"capture_screenshot_v1\"]}";
 }
 
 struct Node {

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -31,6 +31,8 @@ public:
     String get_version_json() const;
     void set_screenshot(const String& data_uri, int width, int height);
     String get_screenshot_json() const;
+    Dictionary consume_screenshot_request();
+    bool complete_screenshot_request(const Dictionary& result);
     bool enqueue_click(const String& node_id);
     bool consume_click_request(const String& node_id);
     bool emit_click(const String& node_id);

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -109,6 +109,30 @@ String GuaContext::get_screenshot_json() const
     return copy_runtime_json(runtime_, gua_runtime_copy_screenshot_json);
 }
 
+Dictionary GuaContext::consume_screenshot_request()
+{
+    gua_screenshot_request_t request { sizeof(gua_screenshot_request_t) };
+    if (gua_runtime_consume_screenshot_request(runtime_, &request) == 0) return Dictionary();
+    Dictionary result;
+    result["request_id"] = request.request_id;
+    result["session_epoch"] = request.session_epoch;
+    result["after_frame_sequence"] = request.after_frame_sequence;
+    return result;
+}
+
+bool GuaContext::complete_screenshot_request(const Dictionary& source)
+{
+    const String data_uri = source.get("data_uri", String());
+    const CharString utf8 = data_uri.utf8();
+    int result = GUA_SCREENSHOT_AVAILABLE;
+    const String unavailable = source.get("unavailable", String());
+    if (unavailable == "headless") result = GUA_SCREENSHOT_UNAVAILABLE_HEADLESS;
+    else if (unavailable == "rendering_disabled") result = GUA_SCREENSHOT_UNAVAILABLE_RENDERING_DISABLED;
+    else if (unavailable == "unsupported") result = GUA_SCREENSHOT_UNAVAILABLE_UNSUPPORTED;
+    return gua_runtime_complete_screenshot_request(
+        runtime_, source.get("request_id", 0), result, utf8.get_data(), source.get("width", 0), source.get("height", 0)) != 0;
+}
+
 void GuaContext::register_node(
     const String& id,
     const String& role,
@@ -398,6 +422,8 @@ void GuaContext::_bind_methods()
     ClassDB::bind_method(D_METHOD("get_version_json"), &GuaContext::get_version_json);
     ClassDB::bind_method(D_METHOD("set_screenshot", "data_uri", "width", "height"), &GuaContext::set_screenshot);
     ClassDB::bind_method(D_METHOD("get_screenshot_json"), &GuaContext::get_screenshot_json);
+    ClassDB::bind_method(D_METHOD("consume_screenshot_request"), &GuaContext::consume_screenshot_request);
+    ClassDB::bind_method(D_METHOD("complete_screenshot_request", "result"), &GuaContext::complete_screenshot_request);
     ClassDB::bind_method(D_METHOD("enqueue_click", "node_id"), &GuaContext::enqueue_click);
     ClassDB::bind_method(D_METHOD("consume_click_request", "node_id"), &GuaContext::consume_click_request);
     ClassDB::bind_method(D_METHOD("emit_click", "node_id"), &GuaContext::emit_click);

--- a/native/gua-runtime/CMakeLists.txt
+++ b/native/gua-runtime/CMakeLists.txt
@@ -40,6 +40,13 @@ else()
     )
 endif()
 
+if(BUILD_TESTING)
+    add_executable(gua-runtime-screenshot-tests tests/screenshot_request_tests.cpp)
+    target_link_libraries(gua-runtime-screenshot-tests PRIVATE gua-runtime)
+    target_compile_features(gua-runtime-screenshot-tests PRIVATE cxx_std_20)
+    add_test(NAME gua-runtime-screenshot-tests COMMAND gua-runtime-screenshot-tests)
+endif()
+
 if(WIN32)
     add_custom_command(TARGET gua-runtime POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -8,6 +8,21 @@ extern "C" {
 
 typedef struct gua_runtime_t gua_runtime_t;
 
+enum {
+    GUA_SCREENSHOT_AVAILABLE = 1,
+    GUA_SCREENSHOT_UNAVAILABLE_HEADLESS = -1,
+    GUA_SCREENSHOT_UNAVAILABLE_RENDERING_DISABLED = -2,
+    GUA_SCREENSHOT_UNAVAILABLE_UNSUPPORTED = -3,
+    GUA_SCREENSHOT_UNAVAILABLE_STALE_SESSION = -4
+};
+
+typedef struct gua_screenshot_request_t {
+    uint32_t struct_size;
+    uint64_t request_id;
+    uint64_t session_epoch;
+    uint64_t after_frame_sequence;
+} gua_screenshot_request_t;
+
 gua_runtime_t* gua_runtime_create(void);
 void gua_runtime_destroy(gua_runtime_t* runtime);
 
@@ -35,6 +50,11 @@ void gua_runtime_set_screenshot(gua_runtime_t* runtime, const char* data_uri, in
 const char* gua_runtime_get_screenshot_json(gua_runtime_t* runtime);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
 int gua_runtime_copy_screenshot_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
+int gua_runtime_enqueue_screenshot_request(gua_runtime_t* runtime, uint64_t after_frame_sequence, uint64_t* out_request_id);
+int gua_runtime_consume_screenshot_request(gua_runtime_t* runtime, gua_screenshot_request_t* out_request);
+int gua_runtime_complete_screenshot_request(gua_runtime_t* runtime, uint64_t request_id, int result, const char* data_uri, int width, int height);
+int gua_runtime_poll_screenshot_result_json(gua_runtime_t* runtime, uint64_t request_id, char* out_json, int out_json_size);
+int gua_runtime_cancel_screenshot_request(gua_runtime_t* runtime, uint64_t request_id);
 int gua_runtime_set_diagnostics_history_limit(gua_runtime_t* runtime, uint32_t history_limit);
 int gua_runtime_set_diagnostics_environment_json(gua_runtime_t* runtime, const char* environment_json);
 const char* gua_runtime_get_diagnostics_json(gua_runtime_t* runtime);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -3,6 +3,11 @@
 #include "gua/ws_bridge.hpp"
 
 #include <cstdio>
+#include <chrono>
+#include <deque>
+#include <thread>
+#include <unordered_map>
+#include <vector>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -21,6 +26,10 @@ struct gua_runtime_t {
     std::string screenshot_json;
     std::string diagnostics_json;
     std::string godot_plugin_version;
+    uint64_t next_screenshot_request_id = 1;
+    std::deque<gua_screenshot_request_t> screenshot_requests;
+    std::unordered_map<uint64_t, std::vector<uint64_t>> screenshot_batches;
+    std::unordered_map<uint64_t, std::string> screenshot_results;
 };
 
 std::string escape_json(std::string_view value);
@@ -57,6 +66,14 @@ std::string copy_screenshot_json(gua_runtime_t* runtime)
 {
     const std::lock_guard lock(runtime->context_mutex);
     return gua_get_screenshot_json(runtime->context);
+}
+
+const char* screenshot_unavailable_name(int result)
+{
+    if (result == GUA_SCREENSHOT_UNAVAILABLE_HEADLESS) return "headless";
+    if (result == GUA_SCREENSHOT_UNAVAILABLE_RENDERING_DISABLED) return "rendering_disabled";
+    if (result == GUA_SCREENSHOT_UNAVAILABLE_STALE_SESSION) return "stale_session";
+    return "unsupported";
 }
 
 std::string copy_diagnostics_json(gua_runtime_t* runtime)
@@ -287,6 +304,104 @@ extern "C" int gua_runtime_copy_screenshot_json(gua_runtime_t* runtime, char* ou
     }
 
     return copy_json_string(copy_screenshot_json(runtime), out_json, out_json_size);
+}
+
+extern "C" int gua_runtime_enqueue_screenshot_request(gua_runtime_t* runtime, uint64_t after_frame_sequence, uint64_t* out_request_id)
+{
+    if (!valid_runtime(runtime) || out_request_id == nullptr) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    gua_context_status_t status { sizeof(gua_context_status_t) };
+    if (gua_get_context_status(runtime->context, &status) == 0) return 0;
+    const uint64_t id = runtime->next_screenshot_request_id++;
+    runtime->screenshot_requests.push_back({ sizeof(gua_screenshot_request_t), id, status.session_epoch, after_frame_sequence });
+    *out_request_id = id;
+    return 1;
+}
+
+extern "C" int gua_runtime_consume_screenshot_request(gua_runtime_t* runtime, gua_screenshot_request_t* out_request)
+{
+    if (!valid_runtime(runtime) || out_request == nullptr || out_request->struct_size < sizeof(gua_screenshot_request_t)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    gua_context_status_t status { sizeof(gua_context_status_t) };
+    gua_get_context_status(runtime->context, &status);
+    while (!runtime->screenshot_requests.empty() && runtime->screenshot_requests.front().session_epoch != status.session_epoch) {
+        const auto stale = runtime->screenshot_requests.front();
+        runtime->screenshot_requests.pop_front();
+        runtime->screenshot_results[stale.request_id] = "{\"requestId\":" + std::to_string(stale.request_id) +
+            ",\"sessionEpoch\":" + std::to_string(status.session_epoch) +
+            ",\"frameSequence\":" + std::to_string(status.frame_sequence) + ",\"unavailable\":\"stale_session\"}";
+    }
+    if (runtime->screenshot_requests.empty()) return 0;
+    auto first = runtime->screenshot_requests.front();
+    std::vector<uint64_t> batch;
+    uint64_t after = first.after_frame_sequence;
+    while (!runtime->screenshot_requests.empty() && runtime->screenshot_requests.front().session_epoch == first.session_epoch) {
+        batch.push_back(runtime->screenshot_requests.front().request_id);
+        after = std::max(after, runtime->screenshot_requests.front().after_frame_sequence);
+        runtime->screenshot_requests.pop_front();
+    }
+    first.after_frame_sequence = after;
+    runtime->screenshot_batches[first.request_id] = std::move(batch);
+    *out_request = first;
+    return 1;
+}
+
+extern "C" int gua_runtime_complete_screenshot_request(gua_runtime_t* runtime, uint64_t request_id, int result, const char* data_uri, int width, int height)
+{
+    if (!valid_runtime(runtime) || request_id == 0) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    const auto batch = runtime->screenshot_batches.find(request_id);
+    if (batch == runtime->screenshot_batches.end()) return 0;
+    gua_context_status_t status { sizeof(gua_context_status_t) };
+    gua_get_context_status(runtime->context, &status);
+    if (result == GUA_SCREENSHOT_AVAILABLE) gua_set_screenshot(runtime->context, data_uri, width, height);
+    for (const auto id : batch->second) {
+        if (result == GUA_SCREENSHOT_AVAILABLE) {
+            runtime->screenshot_results[id] = "{\"requestId\":" + std::to_string(id) +
+                ",\"sessionEpoch\":" + std::to_string(status.session_epoch) +
+                ",\"frameSequence\":" + std::to_string(status.frame_sequence) +
+                ",\"width\":" + std::to_string(std::max(0, width)) + ",\"height\":" + std::to_string(std::max(0, height)) +
+                ",\"dataUri\":\"" + escape_json(data_uri == nullptr ? "" : data_uri) + "\"}";
+        } else {
+            runtime->screenshot_results[id] = "{\"requestId\":" + std::to_string(id) +
+                ",\"sessionEpoch\":" + std::to_string(status.session_epoch) +
+                ",\"frameSequence\":" + std::to_string(status.frame_sequence) +
+                ",\"unavailable\":\"" + screenshot_unavailable_name(result) + "\"}";
+        }
+    }
+    runtime->screenshot_batches.erase(batch);
+    return 1;
+}
+
+extern "C" int gua_runtime_poll_screenshot_result_json(gua_runtime_t* runtime, uint64_t request_id, char* out_json, int out_json_size)
+{
+    if (!valid_runtime(runtime) || request_id == 0) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    const auto found = runtime->screenshot_results.find(request_id);
+    if (found == runtime->screenshot_results.end()) return 0;
+    const int size = copy_json_string(found->second, out_json, out_json_size);
+    if (out_json != nullptr && out_json_size >= size) runtime->screenshot_results.erase(found);
+    return size;
+}
+
+extern "C" int gua_runtime_cancel_screenshot_request(gua_runtime_t* runtime, uint64_t request_id)
+{
+    if (!valid_runtime(runtime) || request_id == 0) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    bool removed = runtime->screenshot_results.erase(request_id) != 0;
+    const auto before = runtime->screenshot_requests.size();
+    runtime->screenshot_requests.erase(
+        std::remove_if(runtime->screenshot_requests.begin(), runtime->screenshot_requests.end(),
+            [request_id](const auto& request) { return request.request_id == request_id; }),
+        runtime->screenshot_requests.end());
+    removed = removed || before != runtime->screenshot_requests.size();
+    for (auto& [leader, batch] : runtime->screenshot_batches) {
+        (void)leader;
+        const auto batch_before = batch.size();
+        batch.erase(std::remove(batch.begin(), batch.end(), request_id), batch.end());
+        removed = removed || batch_before != batch.size();
+    }
+    return removed ? 1 : 0;
 }
 
 extern "C" int gua_runtime_set_diagnostics_history_limit(gua_runtime_t* runtime, uint32_t history_limit)
@@ -526,6 +641,26 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
         },
         .get_screenshot_json = [runtime] {
             return copy_screenshot_json(runtime);
+        },
+        .capture_screenshot = [runtime](unsigned long long after_frame_sequence, unsigned int timeout_ms) {
+            uint64_t request_id = 0;
+            if (gua_runtime_enqueue_screenshot_request(runtime, after_frame_sequence, &request_id) == 0)
+                return gua::ws::CommandResult { false, {}, "capture_screenshot request could not be queued" };
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms == 0 ? 1 : timeout_ms);
+            while (std::chrono::steady_clock::now() < deadline) {
+                const int size = gua_runtime_poll_screenshot_result_json(runtime, request_id, nullptr, 0);
+                if (size > 0) {
+                    std::string json(static_cast<std::size_t>(size), '\0');
+                    gua_runtime_poll_screenshot_result_json(runtime, request_id, json.data(), size);
+                    json.resize(static_cast<std::size_t>(size - 1));
+                    if (json.find("\"unavailable\"") != std::string::npos)
+                        return gua::ws::CommandResult { false, {}, json };
+                    return gua::ws::CommandResult { true, std::move(json), {} };
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            }
+            gua_runtime_cancel_screenshot_request(runtime, request_id);
+            return gua::ws::CommandResult { false, {}, "capture_screenshot timed out" };
         },
         .get_diagnostics_json = [runtime] {
             return copy_diagnostics_json(runtime);

--- a/native/gua-runtime/tests/screenshot_request_tests.cpp
+++ b/native/gua-runtime/tests/screenshot_request_tests.cpp
@@ -1,0 +1,67 @@
+#include "gua/runtime.h"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string poll(gua_runtime_t* runtime, uint64_t request_id)
+{
+    const int size = gua_runtime_poll_screenshot_result_json(runtime, request_id, nullptr, 0);
+    if (size == 0) return {};
+    std::vector<char> buffer(static_cast<std::size_t>(size));
+    assert(gua_runtime_poll_screenshot_result_json(runtime, request_id, buffer.data(), size) == size);
+    return buffer.data();
+}
+
+} // namespace
+
+int main()
+{
+    gua_runtime_t* runtime = gua_runtime_create();
+    assert(runtime != nullptr);
+    gua_runtime_begin_frame(runtime, "title");
+    gua_runtime_end_frame(runtime);
+
+    uint64_t first = 0;
+    uint64_t second = 0;
+    assert(gua_runtime_enqueue_screenshot_request(runtime, 1, &first) == 1);
+    assert(gua_runtime_enqueue_screenshot_request(runtime, 3, &second) == 1);
+    assert(first != second);
+    assert(poll(runtime, first).empty());
+
+    gua_screenshot_request_t request { sizeof(gua_screenshot_request_t) };
+    assert(gua_runtime_consume_screenshot_request(runtime, &request) == 1);
+    assert(request.request_id == first);
+    assert(request.session_epoch == 1);
+    assert(request.after_frame_sequence == 3);
+    assert(gua_runtime_consume_screenshot_request(runtime, &request) == 0);
+
+    gua_runtime_begin_frame(runtime, "title");
+    gua_runtime_end_frame(runtime);
+    assert(gua_runtime_complete_screenshot_request(
+        runtime, first, GUA_SCREENSHOT_AVAILABLE, "data:image/png;base64,iVBORw0KGgo=", 2, 3) == 1);
+    const std::string first_json = poll(runtime, first);
+    const std::string second_json = poll(runtime, second);
+    assert(first_json.find("\"requestId\":" + std::to_string(first)) != std::string::npos);
+    assert(second_json.find("\"requestId\":" + std::to_string(second)) != std::string::npos);
+    assert(first_json.find("\"frameSequence\":2") != std::string::npos);
+    assert(first_json.find("\"width\":2,\"height\":3") != std::string::npos);
+
+    uint64_t unavailable = 0;
+    assert(gua_runtime_enqueue_screenshot_request(runtime, 2, &unavailable) == 1);
+    request = { sizeof(gua_screenshot_request_t) };
+    assert(gua_runtime_consume_screenshot_request(runtime, &request) == 1);
+    assert(gua_runtime_complete_screenshot_request(runtime, request.request_id, GUA_SCREENSHOT_UNAVAILABLE_HEADLESS, nullptr, 0, 0) == 1);
+    assert(poll(runtime, unavailable).find("\"unavailable\":\"headless\"") != std::string::npos);
+
+    uint64_t cancelled = 0;
+    assert(gua_runtime_enqueue_screenshot_request(runtime, 2, &cancelled) == 1);
+    assert(gua_runtime_cancel_screenshot_request(runtime, cancelled) == 1);
+    request = { sizeof(gua_screenshot_request_t) };
+    assert(gua_runtime_consume_screenshot_request(runtime, &request) == 0);
+
+    gua_runtime_destroy(runtime);
+    return 0;
+}

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -35,10 +35,17 @@ struct ActionCommand {
     int scroll_unit = 0;
 };
 
+struct CommandResult {
+    bool ok = false;
+    std::string json;
+    std::string error;
+};
+
 struct BridgeHandlers {
     std::function<std::string()> get_ui_tree_json;
     std::function<std::string()> get_logs_json;
     std::function<std::string()> get_screenshot_json;
+    std::function<CommandResult(unsigned long long after_frame_sequence, unsigned int timeout_ms)> capture_screenshot;
     std::function<std::string()> get_diagnostics_json;
     std::function<std::string()> get_version_json;
     std::function<std::string(const QuerySelector& selector)> query_nodes_json;

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -40,6 +40,8 @@ struct Command {
     int scroll_unit = 0;
     unsigned long long request_id = 0;
     unsigned long long expected_session_epoch = 0;
+    unsigned long long after_frame_sequence = 0;
+    unsigned int timeout_ms = 10000;
     unsigned int reset_flags = 15;
     bool strict = false;
 };
@@ -616,6 +618,8 @@ Command parse_command(std::string_view json)
     command.scroll_unit = json_int_field(json, "scrollUnit").value_or(0);
     command.request_id = json_uint64_field(json, "requestId").value_or(0);
     command.expected_session_epoch = json_uint64_field(json, "expectedSessionEpoch").value_or(0);
+    command.after_frame_sequence = json_uint64_field(json, "afterFrameSequence").value_or(0);
+    command.timeout_ms = static_cast<unsigned int>(std::clamp(json_int_field(json, "timeoutMs").value_or(10000), 1, 300000));
     command.reset_flags = static_cast<unsigned int>(json_int_field(json, "flags").value_or(15));
     command.strict = json_bool_field(json, "strict");
     return command;
@@ -915,6 +919,11 @@ private:
             }
             if (command.type == "get_screenshot") {
                 return ok_response(command.id, handlers_.get_screenshot_json());
+            }
+            if (command.type == "capture_screenshot") {
+                if (!handlers_.capture_screenshot) return error_response(command.id, "capture_screenshot is not supported by this bridge");
+                const auto result = handlers_.capture_screenshot(command.after_frame_sequence, command.timeout_ms);
+                return result.ok ? ok_response(command.id, result.json) : error_response(command.id, result.error);
             }
             if (command.type == "get_diagnostics") {
                 return handlers_.get_diagnostics_json

--- a/protocol/fixtures/capture-screenshot-command-v1.json
+++ b/protocol/fixtures/capture-screenshot-command-v1.json
@@ -1,0 +1,5 @@
+{
+  "type": "capture_screenshot",
+  "afterFrameSequence": 17,
+  "timeoutMs": 10000
+}

--- a/protocol/fixtures/screenshot-capture-v1.json
+++ b/protocol/fixtures/screenshot-capture-v1.json
@@ -1,0 +1,8 @@
+{
+  "requestId": 42,
+  "sessionEpoch": 3,
+  "frameSequence": 18,
+  "dataUri": "data:image/png;base64,iVBORw0KGgo=",
+  "width": 1280,
+  "height": 720
+}

--- a/protocol/fixtures/version-v1.json
+++ b/protocol/fixtures/version-v1.json
@@ -5,5 +5,5 @@
   "godotPluginVersion": null,
   "abiVersion": 1,
   "buildId": "development",
-  "capabilities": ["semantic_ui_tree_v2", "semantic_actions_v2", "context_reset_v1", "diagnostics_v1", "version_v1"]
+  "capabilities": ["semantic_ui_tree_v2", "semantic_actions_v2", "context_reset_v1", "diagnostics_v1", "version_v1", "capture_screenshot_v1"]
 }

--- a/protocol/schema/commands.schema.json
+++ b/protocol/schema/commands.schema.json
@@ -11,6 +11,7 @@
     { "$ref": "#/$defs/selectAction" },
     { "$ref": "#/$defs/scrollAction" },
     { "$ref": "#/$defs/resetContext" },
+    { "$ref": "#/$defs/captureScreenshot" },
     { "$ref": "#/$defs/textInput" },
     { "$ref": "#/$defs/moveGamepad" },
     { "$ref": "#/$defs/simpleCommand" }
@@ -105,6 +106,16 @@
         "expectedSessionEpoch": { "type": "integer", "minimum": 1 },
         "flags": { "type": "integer", "minimum": 0, "maximum": 63, "default": 15 },
         "strict": { "type": "boolean", "default": false }
+      }
+    },
+    "captureScreenshot": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "capture_screenshot" },
+        "afterFrameSequence": { "type": ["integer", "null"], "minimum": 0 },
+        "timeoutMs": { "type": "integer", "minimum": 1 }
       }
     },
     "textInput": {

--- a/protocol/schema/screenshot-capture.schema.json
+++ b/protocol/schema/screenshot-capture.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gua.dev/schema/screenshot-capture.schema.json",
+  "title": "Gua On-demand Screenshot Result",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": ["requestId", "sessionEpoch", "frameSequence", "dataUri", "width", "height"],
+      "additionalProperties": false,
+      "properties": {
+        "requestId": { "type": "integer", "minimum": 1 },
+        "sessionEpoch": { "type": "integer", "minimum": 1 },
+        "frameSequence": { "type": "integer", "minimum": 0 },
+        "dataUri": { "type": "string", "pattern": "^data:image/png;base64," },
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["requestId", "sessionEpoch", "frameSequence", "unavailable"],
+      "additionalProperties": false,
+      "properties": {
+        "requestId": { "type": "integer", "minimum": 1 },
+        "sessionEpoch": { "type": "integer", "minimum": 1 },
+        "frameSequence": { "type": "integer", "minimum": 0 },
+        "unavailable": {
+          "type": "string",
+          "enum": ["headless", "rendering_disabled", "unsupported", "stale_session"]
+        }
+      }
+    }
+  ]
+}

--- a/protocol/schema/screenshot.schema.json
+++ b/protocol/schema/screenshot.schema.json
@@ -16,6 +16,18 @@
     "height": {
       "type": "integer",
       "minimum": 0
+    },
+    "requestId": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "sessionEpoch": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "frameSequence": {
+      "type": "integer",
+      "minimum": 0
     }
   }
 }

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -167,6 +167,15 @@ The screenshot payload stores an already encoded `dataUri` plus `width` and
 `height`. This keeps the C ABI small and avoids forcing the core protocol to own
 PNG encoding, GPU readback, or platform-specific capture code.
 
+`capture_screenshot` is explicit and on demand. The runtime queues and correlates
+requests while the adapter owns viewport readback and PNG encoding on the next
+drawable frame. Concurrent pending requests are coalesced into one capture and
+receive the same image with distinct request IDs. Results include `sessionEpoch`
+and `frameSequence`; `headless`, `rendering_disabled`, and `unsupported` are
+distinct unavailable errors defined by `screenshot-capture.schema.json`; a reset
+while queued produces `stale_session`. `get_screenshot` remains the latest-published-image
+compatibility API. Screenshots can contain rendered secrets and are not redacted.
+
 ## Visual comparison and operation recording v1
 
 Visual comparison is an opt-in consumer of the existing PNG screenshot payload;
@@ -210,6 +219,7 @@ Key modifiers use a transport-neutral bit mask: Shift is `1`, Alt is `2`, Contro
 - `move_gamepad`
 - `wait_for_node`
 - `get_screenshot`
+- `capture_screenshot` with optional `afterFrameSequence`
 - `get_logs`
 - `get_diagnostics`
 - `get_version`


### PR DESCRIPTION
## 対応 Issue

Closes #46

## 実装内容

- `capture_screenshot` command、成功/unavailable schema、fixture、`capture_screenshot_v1` capability を追加
- runtime C ABI に request queue、request ID、session/frame相関、coalesce、完了・cancel APIを追加
- WebSocket bridge が timeout付きで要求完了を待ち、`get_screenshot` のlatest-image互換性を維持
- Godot GDScript/GDExtension と C# adapter が次の描画可能frameで1回だけviewportをPNG化
- `GodotSceneTestHost.CaptureScreenshotAsync` と型付き `GuaScreenshot` を追加
- headless / rendering_disabled / unsupported / stale_session / timeout / cancellation を区別

## Architecture判断

PNG encodeとGPU readbackはadapter所有とし、protocol/runtime coreは要求キューと相関metadataだけを担当する。複数の未処理要求は1回のcaptureへまとめるが、各clientには固有request IDを返す。`afterFrameSequence`はsession epochと組み合わせ、reset後の要求をstaleとして拒否する。既存`get_screenshot`、既存ABI export、visual comparison APIは変更していない。

## テスト・検証

- `cmake --preset windows-msvc-debug` 成功
- `cmake --build --preset windows-msvc-debug` 成功
- `ctest --test-dir build/windows-msvc-debug -C Debug --output-on-failure` 3/3成功
- `dotnet test bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj` 7/7成功
- `dotnet test bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/Gua.Godot.Visual.Integration.Tests.csproj` Godot 4.7実renderer 5/5成功
- Godot 4.7 headless GDScript smoke成功
- `bun run check` 3 workspace成功
- `uvx check-jsonschema` command/screenshot/version fixture成功
- `git diff --check` 成功

## 未対応事項

Issue #46 範囲内の未対応はない。画像比較/baseline管理、screenshot自動redaction、diagnostics session統合、常時captureは範囲外のため変更していない。screenshotは描画済みsecretを含み得るため、保存・添付責任は利用側にある。