### PR TITLE
#47 action後の詳細semantic stateを公開する

### DIFF
--- a/bindings/dotnet/src/Gua.Core/GuaAction.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaAction.cs
@@ -42,4 +42,7 @@ public readonly record struct GuaActionEvent(
     GuaActionError Error,
     string NodeId,
     string Value,
-    bool Sensitive);
+    bool Sensitive,
+    ulong? SessionEpoch = null,
+    ulong? FrameSequence = null,
+    ulong? Revision = null);

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -72,6 +72,14 @@ public sealed class GuaContext : IGuaContext, IDisposable
         if (descriptor.Pressed.HasValue) known |= GuaNodeKnownState.Pressed;
         if (descriptor.Checked.HasValue) known |= GuaNodeKnownState.Checked;
         if (descriptor.Selected.HasValue) known |= GuaNodeKnownState.Selected;
+        if (descriptor.CaretPosition.HasValue) known |= GuaNodeKnownState.CaretPosition;
+        if (descriptor.SelectionStart.HasValue && descriptor.SelectionEnd.HasValue) known |= GuaNodeKnownState.Selection;
+        if (descriptor.ScrollX.HasValue && descriptor.ScrollY.HasValue) known |= GuaNodeKnownState.Scroll;
+        if (descriptor.ScrollMaxX.HasValue && descriptor.ScrollMaxY.HasValue) known |= GuaNodeKnownState.ScrollMax;
+        if (descriptor.RangeValue.HasValue) known |= GuaNodeKnownState.RangeValue;
+        if (descriptor.RangeMin.HasValue) known |= GuaNodeKnownState.RangeMin;
+        if (descriptor.RangeMax.HasValue) known |= GuaNodeKnownState.RangeMax;
+        if (descriptor.SelectedIndex.HasValue) known |= GuaNodeKnownState.SelectedIndex;
 
         var strings = new[] { descriptor.Id, descriptor.ParentId, descriptor.Role, descriptor.Label, descriptor.Text, descriptor.Value };
         var pointers = strings.Select(value => value is null ? nint.Zero : System.Runtime.InteropServices.Marshal.StringToCoTaskMemUTF8(value)).ToArray();
@@ -96,7 +104,16 @@ public sealed class GuaContext : IGuaContext, IDisposable
                 Checked = descriptor.Checked == true ? 1 : 0,
                 Selected = descriptor.Selected == true ? 1 : 0,
             };
-            if (Native.gua_register_node_v2(_handle, in native) == 0)
+            var detailed = new Native.GuaNativeNodeDescriptorV3
+            {
+                StructSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<Native.GuaNativeNodeDescriptorV3>(),
+                Base = native,
+                CaretPosition = descriptor.CaretPosition ?? 0, SelectionStart = descriptor.SelectionStart ?? 0, SelectionEnd = descriptor.SelectionEnd ?? 0,
+                ScrollX = descriptor.ScrollX ?? 0, ScrollY = descriptor.ScrollY ?? 0, ScrollMaxX = descriptor.ScrollMaxX ?? 0, ScrollMaxY = descriptor.ScrollMaxY ?? 0,
+                RangeValue = descriptor.RangeValue ?? 0, RangeMin = descriptor.RangeMin ?? 0, RangeMax = descriptor.RangeMax ?? 0,
+                SelectedIndex = descriptor.SelectedIndex ?? -1,
+            };
+            if (Native.gua_register_node_v3(_handle, in detailed) == 0)
             {
                 throw new InvalidOperationException($"Failed to register Gua v2 node: {descriptor.Id}");
             }
@@ -394,26 +411,28 @@ public sealed class GuaContext : IGuaContext, IDisposable
         ThrowIfDisposed();
         unsafe
         {
-            Native.GuaNativeEventV2 nativeEvent = new()
+            Native.GuaNativeEventV3 nativeEvent = new()
             {
-                StructSize = (uint)sizeof(Native.GuaNativeEventV2),
+                StructSize = (uint)sizeof(Native.GuaNativeEventV3),
+                Base = new Native.GuaNativeEventV2 { StructSize = (uint)sizeof(Native.GuaNativeEventV2) },
             };
             var found = requestId.HasValue
-                ? Native.gua_poll_event_v2_for_request(_handle, requestId.Value, &nativeEvent)
-                : Native.gua_poll_event_v2(_handle, &nativeEvent);
+                ? Native.gua_poll_event_v3_for_request(_handle, requestId.Value, &nativeEvent)
+                : Native.gua_poll_event_v3(_handle, &nativeEvent);
             if (found == 0)
             {
                 e = default;
                 return false;
             }
             e = new GuaActionEvent(
-                nativeEvent.RequestId,
-                (GuaActionType)nativeEvent.Action,
-                nativeEvent.Status == 1,
-                (GuaActionError)nativeEvent.ErrorCode,
-                Marshal.PtrToStringUTF8((nint)nativeEvent.NodeId) ?? string.Empty,
-                Marshal.PtrToStringUTF8((nint)nativeEvent.Value) ?? string.Empty,
-                nativeEvent.Sensitive != 0);
+                nativeEvent.Base.RequestId,
+                (GuaActionType)nativeEvent.Base.Action,
+                nativeEvent.Base.Status == 1,
+                (GuaActionError)nativeEvent.Base.ErrorCode,
+                Marshal.PtrToStringUTF8((nint)nativeEvent.Base.NodeId) ?? string.Empty,
+                Marshal.PtrToStringUTF8((nint)nativeEvent.Base.Value) ?? string.Empty,
+                nativeEvent.Base.Sensitive != 0,
+                nativeEvent.SessionEpoch, nativeEvent.FrameSequence, nativeEvent.Revision);
             return true;
         }
     }

--- a/bindings/dotnet/src/Gua.Core/GuaNodeDescriptor.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaNodeDescriptor.cs
@@ -12,6 +12,14 @@ public enum GuaNodeKnownState : ulong
     Pressed = 1UL << 5,
     Checked = 1UL << 6,
     Selected = 1UL << 7,
+    CaretPosition = 1UL << 8,
+    Selection = 1UL << 9,
+    Scroll = 1UL << 10,
+    ScrollMax = 1UL << 11,
+    RangeValue = 1UL << 12,
+    RangeMin = 1UL << 13,
+    RangeMax = 1UL << 14,
+    SelectedIndex = 1UL << 15,
 }
 
 public sealed record GuaNodeDescriptor(
@@ -28,7 +36,10 @@ public sealed record GuaNodeDescriptor(
     bool? Hovered = null,
     bool? Pressed = null,
     bool? Checked = null,
-    bool? Selected = null);
+    bool? Selected = null,
+    long? CaretPosition = null, long? SelectionStart = null, long? SelectionEnd = null,
+    double? ScrollX = null, double? ScrollY = null, double? ScrollMaxX = null, double? ScrollMaxY = null,
+    double? RangeValue = null, double? RangeMin = null, double? RangeMax = null, long? SelectedIndex = null);
 
 public sealed record GuaNodeStateV2(
     GuaNodeKnownState KnownState,

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -146,6 +146,27 @@ internal static partial class Native
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct GuaNativeEventV3
+    {
+        public uint StructSize;
+        public GuaNativeEventV2 Base;
+        public ulong SessionEpoch;
+        public ulong FrameSequence;
+        public ulong Revision;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GuaNativeNodeDescriptorV3
+    {
+        public uint StructSize;
+        public GuaNativeNodeDescriptorV2 Base;
+        public long CaretPosition, SelectionStart, SelectionEnd;
+        public double ScrollX, ScrollY, ScrollMaxX, ScrollMaxY;
+        public double RangeValue, RangeMin, RangeMax;
+        public long SelectedIndex;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct GuaNativeNodeStateV2
     {
         public uint StructSize;
@@ -292,6 +313,9 @@ internal static partial class Native
     internal static partial int gua_register_node_v2(nint context, in GuaNativeNodeDescriptorV2 descriptor);
 
     [LibraryImport("gua")]
+    internal static partial int gua_register_node_v3(nint context, in GuaNativeNodeDescriptorV3 descriptor);
+
+    [LibraryImport("gua")]
     internal static partial nint gua_get_ui_tree_json(nint context);
 
     [LibraryImport("gua")]
@@ -365,6 +389,12 @@ internal static partial class Native
 
     [LibraryImport("gua")]
     internal static unsafe partial int gua_poll_event_v2_for_request(nint context, ulong requestId, GuaNativeEventV2* outEvent);
+
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_poll_event_v3(nint context, GuaNativeEventV3* outEvent);
+
+    [LibraryImport("gua")]
+    internal static unsafe partial int gua_poll_event_v3_for_request(nint context, ulong requestId, GuaNativeEventV3* outEvent);
 
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static unsafe partial int gua_consume_action_request(nint context, int action, string? nodeId, GuaNativeActionRequest* outRequest);

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -209,7 +209,8 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
             return false;
         }
         e = new GuaActionEvent(result.RequestId, (GuaActionType)result.Action, result.Succeeded,
-            (GuaActionError)result.Error, result.NodeId, result.Value, result.Sensitive);
+            (GuaActionError)result.Error, result.NodeId, result.Value, result.Sensitive,
+            result.SessionEpoch, result.FrameSequence, result.Revision);
         return true;
     }
 
@@ -427,7 +428,8 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
 
     private sealed record ActionRequestResult(ulong RequestId);
     private sealed record ActionEventResult(
-        ulong RequestId, int Action, bool Succeeded, int Error, string NodeId, string Value, bool Sensitive);
+        ulong RequestId, int Action, bool Succeeded, int Error, string NodeId, string Value, bool Sensitive,
+        ulong SessionEpoch, ulong FrameSequence, ulong Revision);
     private sealed record ContextStatusResult(
         ulong SessionEpoch, ulong FrameSequence, ulong Revision, uint NodeCount,
         uint PendingRequestCount, uint InFlightRequestCount, uint UnconsumedEventCount,

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -122,6 +122,8 @@ public static partial class GuaAssertions
             bool? OptionalBoolean(string name) => hasState && state.TryGetProperty(name, out var value)
                 ? value.GetBoolean()
                 : null;
+            long? OptionalStateInt64(string name) => hasState && state.TryGetProperty(name, out var value) ? value.GetInt64() : null;
+            double? OptionalStateDouble(string name) => hasState && state.TryGetProperty(name, out var value) ? value.GetDouble() : null;
             string? OptionalString(string name) => node.TryGetProperty(name, out var value)
                 ? value.GetString()
                 : null;
@@ -161,7 +163,10 @@ public static partial class GuaAssertions
                 SchemaVersion: document.RootElement.TryGetProperty("schemaVersion", out var schemaVersion) ? schemaVersion.GetInt32() : null,
                 SessionEpoch: OptionalRootUInt64("sessionEpoch"),
                 FrameSequence: OptionalRootUInt64("frameSequence"),
-                Revision: OptionalRootUInt64("revision"));
+                Revision: OptionalRootUInt64("revision"),
+                CaretPosition: OptionalStateInt64("caretPosition"), SelectionStart: OptionalStateInt64("selectionStart"), SelectionEnd: OptionalStateInt64("selectionEnd"),
+                ScrollX: OptionalStateDouble("scrollX"), ScrollY: OptionalStateDouble("scrollY"), ScrollMaxX: OptionalStateDouble("scrollMaxX"), ScrollMaxY: OptionalStateDouble("scrollMaxY"),
+                RangeValue: OptionalStateDouble("rangeValue"), RangeMin: OptionalStateDouble("rangeMin"), RangeMax: OptionalStateDouble("rangeMax"), SelectedIndex: OptionalStateInt64("selectedIndex"));
         }
 
         return null;

--- a/bindings/dotnet/src/Gua.Testing/GuaNodeSnapshot.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaNodeSnapshot.cs
@@ -21,4 +21,15 @@ public sealed record GuaNodeSnapshot(
     int? SchemaVersion = null,
     ulong? SessionEpoch = null,
     ulong? FrameSequence = null,
-    ulong? Revision = null);
+    ulong? Revision = null,
+    long? CaretPosition = null,
+    long? SelectionStart = null,
+    long? SelectionEnd = null,
+    double? ScrollX = null,
+    double? ScrollY = null,
+    double? ScrollMaxX = null,
+    double? ScrollMaxY = null,
+    double? RangeValue = null,
+    double? RangeMin = null,
+    double? RangeMax = null,
+    long? SelectedIndex = null);

--- a/bindings/dotnet/src/Gua.Testing/GuaWaits.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWaits.cs
@@ -59,6 +59,14 @@ public static partial class GuaAssertions
         WaitForNodeAsync(context, id, node => node?.Checked == expected,
             $"have checked={expected}", timeout, pollInterval, cancellationToken);
 
+    public static Task<GuaNodeExpectation> WaitForStateAsync(
+        IGuaContext context, string id, Func<GuaNodeSnapshot, bool> predicate, string description = "match semantic state",
+        TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return WaitForNodeAsync(context, id, node => node is not null && predicate(node), description, timeout, pollInterval, cancellationToken);
+    }
+
     public static GuaNodeExpectation WaitForVisible(IGuaContext context, string id, TimeSpan? timeout = null, TimeSpan? pollInterval = null) =>
         WaitForVisibleAsync(context, id, timeout, pollInterval).GetAwaiter().GetResult();
 
@@ -207,6 +215,8 @@ public static partial class GuaAssertions
             : [];
         var hasState = node.TryGetProperty("state", out var state) && state.ValueKind == JsonValueKind.Object;
         bool? StateBoolean(string name) => hasState && state.TryGetProperty(name, out var value) ? value.GetBoolean() : null;
+        long? StateInt64(string name) => hasState && state.TryGetProperty(name, out var value) ? value.GetInt64() : null;
+        double? StateDouble(string name) => hasState && state.TryGetProperty(name, out var value) ? value.GetDouble() : null;
         string? NodeString(string name) => node.TryGetProperty(name, out var value) ? value.GetString() : null;
         return new GuaNodeSnapshot(
             node.GetProperty("id").GetString() ?? string.Empty,
@@ -217,7 +227,10 @@ public static partial class GuaAssertions
             NodeString("parentId"), NodeString("text"), NodeString("value"), StateBoolean("focused"), StateBoolean("hovered"),
             StateBoolean("pressed"), StateBoolean("checked"), StateBoolean("selected"),
             root.TryGetProperty("schemaVersion", out var schemaVersion) ? schemaVersion.GetInt32() : null,
-            RootUInt64(root, "sessionEpoch"), RootUInt64(root, "frameSequence"), RootUInt64(root, "revision"));
+            RootUInt64(root, "sessionEpoch"), RootUInt64(root, "frameSequence"), RootUInt64(root, "revision"),
+            StateInt64("caretPosition"), StateInt64("selectionStart"), StateInt64("selectionEnd"),
+            StateDouble("scrollX"), StateDouble("scrollY"), StateDouble("scrollMaxX"), StateDouble("scrollMaxY"),
+            StateDouble("rangeValue"), StateDouble("rangeMin"), StateDouble("rangeMax"), StateInt64("selectedIndex"));
     }
 
     private static ulong? RootUInt64(JsonElement root, string name) => root.TryGetProperty(name, out var value) ? value.GetUInt64() : null;

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -69,6 +69,10 @@ satisfies the wait. Hidden waiting succeeds for either `visible=false` or a
 removed node. Timeout messages include the condition, last node state, frame,
 and revision. Sync wrappers remain available for compatibility.
 
+`WaitForStateAsync(context, id, predicate)` polls fresh snapshots for detailed state such as caret/selection,
+scroll offsets, range bounds, and selected index. Action completion includes session/frame/revision metadata,
+but remains distinct from observing the requested state; chain a state wait when the UI result matters.
+
 Use `GuaTestSession` as the explicit process-reuse boundary. The default reset
 clears semantic nodes, requests, events, and retained history while preserving
 logs and screenshots. Strict teardown detects leaked requests/events without

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -53,6 +53,27 @@ public sealed class SelectorParityTests
     }
 
     [Test]
+    public async Task DetailedSemanticStatePreservesObservedZeroAndWaitsByPredicate()
+    {
+        using var context = new GuaContext();
+        context.BeginFrame("details");
+        context.RegisterNode(new GuaNodeDescriptor("editor", "textbox", "Editor", new GuaBounds(0, 0, 1, 1),
+            CaretPosition: 0, SelectionStart: 0, SelectionEnd: 0, ScrollX: 0, ScrollY: 12,
+            ScrollMaxX: 0, ScrollMaxY: 100, RangeValue: 5, RangeMin: 0, RangeMax: 10, SelectedIndex: 0));
+        context.EndFrame();
+
+        var state = await GuaAssertions.WaitForStateAsync(context, "editor", node =>
+            node.CaretPosition == 0 && node.ScrollY == 12 && node.RangeValue == 5 && node.SelectedIndex == 0);
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.Snapshot.CaretPosition, Is.Zero);
+            Assert.That(state.Snapshot.SelectionStart, Is.Zero);
+            Assert.That(state.Snapshot.ScrollMaxY, Is.EqualTo(100));
+            Assert.That(state.Snapshot.RangeMin, Is.Zero);
+        });
+    }
+
+    [Test]
     public async Task V2LocatorAndActionCompletionPreserveUnrelatedEvents()
     {
         using var context = new GuaContext();
@@ -80,6 +101,9 @@ public sealed class SelectorParityTests
         {
             Assert.That(result.RequestId, Is.EqualTo(request.RequestId));
             Assert.That(result.Action, Is.EqualTo(GuaActionType.SetValue));
+            Assert.That(result.SessionEpoch, Is.EqualTo(1));
+            Assert.That(result.FrameSequence, Is.EqualTo(1));
+            Assert.That(result.Revision, Is.EqualTo(1));
             Assert.That(context.TryPollActionEvent(otherId, out var preserved), Is.True);
             Assert.That(preserved.Action, Is.EqualTo(GuaActionType.Focus));
         });

--- a/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
+++ b/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
@@ -208,13 +208,7 @@ public sealed class GuaGodotRuntime : IDisposable
         var role = GetControlRole(control);
         var label = GetControlLabel(control);
         var enabled = IsControlEnabled(control);
-        RegisterNode(
-            id,
-            role,
-            label,
-            new Rect2(control.GlobalPosition, control.Size),
-            control.IsVisibleInTree(),
-            enabled);
+        RegisterReflectedNode(id, role, label, control, enabled);
 
         if (control is BaseButton button)
         {
@@ -229,6 +223,60 @@ public sealed class GuaGodotRuntime : IDisposable
                 CollectControl(root, childControl);
             }
         }
+    }
+
+    private void RegisterReflectedNode(string id, string role, string label, Control control, bool enabled)
+    {
+        const ulong focused = 1UL << 3, caret = 1UL << 8, selection = 1UL << 9, scroll = 1UL << 10,
+            scrollMax = 1UL << 11, rangeValue = 1UL << 12, rangeMin = 1UL << 13, rangeMax = 1UL << 14, selectedIndex = 1UL << 15;
+        var mask = focused;
+        long caretPosition = 0, selectionStart = 0, selectionEnd = 0, selected = -1;
+        double x = 0, y = 0, maxX = 0, maxY = 0, value = 0, min = 0, max = 0;
+        if (control is LineEdit line)
+        {
+            mask |= caret | selection; caretPosition = line.CaretColumn;
+            selectionStart = line.HasSelection() ? line.GetSelectionFromColumn() : caretPosition;
+            selectionEnd = line.HasSelection() ? line.GetSelectionToColumn() : caretPosition;
+        }
+        else if (control is TextEdit edit)
+        {
+            mask |= caret | selection; caretPosition = edit.GetCaretColumn();
+            selectionStart = edit.HasSelection() ? edit.GetSelectionFromColumn() : caretPosition;
+            selectionEnd = edit.HasSelection() ? edit.GetSelectionToColumn() : caretPosition;
+        }
+        if (control is ScrollContainer sc)
+        {
+            mask |= scroll | scrollMax; x = sc.ScrollHorizontal; y = sc.ScrollVertical;
+            maxX = sc.GetHScrollBar().MaxValue; maxY = sc.GetVScrollBar().MaxValue;
+        }
+        if (control is global::Godot.Range rangeControl)
+        {
+            mask |= rangeValue | rangeMin | rangeMax; value = rangeControl.Value; min = rangeControl.MinValue; max = rangeControl.MaxValue;
+        }
+        if (control is OptionButton option) { mask |= selectedIndex; selected = option.Selected; }
+        else if (control is ItemList list) { mask |= selectedIndex; var items = list.GetSelectedItems(); selected = items.Length == 0 ? -1 : items[0]; }
+        else if (control is TabContainer tabs) { mask |= selectedIndex; selected = tabs.CurrentTab; }
+
+        var values = new[] { id, role, label };
+        var pointers = values.Select(System.Runtime.InteropServices.Marshal.StringToCoTaskMemUTF8).ToArray();
+        try
+        {
+            var baseNode = new GuaRuntimeNative.NativeNodeV2
+            {
+                StructSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<GuaRuntimeNative.NativeNodeV2>(), KnownMask = mask,
+                Id = pointers[0], Role = pointers[1], Label = pointers[2], Bounds = new GuaBounds(control.GlobalPosition.X, control.GlobalPosition.Y, control.Size.X, control.Size.Y),
+                Visible = control.IsVisibleInTree() ? 1 : 0, Enabled = enabled ? 1 : 0, Focused = control.HasFocus() ? 1 : 0,
+            };
+            var node = new GuaRuntimeNative.NativeNodeV3
+            {
+                StructSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<GuaRuntimeNative.NativeNodeV3>(), Base = baseNode,
+                CaretPosition = caretPosition, SelectionStart = selectionStart, SelectionEnd = selectionEnd,
+                ScrollX = x, ScrollY = y, ScrollMaxX = maxX, ScrollMaxY = maxY,
+                RangeValue = value, RangeMin = min, RangeMax = max, SelectedIndex = selected,
+            };
+            if (GuaRuntimeNative.gua_runtime_register_node_v3(_runtime, in node) == 0) throw new InvalidOperationException($"Failed to reflect Gua node: {id}");
+        }
+        finally { foreach (var pointer in pointers) System.Runtime.InteropServices.Marshal.FreeCoTaskMem(pointer); }
     }
 
     private void DispatchClickRequests()

--- a/examples/dotnet-godot/addons/gua/GuaRuntimeNative.cs
+++ b/examples/dotnet-godot/addons/gua/GuaRuntimeNative.cs
@@ -14,6 +14,24 @@ internal static class GuaRuntimeNative
         public fixed byte NodeId[NodeIdBufferSize];
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct NativeNodeV2
+    {
+        internal uint StructSize; internal ulong KnownMask;
+        internal nint Id, ParentId, Role, Label, Text, Value;
+        internal GuaBounds Bounds;
+        internal int Visible, Enabled, Focused, Hovered, Pressed, Checked, Selected;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct NativeNodeV3
+    {
+        internal uint StructSize; internal NativeNodeV2 Base;
+        internal long CaretPosition, SelectionStart, SelectionEnd;
+        internal double ScrollX, ScrollY, ScrollMaxX, ScrollMaxY, RangeValue, RangeMin, RangeMax;
+        internal long SelectedIndex;
+    }
+
     static GuaRuntimeNative()
     {
         NativeLibrary.SetDllImportResolver(typeof(GuaRuntimeNative).Assembly, ResolveRuntimeLibrary);
@@ -96,6 +114,9 @@ internal static class GuaRuntimeNative
         GuaBounds bounds,
         int visible,
         int enabled);
+
+    [DllImport("gua_runtime")]
+    internal static extern int gua_runtime_register_node_v3(nint runtime, in NativeNodeV3 descriptor);
 
     [DllImport("gua_runtime")]
     internal static extern nint gua_runtime_get_ui_tree_json(nint runtime);

--- a/examples/godot-gdscript/README.md
+++ b/examples/godot-gdscript/README.md
@@ -78,8 +78,11 @@ The sample attaches `GuaAutoAdapter` to the root Godot `Control`; the adapter
 collects standard controls into the semantic UI tree and dispatches semantic
 actions through the real controls. The v1 matrix covers focus, `LineEdit` /
 `TextEdit` / slider values, checkbox state, `OptionButton` / `ItemList` /
-`TabContainer` selection, `ScrollContainer`, and key input. Every requested host
-operation emits an observed result carrying the same `requestId`.
+`TabContainer` selection, `ScrollContainer`, and key input. Controls also reflect
+detailed state where Godot exposes it: caret/selection, scroll offset/max, numeric
+range value/min/max, and selected index. Unsupported fields are omitted and observed
+zero is retained. Every requested host operation emits an observed result carrying
+the same `requestId`.
 
 `GuaAutoAdapter.reset_context()` resets the shared runtime context and its
 temporary control/request-dispatch caches as one operation. Strict reset first

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -224,6 +224,34 @@ func _collect_control(control: Control, parent_id: String) -> void:
 		descriptor["value"] = value
 	if control is CheckBox:
 		descriptor["checked"] = (control as CheckBox).button_pressed
+	if control is LineEdit:
+		var line := control as LineEdit
+		descriptor["caret_position"] = line.caret_column
+		descriptor["selection_start"] = line.get_selection_from_column() if line.has_selection() else line.caret_column
+		descriptor["selection_end"] = line.get_selection_to_column() if line.has_selection() else line.caret_column
+	elif control is TextEdit:
+		var edit := control as TextEdit
+		descriptor["caret_position"] = edit.get_caret_column()
+		descriptor["selection_start"] = edit.get_selection_from_column() if edit.has_selection() else edit.get_caret_column()
+		descriptor["selection_end"] = edit.get_selection_to_column() if edit.has_selection() else edit.get_caret_column()
+	if control is ScrollContainer:
+		var scroll := control as ScrollContainer
+		descriptor["scroll_x"] = scroll.scroll_horizontal
+		descriptor["scroll_y"] = scroll.scroll_vertical
+		descriptor["scroll_max_x"] = scroll.get_h_scroll_bar().max_value
+		descriptor["scroll_max_y"] = scroll.get_v_scroll_bar().max_value
+	if control is Range:
+		var range := control as Range
+		descriptor["range_value"] = range.value
+		descriptor["range_min"] = range.min_value
+		descriptor["range_max"] = range.max_value
+	if control is OptionButton:
+		descriptor["selected_index"] = (control as OptionButton).selected
+	elif control is ItemList:
+		var selected := (control as ItemList).get_selected_items()
+		descriptor["selected_index"] = selected[0] if not selected.is_empty() else -1
+	elif control is TabContainer:
+		descriptor["selected_index"] = (control as TabContainer).current_tab
 	context.register_node_v2(descriptor)
 	controls_by_id[id] = control
 

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -148,6 +148,12 @@ func _run() -> void:
 	if not tree_json.contains("\"role\":\"combobox\"") or not tree_json.contains("\"value\":\"Hard\""):
 		_fail("Gua smoke did not publish OptionButton value state: %s" % tree_json)
 		return
+	if not tree_json.contains("\"selectedIndex\":1") or not tree_json.contains("\"rangeMin\":0.000000"):
+		_fail("Gua smoke did not publish detailed selected/range state: %s" % tree_json)
+		return
+	if not tree_json.contains("\"scrollY\":0.000000") or not tree_json.contains("\"scrollMaxY\""):
+		_fail("Gua smoke did not publish detailed scroll state: %s" % tree_json)
+		return
 	if not tree_json.contains("servers$item:0") or not tree_json.contains("tabs$tab:1"):
 		_fail("Gua smoke did not publish stable ItemList/TabContainer semantic children: %s" % tree_json)
 		return

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -96,6 +96,14 @@ typedef struct gua_event_v2_t {
     int sensitive;
 } gua_event_v2_t;
 
+typedef struct gua_event_v3_t {
+    uint32_t struct_size;
+    gua_event_v2_t base;
+    uint64_t session_epoch;
+    uint64_t frame_sequence;
+    uint64_t revision;
+} gua_event_v3_t;
+
 enum {
     GUA_RESET_NODES = 1U << 0,
     GUA_RESET_REQUESTS = 1U << 1,
@@ -170,7 +178,15 @@ enum {
     GUA_NODE_KNOWN_HOVERED = 1ULL << 4,
     GUA_NODE_KNOWN_PRESSED = 1ULL << 5,
     GUA_NODE_KNOWN_CHECKED = 1ULL << 6,
-    GUA_NODE_KNOWN_SELECTED = 1ULL << 7
+    GUA_NODE_KNOWN_SELECTED = 1ULL << 7,
+    GUA_NODE_KNOWN_CARET_POSITION = 1ULL << 8,
+    GUA_NODE_KNOWN_SELECTION = 1ULL << 9,
+    GUA_NODE_KNOWN_SCROLL = 1ULL << 10,
+    GUA_NODE_KNOWN_SCROLL_MAX = 1ULL << 11,
+    GUA_NODE_KNOWN_RANGE_VALUE = 1ULL << 12,
+    GUA_NODE_KNOWN_RANGE_MIN = 1ULL << 13,
+    GUA_NODE_KNOWN_RANGE_MAX = 1ULL << 14,
+    GUA_NODE_KNOWN_SELECTED_INDEX = 1ULL << 15
 };
 
 typedef struct gua_node_descriptor_v2_t {
@@ -206,6 +222,24 @@ typedef struct gua_node_state_v2_t {
     char text[256];
     char value[256];
 } gua_node_state_v2_t;
+
+typedef struct gua_node_descriptor_v3_t {
+    uint32_t struct_size;
+    gua_node_descriptor_v2_t base;
+    int64_t caret_position, selection_start, selection_end;
+    double scroll_x, scroll_y, scroll_max_x, scroll_max_y;
+    double range_value, range_min, range_max;
+    int64_t selected_index;
+} gua_node_descriptor_v3_t;
+
+typedef struct gua_node_state_v3_t {
+    uint32_t struct_size;
+    gua_node_state_v2_t base;
+    int64_t caret_position, selection_start, selection_end;
+    double scroll_x, scroll_y, scroll_max_x, scroll_max_y;
+    double range_value, range_min, range_max;
+    int64_t selected_index;
+} gua_node_state_v3_t;
 
 enum {
     GUA_MATCH_EXACT = 0,
@@ -265,6 +299,7 @@ void gua_register_node(
     int enabled
 );
 int gua_register_node_v2(gua_context_t* ctx, const gua_node_descriptor_v2_t* descriptor);
+int gua_register_node_v3(gua_context_t* ctx, const gua_node_descriptor_v3_t* descriptor);
 
 const char* gua_get_ui_tree_json(gua_context_t* ctx);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
@@ -289,6 +324,7 @@ int gua_copy_version_json(char* out_json, int out_json_size);
 int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state);
 /* Returns 0 rather than a partial state when a v2 string does not fit its fixed output buffer. */
 int gua_get_node_state_v2(gua_context_t* ctx, const char* node_id, gua_node_state_v2_t* out_state);
+int gua_get_node_state_v3(gua_context_t* ctx, const char* node_id, gua_node_state_v3_t* out_state);
 int gua_find_node_by_id(gua_context_t* ctx, const char* node_id, char* out_node_id, int out_node_id_size);
 int gua_find_node_by_role(gua_context_t* ctx, const char* role, const char* name, char* out_node_id, int out_node_id_size);
 int gua_find_node_by_text(gua_context_t* ctx, const char* text, char* out_node_id, int out_node_id_size);
@@ -303,6 +339,8 @@ int gua_consume_action_request(gua_context_t* ctx, int action, const char* node_
 int gua_emit_action_result(gua_context_t* ctx, const gua_action_result_t* result);
 int gua_poll_event_v2(gua_context_t* ctx, gua_event_v2_t* out_event);
 int gua_poll_event_v2_for_request(gua_context_t* ctx, uint64_t request_id, gua_event_v2_t* out_event);
+int gua_poll_event_v3(gua_context_t* ctx, gua_event_v3_t* out_event);
+int gua_poll_event_v3_for_request(gua_context_t* ctx, uint64_t request_id, gua_event_v3_t* out_event);
 int gua_get_context_status(gua_context_t* ctx, gua_context_status_t* out_status);
 int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* options, gua_reset_report_t* out_report);
 

--- a/native/gua-core/include/gua/gua.hpp
+++ b/native/gua-core/include/gua/gua.hpp
@@ -75,6 +75,10 @@ struct NodeProperties {
     std::optional<bool> pressed;
     std::optional<bool> checked;
     std::optional<bool> selected;
+    std::optional<std::int64_t> caret_position, selection_start, selection_end;
+    std::optional<double> scroll_x, scroll_y, scroll_max_x, scroll_max_y;
+    std::optional<double> range_value, range_min, range_max;
+    std::optional<std::int64_t> selected_index;
 };
 
 class Context {
@@ -173,6 +177,14 @@ public:
         if (properties.pressed) known_mask |= GUA_NODE_KNOWN_PRESSED;
         if (properties.checked) known_mask |= GUA_NODE_KNOWN_CHECKED;
         if (properties.selected) known_mask |= GUA_NODE_KNOWN_SELECTED;
+        if (properties.caret_position) known_mask |= GUA_NODE_KNOWN_CARET_POSITION;
+        if (properties.selection_start && properties.selection_end) known_mask |= GUA_NODE_KNOWN_SELECTION;
+        if (properties.scroll_x && properties.scroll_y) known_mask |= GUA_NODE_KNOWN_SCROLL;
+        if (properties.scroll_max_x && properties.scroll_max_y) known_mask |= GUA_NODE_KNOWN_SCROLL_MAX;
+        if (properties.range_value) known_mask |= GUA_NODE_KNOWN_RANGE_VALUE;
+        if (properties.range_min) known_mask |= GUA_NODE_KNOWN_RANGE_MIN;
+        if (properties.range_max) known_mask |= GUA_NODE_KNOWN_RANGE_MAX;
+        if (properties.selected_index) known_mask |= GUA_NODE_KNOWN_SELECTED_INDEX;
 
         const gua_node_descriptor_v2_t descriptor {
             sizeof(gua_node_descriptor_v2_t),
@@ -192,7 +204,13 @@ public:
             properties.checked.value_or(false) ? 1 : 0,
             properties.selected.value_or(false) ? 1 : 0,
         };
-        if (gua_register_node_v2(context_, &descriptor) == 0) {
+        const gua_node_descriptor_v3_t detailed {
+            sizeof(gua_node_descriptor_v3_t), descriptor,
+            properties.caret_position.value_or(0), properties.selection_start.value_or(0), properties.selection_end.value_or(0),
+            properties.scroll_x.value_or(0), properties.scroll_y.value_or(0), properties.scroll_max_x.value_or(0), properties.scroll_max_y.value_or(0),
+            properties.range_value.value_or(0), properties.range_min.value_or(0), properties.range_max.value_or(0), properties.selected_index.value_or(-1)
+        };
+        if (gua_register_node_v3(context_, &detailed) == 0) {
             throw std::runtime_error("Failed to register Gua v2 node");
         }
     }

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -31,7 +31,7 @@ std::string build_version_json(const char* godot_plugin_version = nullptr)
     return "{\"protocolSchemaVersion\":\"2\",\"coreVersion\":\"" GUA_VERSION
         "\",\"runtimeVersion\":\"" GUA_VERSION "\",\"godotPluginVersion\":" + plugin +
         ",\"abiVersion\":1,\"buildId\":\"" GUA_BUILD_ID
-        "\",\"capabilities\":[\"semantic_ui_tree_v2\",\"semantic_actions_v2\",\"context_reset_v1\",\"diagnostics_v1\",\"version_v1\"]}";
+        "\",\"capabilities\":[\"semantic_ui_tree_v2\",\"detailed_semantic_state_v1\",\"semantic_actions_v2\",\"context_reset_v1\",\"diagnostics_v1\",\"version_v1\"]}";
 }
 
 struct Node {
@@ -50,6 +50,10 @@ struct Node {
     bool pressed = false;
     bool checked = false;
     bool selected = false;
+    long long caret_position = 0, selection_start = 0, selection_end = 0;
+    double scroll_x = 0, scroll_y = 0, scroll_max_x = 0, scroll_max_y = 0;
+    double range_value = 0, range_min = 0, range_max = 0;
+    long long selected_index = -1;
 };
 
 struct Event {
@@ -60,6 +64,9 @@ struct Event {
     int error_code = 0;
     std::string value;
     bool sensitive = false;
+    unsigned long long session_epoch = 0;
+    unsigned long long frame_sequence = 0;
+    unsigned long long revision = 0;
 };
 
 struct ActionRequest {
@@ -376,7 +383,10 @@ std::string build_semantic_snapshot_json(const std::string& screen, const std::v
         const unsigned long long boolean_state_mask =
             GUA_NODE_KNOWN_FOCUSED | GUA_NODE_KNOWN_HOVERED | GUA_NODE_KNOWN_PRESSED |
             GUA_NODE_KNOWN_CHECKED | GUA_NODE_KNOWN_SELECTED;
-        if ((node.known_mask & boolean_state_mask) != 0U) {
+        const unsigned long long detailed_state_mask = GUA_NODE_KNOWN_CARET_POSITION | GUA_NODE_KNOWN_SELECTION |
+            GUA_NODE_KNOWN_SCROLL | GUA_NODE_KNOWN_SCROLL_MAX | GUA_NODE_KNOWN_RANGE_VALUE |
+            GUA_NODE_KNOWN_RANGE_MIN | GUA_NODE_KNOWN_RANGE_MAX | GUA_NODE_KNOWN_SELECTED_INDEX;
+        if ((node.known_mask & (boolean_state_mask | detailed_state_mask)) != 0U) {
             json += ",\"state\":{";
             bool wrote_state = false;
             const auto append_state = [&](const char* name, bool value) {
@@ -394,6 +404,19 @@ std::string build_semantic_snapshot_json(const std::string& screen, const std::v
             if ((node.known_mask & GUA_NODE_KNOWN_PRESSED) != 0U) append_state("pressed", node.pressed);
             if ((node.known_mask & GUA_NODE_KNOWN_CHECKED) != 0U) append_state("checked", node.checked);
             if ((node.known_mask & GUA_NODE_KNOWN_SELECTED) != 0U) append_state("selected", node.selected);
+            const auto append_number = [&](const char* name, auto value) {
+                if (wrote_state) json += ",";
+                json += "\"" + std::string(name) + "\":" + std::to_string(value);
+                wrote_state = true;
+            };
+            if ((node.known_mask & GUA_NODE_KNOWN_CARET_POSITION) != 0U) append_number("caretPosition", node.caret_position);
+            if ((node.known_mask & GUA_NODE_KNOWN_SELECTION) != 0U) { append_number("selectionStart", node.selection_start); append_number("selectionEnd", node.selection_end); }
+            if ((node.known_mask & GUA_NODE_KNOWN_SCROLL) != 0U) { append_number("scrollX", node.scroll_x); append_number("scrollY", node.scroll_y); }
+            if ((node.known_mask & GUA_NODE_KNOWN_SCROLL_MAX) != 0U) { append_number("scrollMaxX", node.scroll_max_x); append_number("scrollMaxY", node.scroll_max_y); }
+            if ((node.known_mask & GUA_NODE_KNOWN_RANGE_VALUE) != 0U) append_number("rangeValue", node.range_value);
+            if ((node.known_mask & GUA_NODE_KNOWN_RANGE_MIN) != 0U) append_number("rangeMin", node.range_min);
+            if ((node.known_mask & GUA_NODE_KNOWN_RANGE_MAX) != 0U) append_number("rangeMax", node.range_max);
+            if ((node.known_mask & GUA_NODE_KNOWN_SELECTED_INDEX) != 0U) append_number("selectedIndex", node.selected_index);
             json += "}";
         }
         json += ",\"actions\":[";
@@ -578,6 +601,14 @@ extern "C" void gua_end_frame(gua_context_t* ctx)
         ctx->staging_valid = true;
         return;
     }
+    const auto focused_count = std::count_if(ctx->staging_nodes.begin(), ctx->staging_nodes.end(), [](const Node& node) {
+        return (node.known_mask & GUA_NODE_KNOWN_FOCUSED) != 0U && node.focused;
+    });
+    if (focused_count > 1) {
+        ctx->staging_nodes.clear();
+        ctx->frame_in_progress = false;
+        return;
+    }
     const std::string semantic_snapshot = build_semantic_snapshot_json(ctx->staging_screen, ctx->staging_nodes);
     ctx->screen.swap(ctx->staging_screen);
     ctx->nodes.swap(ctx->staging_nodes);
@@ -648,6 +679,20 @@ extern "C" int gua_register_node_v2(gua_context_t* ctx, const gua_node_descripto
         descriptor->checked != 0,
         descriptor->selected != 0,
     });
+    return 1;
+}
+
+extern "C" int gua_register_node_v3(gua_context_t* ctx, const gua_node_descriptor_v3_t* descriptor)
+{
+    if (ctx == nullptr || descriptor == nullptr || descriptor->struct_size < sizeof(gua_node_descriptor_v3_t) ||
+        descriptor->base.struct_size < sizeof(gua_node_descriptor_v2_t)) return 0;
+    if (gua_register_node_v2(ctx, &descriptor->base) == 0) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    Node& node = ctx->staging_nodes.back();
+    node.caret_position = descriptor->caret_position; node.selection_start = descriptor->selection_start; node.selection_end = descriptor->selection_end;
+    node.scroll_x = descriptor->scroll_x; node.scroll_y = descriptor->scroll_y; node.scroll_max_x = descriptor->scroll_max_x; node.scroll_max_y = descriptor->scroll_max_y;
+    node.range_value = descriptor->range_value; node.range_min = descriptor->range_min; node.range_max = descriptor->range_max;
+    node.selected_index = descriptor->selected_index;
     return 1;
 }
 
@@ -834,6 +879,20 @@ extern "C" int gua_get_node_state_v2(gua_context_t* ctx, const char* node_id, gu
     std::snprintf(out_state->parent_id, sizeof(out_state->parent_id), "%s", found->parent_id.c_str());
     std::snprintf(out_state->text, sizeof(out_state->text), "%s", found->text.c_str());
     std::snprintf(out_state->value, sizeof(out_state->value), "%s", found->value.c_str());
+    return 1;
+}
+
+extern "C" int gua_get_node_state_v3(gua_context_t* ctx, const char* node_id, gua_node_state_v3_t* out_state)
+{
+    if (ctx == nullptr || node_id == nullptr || out_state == nullptr || out_state->struct_size < sizeof(gua_node_state_v3_t)) return 0;
+    out_state->base.struct_size = sizeof(gua_node_state_v2_t);
+    if (gua_get_node_state_v2(ctx, node_id, &out_state->base) == 0) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    const auto found = std::find_if(ctx->nodes.begin(), ctx->nodes.end(), [&](const Node& node) { return node.id == node_id; });
+    if (found == ctx->nodes.end()) return 0;
+    out_state->caret_position = found->caret_position; out_state->selection_start = found->selection_start; out_state->selection_end = found->selection_end;
+    out_state->scroll_x = found->scroll_x; out_state->scroll_y = found->scroll_y; out_state->scroll_max_x = found->scroll_max_x; out_state->scroll_max_y = found->scroll_max_y;
+    out_state->range_value = found->range_value; out_state->range_min = found->range_min; out_state->range_max = found->range_max; out_state->selected_index = found->selected_index;
     return 1;
 }
 
@@ -1057,6 +1116,9 @@ extern "C" int gua_emit_action_result(gua_context_t* ctx, const gua_action_resul
         result->error_code,
         result->sensitive != 0 ? "" : (result->value != nullptr ? result->value : ""),
         result->sensitive != 0,
+        ctx->session_epoch,
+        ctx->frame_sequence,
+        ctx->revision,
     });
     append_history(*ctx, ctx->event_history, "observed", result->request_id, result->action,
         result->node_id != nullptr ? result->node_id : "", result->status, result->error_code,
@@ -1097,6 +1159,35 @@ extern "C" int gua_poll_event_v2_for_request(gua_context_t* ctx, uint64_t reques
     std::snprintf(out_event->node_id, sizeof(out_event->node_id), "%s", event.node_id.c_str());
     std::snprintf(out_event->value, sizeof(out_event->value), "%s", event.value.c_str());
     out_event->sensitive = event.sensitive ? 1 : 0;
+    return 1;
+}
+
+extern "C" int gua_poll_event_v3(gua_context_t* ctx, gua_event_v3_t* out_event)
+{
+    if (ctx == nullptr || out_event == nullptr || out_event->struct_size < sizeof(gua_event_v3_t)) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    if (ctx->events.empty()) return 0;
+    const Event event = ctx->events.front(); ctx->events.pop_front();
+    out_event->base.struct_size = sizeof(gua_event_v2_t);
+    out_event->base.request_id = event.request_id; out_event->base.action = event.action; out_event->base.status = event.status; out_event->base.error_code = event.error_code;
+    std::snprintf(out_event->base.node_id, sizeof(out_event->base.node_id), "%s", event.node_id.c_str());
+    std::snprintf(out_event->base.value, sizeof(out_event->base.value), "%s", event.value.c_str()); out_event->base.sensitive = event.sensitive ? 1 : 0;
+    out_event->session_epoch = event.session_epoch; out_event->frame_sequence = event.frame_sequence; out_event->revision = event.revision;
+    return 1;
+}
+
+extern "C" int gua_poll_event_v3_for_request(gua_context_t* ctx, uint64_t request_id, gua_event_v3_t* out_event)
+{
+    if (ctx == nullptr || request_id == 0 || out_event == nullptr || out_event->struct_size < sizeof(gua_event_v3_t)) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    const auto found = std::find_if(ctx->events.begin(), ctx->events.end(), [&](const Event& event) { return event.request_id == request_id; });
+    if (found == ctx->events.end()) return 0;
+    const Event event = *found; ctx->events.erase(found);
+    out_event->base.struct_size = sizeof(gua_event_v2_t);
+    out_event->base.request_id = event.request_id; out_event->base.action = event.action; out_event->base.status = event.status; out_event->base.error_code = event.error_code;
+    std::snprintf(out_event->base.node_id, sizeof(out_event->base.node_id), "%s", event.node_id.c_str());
+    std::snprintf(out_event->base.value, sizeof(out_event->base.value), "%s", event.value.c_str()); out_event->base.sensitive = event.sensitive ? 1 : 0;
+    out_event->session_epoch = event.session_epoch; out_event->frame_sequence = event.frame_sequence; out_event->revision = event.revision;
     return 1;
 }
 

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -43,6 +43,34 @@ int main()
     assert(gua_copy_version_json(version.data(), version_size) == version_size);
     assert(std::string(version.data()).find("\"godotPluginVersion\":null") != std::string::npos);
     assert(std::string(version.data()).find("\"version_v1\"") != std::string::npos);
+    gua_context_t* detailed_context = gua_create_context();
+    gua_begin_frame(detailed_context, "details");
+    const gua_node_descriptor_v3_t detailed {
+        sizeof(gua_node_descriptor_v3_t),
+        { sizeof(gua_node_descriptor_v2_t), GUA_NODE_KNOWN_FOCUSED | GUA_NODE_KNOWN_CARET_POSITION |
+            GUA_NODE_KNOWN_SELECTION | GUA_NODE_KNOWN_SCROLL | GUA_NODE_KNOWN_SCROLL_MAX |
+            GUA_NODE_KNOWN_RANGE_VALUE | GUA_NODE_KNOWN_RANGE_MIN | GUA_NODE_KNOWN_RANGE_MAX |
+            GUA_NODE_KNOWN_SELECTED_INDEX, "detail", nullptr, "textbox", "Detail", nullptr, nullptr,
+            {0, 0, 10, 10}, 1, 1, 1, 0, 0, 0, 0 },
+        0, 0, 0, 0, 12, 0, 100, 5, 0, 10, 0
+    };
+    assert(gua_register_node_v3(detailed_context, &detailed) == 1);
+    gua_end_frame(detailed_context);
+    const std::string detailed_json = gua_get_ui_tree_json(detailed_context);
+    assert(detailed_json.find("\"caretPosition\":0") != std::string::npos);
+    assert(detailed_json.find("\"scrollY\":12.000000") != std::string::npos);
+    assert(detailed_json.find("\"rangeValue\":5.000000") != std::string::npos);
+    gua_node_state_v3_t detailed_state { sizeof(gua_node_state_v3_t) };
+    assert(gua_get_node_state_v3(detailed_context, "detail", &detailed_state) == 1);
+    assert(detailed_state.caret_position == 0 && detailed_state.scroll_y == 12 && detailed_state.range_value == 5);
+
+    gua_begin_frame(detailed_context, "invalid-focus");
+    auto focused = detailed.base;
+    focused.id = "one"; assert(gua_register_node_v2(detailed_context, &focused) == 1);
+    focused.id = "two"; assert(gua_register_node_v2(detailed_context, &focused) == 1);
+    gua_end_frame(detailed_context);
+    assert(std::string(gua_get_ui_tree_json(detailed_context)) == detailed_json);
+    gua_destroy_context(detailed_context);
     gua_context_t* context = gua_create_context();
     assert(context != nullptr);
 
@@ -192,13 +220,14 @@ int main()
     assert(gua_poll_event(context, &legacy_event) == 1);
     assert(legacy_event.type == GUA_EVENT_CLICK);
 
-    gua_event_v2_t event { sizeof(gua_event_v2_t) };
-    assert(gua_poll_event_v2_for_request(context, request_id, &event) == 1);
-    assert(event.request_id == request_id);
-    assert(event.action == GUA_ACTION_SET_VALUE);
-    assert(event.status == GUA_ACTION_STATUS_SUCCEEDED);
-    assert(event.sensitive == 1);
-    assert(std::strlen(event.value) == 0);
+    gua_event_v3_t event { sizeof(gua_event_v3_t), { sizeof(gua_event_v2_t) } };
+    assert(gua_poll_event_v3_for_request(context, request_id, &event) == 1);
+    assert(event.base.request_id == request_id);
+    assert(event.base.action == GUA_ACTION_SET_VALUE);
+    assert(event.base.status == GUA_ACTION_STATUS_SUCCEEDED);
+    assert(event.base.sensitive == 1);
+    assert(std::strlen(event.base.value) == 0);
+    assert(event.session_epoch == 1 && event.frame_sequence > 0 && event.revision > 0);
 
     assert(gua_set_diagnostics_history_limit(context, 2) == 1);
     assert(gua_set_diagnostics_environment_json(context, "{\"testName\":\"native-state\"}") == 1);

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -166,6 +166,14 @@ bool GuaContext::register_node_v2(const Dictionary& source)
     if (source.has("pressed")) known_mask |= GUA_NODE_KNOWN_PRESSED;
     if (source.has("checked")) known_mask |= GUA_NODE_KNOWN_CHECKED;
     if (source.has("selected")) known_mask |= GUA_NODE_KNOWN_SELECTED;
+    if (source.has("caret_position")) known_mask |= GUA_NODE_KNOWN_CARET_POSITION;
+    if (source.has("selection_start") && source.has("selection_end")) known_mask |= GUA_NODE_KNOWN_SELECTION;
+    if (source.has("scroll_x") && source.has("scroll_y")) known_mask |= GUA_NODE_KNOWN_SCROLL;
+    if (source.has("scroll_max_x") && source.has("scroll_max_y")) known_mask |= GUA_NODE_KNOWN_SCROLL_MAX;
+    if (source.has("range_value")) known_mask |= GUA_NODE_KNOWN_RANGE_VALUE;
+    if (source.has("range_min")) known_mask |= GUA_NODE_KNOWN_RANGE_MIN;
+    if (source.has("range_max")) known_mask |= GUA_NODE_KNOWN_RANGE_MAX;
+    if (source.has("selected_index")) known_mask |= GUA_NODE_KNOWN_SELECTED_INDEX;
 
     const gua_node_descriptor_v2_t descriptor {
         sizeof(gua_node_descriptor_v2_t),
@@ -188,7 +196,13 @@ bool GuaContext::register_node_v2(const Dictionary& source)
         source.get("checked", false) ? 1 : 0,
         source.get("selected", false) ? 1 : 0,
     };
-    return gua_runtime_register_node_v2(runtime_, &descriptor) != 0;
+    const gua_node_descriptor_v3_t detailed {
+        sizeof(gua_node_descriptor_v3_t), descriptor,
+        source.get("caret_position", 0), source.get("selection_start", 0), source.get("selection_end", 0),
+        source.get("scroll_x", 0.0), source.get("scroll_y", 0.0), source.get("scroll_max_x", 0.0), source.get("scroll_max_y", 0.0),
+        source.get("range_value", 0.0), source.get("range_min", 0.0), source.get("range_max", 0.0), source.get("selected_index", -1)
+    };
+    return gua_runtime_register_node_v3(runtime_, &detailed) != 0;
 }
 
 String GuaContext::get_ui_tree_json() const

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -23,6 +23,7 @@ void gua_runtime_register_node(
     int enabled
 );
 int gua_runtime_register_node_v2(gua_runtime_t* runtime, const gua_node_descriptor_v2_t* descriptor);
+int gua_runtime_register_node_v3(gua_runtime_t* runtime, const gua_node_descriptor_v3_t* descriptor);
 
 const char* gua_runtime_get_ui_tree_json(gua_runtime_t* runtime);
 /* Returns the required byte size including the trailing NUL. Output is NUL-terminated when out_json_size > 0. */
@@ -56,6 +57,8 @@ int gua_runtime_consume_action_request(gua_runtime_t* runtime, int action, const
 int gua_runtime_emit_action_result(gua_runtime_t* runtime, const gua_action_result_t* result);
 int gua_runtime_poll_event_v2(gua_runtime_t* runtime, gua_event_v2_t* out_event);
 int gua_runtime_poll_event_v2_for_request(gua_runtime_t* runtime, uint64_t request_id, gua_event_v2_t* out_event);
+int gua_runtime_poll_event_v3(gua_runtime_t* runtime, gua_event_v3_t* out_event);
+int gua_runtime_poll_event_v3_for_request(gua_runtime_t* runtime, uint64_t request_id, gua_event_v3_t* out_event);
 int gua_runtime_get_context_status(gua_runtime_t* runtime, gua_context_status_t* out_status);
 int gua_runtime_reset_context(gua_runtime_t* runtime, const gua_reset_options_t* options, gua_reset_report_t* out_report);
 

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -212,6 +212,11 @@ extern "C" int gua_runtime_register_node_v2(gua_runtime_t* runtime, const gua_no
     return gua_register_node_v2(runtime->context, descriptor);
 }
 
+extern "C" int gua_runtime_register_node_v3(gua_runtime_t* runtime, const gua_node_descriptor_v3_t* descriptor)
+{
+    return runtime != nullptr ? gua_register_node_v3(runtime->context, descriptor) : 0;
+}
+
 extern "C" const char* gua_runtime_get_ui_tree_json(gua_runtime_t* runtime)
 {
     if (!valid_runtime(runtime)) {
@@ -492,6 +497,16 @@ extern "C" int gua_runtime_poll_event_v2_for_request(gua_runtime_t* runtime, uin
     return gua_poll_event_v2_for_request(runtime->context, request_id, out_event);
 }
 
+extern "C" int gua_runtime_poll_event_v3(gua_runtime_t* runtime, gua_event_v3_t* out_event)
+{
+    return runtime != nullptr ? gua_poll_event_v3(runtime->context, out_event) : 0;
+}
+
+extern "C" int gua_runtime_poll_event_v3_for_request(gua_runtime_t* runtime, uint64_t request_id, gua_event_v3_t* out_event)
+{
+    return runtime != nullptr ? gua_poll_event_v3_for_request(runtime->context, request_id, out_event) : 0;
+}
+
 extern "C" int gua_runtime_get_context_status(gua_runtime_t* runtime, gua_context_status_t* out_status)
 {
     if (!valid_runtime(runtime)) return 0;
@@ -600,19 +615,22 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
             return result == GUA_ACTION_ACCEPTED ? static_cast<long long>(request_id) : static_cast<long long>(result);
         },
         .poll_action_event_json = [runtime](unsigned long long request_id) {
-            gua_event_v2_t event { sizeof(gua_event_v2_t) };
+            gua_event_v3_t event { sizeof(gua_event_v3_t), { sizeof(gua_event_v2_t) } };
             const std::lock_guard lock(runtime->context_mutex);
             const int found = request_id == 0
-                ? gua_poll_event_v2(runtime->context, &event)
-                : gua_poll_event_v2_for_request(runtime->context, request_id, &event);
+                ? gua_poll_event_v3(runtime->context, &event)
+                : gua_poll_event_v3_for_request(runtime->context, request_id, &event);
             if (found == 0) return std::string("null");
-            return std::string("{\"requestId\":") + std::to_string(event.request_id) +
-                ",\"action\":" + std::to_string(event.action) +
-                ",\"succeeded\":" + (event.status == GUA_ACTION_STATUS_SUCCEEDED ? "true" : "false") +
-                ",\"error\":" + std::to_string(event.error_code) +
-                ",\"nodeId\":\"" + escape_json(event.node_id) + "\"" +
-                ",\"value\":\"" + escape_json(event.value) + "\"" +
-                ",\"sensitive\":" + (event.sensitive != 0 ? "true" : "false") + "}";
+            return std::string("{\"requestId\":") + std::to_string(event.base.request_id) +
+                ",\"action\":" + std::to_string(event.base.action) +
+                ",\"succeeded\":" + (event.base.status == GUA_ACTION_STATUS_SUCCEEDED ? "true" : "false") +
+                ",\"error\":" + std::to_string(event.base.error_code) +
+                ",\"nodeId\":\"" + escape_json(event.base.node_id) + "\"" +
+                ",\"value\":\"" + escape_json(event.base.value) + "\"" +
+                ",\"sensitive\":" + (event.base.sensitive != 0 ? "true" : "false") +
+                ",\"sessionEpoch\":" + std::to_string(event.session_epoch) +
+                ",\"frameSequence\":" + std::to_string(event.frame_sequence) +
+                ",\"revision\":" + std::to_string(event.revision) + "}";
         },
     };
 

--- a/protocol/fixtures/ui-tree-v2.json
+++ b/protocol/fixtures/ui-tree-v2.json
@@ -14,7 +14,7 @@
       "visible": true,
       "enabled": true,
       "bounds": { "x": 10, "y": 20, "w": 100, "h": 24 },
-      "state": { "focused": false, "checked": false },
+      "state": { "focused": false, "checked": false, "caretPosition": 0, "selectionStart": 0, "selectionEnd": 0 },
       "actions": ["click", "focus"]
     },
     {
@@ -26,6 +26,7 @@
       "visible": true,
       "enabled": true,
       "bounds": { "x": 10, "y": 50, "w": 100, "h": 24 },
+      "state": { "selectedIndex": 2, "rangeValue": 2, "rangeMin": 0, "rangeMax": 3 },
       "actions": ["focus", "set_value"]
     }
   ]

--- a/protocol/fixtures/version-v1.json
+++ b/protocol/fixtures/version-v1.json
@@ -5,5 +5,5 @@
   "godotPluginVersion": null,
   "abiVersion": 1,
   "buildId": "development",
-  "capabilities": ["semantic_ui_tree_v2", "semantic_actions_v2", "context_reset_v1", "diagnostics_v1", "version_v1"]
+  "capabilities": ["semantic_ui_tree_v2", "detailed_semantic_state_v1", "semantic_actions_v2", "context_reset_v1", "diagnostics_v1", "version_v1"]
 }

--- a/protocol/schema/ui-tree.schema.json
+++ b/protocol/schema/ui-tree.schema.json
@@ -78,6 +78,17 @@
             "pressed": { "type": "boolean" },
             "checked": { "type": "boolean" },
             "selected": { "type": "boolean" },
+            "caretPosition": { "type": "integer", "minimum": 0 },
+            "selectionStart": { "type": "integer", "minimum": 0 },
+            "selectionEnd": { "type": "integer", "minimum": 0 },
+            "scrollX": { "type": "number" },
+            "scrollY": { "type": "number" },
+            "scrollMaxX": { "type": "number", "minimum": 0 },
+            "scrollMaxY": { "type": "number", "minimum": 0 },
+            "rangeValue": { "type": "number" },
+            "rangeMin": { "type": "number" },
+            "rangeMax": { "type": "number" },
+            "selectedIndex": { "type": "integer", "minimum": -1 },
             "value": {
               "type": ["number", "string", "boolean", "null"]
             }

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -24,6 +24,12 @@ it was false. Adapters must not fill unsupported state with false. Values
 crossing the initial C ABI are normalized to UTF-8 strings; the schema also
 allows native JSON scalar values for future transports.
 
+Detailed state is an additive v2-tree extension backed by the versioned v3 C ABI descriptor. It includes
+`caretPosition`, `selectionStart`/`selectionEnd`, `scrollX`/`scrollY`, `scrollMaxX`/`scrollMaxY`,
+`rangeValue`/`rangeMin`/`rangeMax`, and `selectedIndex`. Unsupported properties are omitted, so an observed
+zero remains distinct from unknown. At most one published node may have `focused: true`; adapters reject a
+staged frame with multiple focused nodes. Sensitive controls continue to omit text/value.
+
 `frameSequence` and `revision` have different purposes. Rebuilding the same
 semantic tree in consecutive frames increments `frameSequence` but leaves
 `revision` unchanged. Changing the screen, node membership, hierarchy, bounds,
@@ -201,6 +207,8 @@ Initial command types:
 ### Semantic action lifecycle (v1)
 
 Semantic actions follow `enqueue -> consume -> host action -> observed event`. Enqueue acceptance only records a request; it is never completion. Each accepted request receives a monotonically increasing `requestId`, and the adapter must copy that ID into its success or failure event after attempting the host operation.
+
+The core captures `sessionEpoch`, `frameSequence`, and `revision` when the adapter emits completion; additive v3 event APIs and remote responses preserve that metadata even when polled later. Callers must still wait for the expected semantic state: action completion proves host processing, while `WaitForStateAsync` repeatedly obtains fresh snapshots until its predicate succeeds.
 
 The v1 action names map directly to the additive C ABI action enum: `click`, `focus`, `set_value`, `set_checked`, `select`, `scroll`, and `press_key`. Enqueue validation distinguishes `node_not_found`, `hidden`, `disabled`, `unsupported`, and `invalid_value`. Existing click functions remain compatibility wrappers over the generic queue.
 


### PR DESCRIPTION
## 対応 Issue

Closes #47

## 実装内容

- UI tree v2へ caret/selection、scroll offset/max、range value/min/max、selected indexを後方互換に追加
- additiveなC ABI v3 node descriptor/stateとaction eventを追加し、既存v2 exportを維持
- focused nodeが複数あるstaged frameをpublishせず、直前の完全snapshotを保持
- C++ wrapper、Gua.Core、Gua.Testing snapshot parser、local/remote action completionを同期
- `WaitForStateAsync`で最新snapshotをpredicate成立まで待機
- Godot C# / GDScript adapterが実controlから詳細stateを自動観測
- `detailed_semantic_state_v1` capability、fixture、protocol docs、README、testsを更新

## Architecture判断

詳細stateは既存UI tree v2のoptional stateとして追加し、未知値はproperty省略、観測済みゼロはknown mask付きの値として保持する。既存C ABI structは拡張せずv3 exportを追加した。action completion metadataはadapterがresultをemitした時点でcoreが固定し、後からpollしても同じsession/frame/revisionを返す。action completedとexpected state observedは分離し、後者は`WaitForStateAsync`がfresh snapshotで検証する。

## テスト・検証

- `cmake --preset windows-msvc-debug` 成功
- `cmake --build --preset windows-msvc-debug -- /m:1` 成功
- `ctest --test-dir build/windows-msvc-debug -C Debug --output-on-failure` 3/3成功（screenshot request含む）
- `dotnet test bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj` 8/8成功
- `dotnet test bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/Gua.Godot.Visual.Integration.Tests.csproj` Godot 4.7実renderer 5/5成功
- `dotnet build examples/dotnet-godot/GuaGodotSample.csproj` 成功・警告0
- `bun run check` 3 workspace成功
- Godot 4.7 headless GDScript smoke成功
- `uvx check-jsonschema` UI tree / version fixture成功
- `git diff --check` 成功

## 未対応事項

Issue #47範囲内の未対応はない。screenshot、visual comparison、Inspector UI変更、action lifecycle再設計は範囲外として変更していない。
## main統合

PR #53（Issue #46）のオンデマンドscreenshot実装を含む最新 `main` (`897f57e`) をmergeした。v3 semantic state structとscreenshot request structを併存させ、version capabilityに`detailed_semantic_state_v1`と`capture_screenshot_v1`の両方を保持した。統合後に上記検証を再実行済み。