### PR TITLE
#48 失敗時diagnostic artifact session APIを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ policy while `GodotSceneTestHost` owns executable/project discovery, automatic
 loopback ports, rendered/headless startup, bridge diagnostics, and reset policy.
 All APIs are additive over the existing C ABI and WebSocket protocol.
 
+Failure diagnostics can be coordinated through the framework-independent
+`GuaDiagnosticsSession`. Assertions and completed actions use the same artifact
+layout, return typed absolute paths/media types/secondary capture errors, and
+can attach through a callback. Godot sessions can include live process metadata,
+stdout/stderr, runtime version, and an opt-in on-demand screenshot; successful
+tests do not create artifacts unless capture is explicitly requested.
+
 Want to try that in GitHub Actions without wiring every setup step by hand?
 [`link1345/gua-tester`](https://github.com/link1345/gua-tester) provides
 reusable Actions for Godot GDScript projects. It downloads Godot on the runner,

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -12,14 +12,16 @@ public sealed class GodotSceneTestHost : IDisposable
     private readonly GodotSceneTestHostOptions _options;
     private readonly Process _process;
     private readonly string _bridgeUrl;
+    private readonly ProcessOutput _processOutput;
     private bool _disposed;
 
-    private GodotSceneTestHost(Process process, GuaRemoteContext context, GodotSceneTestHostOptions options, string bridgeUrl)
+    private GodotSceneTestHost(Process process, GuaRemoteContext context, GodotSceneTestHostOptions options, string bridgeUrl, ProcessOutput processOutput)
     {
         _process = process;
         Context = context;
         _options = options;
         _bridgeUrl = bridgeUrl;
+        _processOutput = processOutput;
     }
 
     public IGuaContext Context { get; }
@@ -43,6 +45,41 @@ public sealed class GodotSceneTestHost : IDisposable
                 ["projectPath"] = _options.ProjectPath ?? string.Empty,
             },
         };
+    }
+
+    public GuaDiagnosticsSession CreateDiagnosticsSession(
+        string testName,
+        string? outputDirectory = null,
+        bool captureScreenshot = false,
+        IReadOnlyDictionary<string, string>? callerMetadata = null,
+        Action<GuaDiagnosticFile>? attachmentSink = null)
+    {
+        ThrowIfDisposed();
+        var basic = CreateDiagnosticOptions(testName, outputDirectory);
+        return new GuaDiagnosticsSession(Context, new GuaDiagnosticOptions
+        {
+            TestName = basic.TestName,
+            OutputDirectory = basic.OutputDirectory,
+            Environment = basic.Environment,
+            CallerMetadata = callerMetadata ?? new Dictionary<string, string>(),
+            AttachmentSink = attachmentSink,
+            TextArtifacts = new Dictionary<string, Func<string>>
+            {
+                ["godot-stdout.txt"] = _processOutput.ReadStandardOutput,
+                ["godot-stderr.txt"] = _processOutput.ReadStandardError,
+                ["godot-process.json"] = () => System.Text.Json.JsonSerializer.Serialize(new
+                {
+                    processId = ProcessId,
+                    bridgeUrl = _bridgeUrl,
+                    projectPath = _options.ProjectPath,
+                    headless = _options.Headless,
+                    hasExited = _process.HasExited,
+                }),
+            },
+            ScreenshotCapture = captureScreenshot
+                ? () => CaptureScreenshotAsync().GetAwaiter().GetResult().DecodePng()
+                : null,
+        });
     }
 
     public static GodotSceneTestHost Load(string scenePath, GodotSceneTestHostOptions? options = null)
@@ -74,7 +111,7 @@ public sealed class GodotSceneTestHost : IDisposable
                 if (!clean.IsClean)
                     throw new InvalidOperationException($"Godot startup reset left queued work: pending={clean.PendingRequestCount}, inFlight={clean.InFlightRequestCount}, events={clean.UnconsumedEventCount}.");
             }
-            return new GodotSceneTestHost(process, context, options, bridgeUrl);
+            return new GodotSceneTestHost(process, context, options, bridgeUrl, output);
         }
         catch (Exception error)
         {
@@ -431,7 +468,8 @@ public sealed class GodotSceneTestHost : IDisposable
     private sealed class ProcessOutput
     {
         private readonly Process _process;
-        private readonly StringBuilder _output = new();
+        private readonly StringBuilder _stdout = new();
+        private readonly StringBuilder _stderr = new();
 
         public ProcessOutput(Process process)
         {
@@ -440,27 +478,35 @@ public sealed class GodotSceneTestHost : IDisposable
 
         public void Start()
         {
-            _process.OutputDataReceived += (_, args) => Append(args.Data);
-            _process.ErrorDataReceived += (_, args) => Append(args.Data);
+            _process.OutputDataReceived += (_, args) => Append(_stdout, args.Data);
+            _process.ErrorDataReceived += (_, args) => Append(_stderr, args.Data);
             _process.BeginOutputReadLine();
             _process.BeginErrorReadLine();
         }
 
         public string Read()
         {
-            return _output.ToString();
+            return ReadStandardOutput() + ReadStandardError();
         }
 
-        private void Append(string? line)
+        public string ReadStandardOutput() => Read(_stdout);
+        public string ReadStandardError() => Read(_stderr);
+
+        private static string Read(StringBuilder output)
+        {
+            lock (output) return output.ToString();
+        }
+
+        private static void Append(StringBuilder output, string? line)
         {
             if (line is null)
             {
                 return;
             }
 
-            lock (_output)
+            lock (output)
             {
-                _output.AppendLine(line);
+                output.AppendLine(line);
             }
         }
     }

--- a/bindings/dotnet/src/Gua.Testing.Godot/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Godot/README.md
@@ -104,3 +104,9 @@ Headless, rendering-disabled, unsupported, timeout, and cancellation outcomes ar
 distinct. Requests arriving together may share one viewport readback. The older
 `GetScreenshot`/`WaitForScreenshotAsync` APIs keep reading the latest published
 image. Rendered secrets are not automatically redacted.
+
+`GodotSceneTestHost.CreateDiagnosticsSession` adds process metadata, separate
+stdout/stderr files, and optional on-demand screenshot capture to the common
+`GuaDiagnosticsSession` layout. Capture runs while the process and bridge are
+still alive. A screenshot or attachment failure is returned as a secondary
+capture error and does not replace the original assertion/action exception.

--- a/bindings/dotnet/src/Gua.Testing/GuaActionCompletion.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaActionCompletion.cs
@@ -103,6 +103,16 @@ public static class GuaActionCompletion
         string? nodeId, GuaActionError error, string message, Exception? inner = null)
     {
         var suffix = GuaAssertions.DescribeSnapshot(context);
-        return new GuaActionException(kind, requestId, action, nodeId, error, $"{message} {suffix}", inner);
+        var failure = new GuaActionException(kind, requestId, action, nodeId, error, $"{message} {suffix}", inner);
+        var session = GuaAssertions.Options.DiagnosticsSession;
+        if (session is not null)
+        {
+            var result = session.Capture(failure);
+            if (result.ArtifactPath is not null)
+                failure.Data["GuaDiagnosticsPath"] = result.ArtifactPath;
+            if (result.CaptureErrors.Count > 0)
+                failure.Data["GuaDiagnosticsCaptureErrors"] = result.CaptureErrors;
+        }
+        return failure;
     }
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertionException.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertionException.cs
@@ -6,4 +6,9 @@ public sealed class GuaAssertionException : Exception
         : base(message)
     {
     }
+
+    public GuaAssertionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertionOptions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertionOptions.cs
@@ -7,4 +7,5 @@ public sealed class GuaAssertionOptions
     public Action<string> Fail { get; init; } = message => throw new GuaAssertionException(message);
 
     public GuaDiagnosticOptions? Diagnostics { get; init; }
+    public GuaDiagnosticsSession? DiagnosticsSession { get; init; }
 }

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -86,6 +86,17 @@ public static partial class GuaAssertions
 
     internal static void Fail(IGuaContext context, string message, string? initialUiTreeJson = null)
     {
+        var failure = new GuaAssertionException(message);
+        var session = Options.DiagnosticsSession;
+        if (session is not null)
+        {
+            var result = session.Capture(failure, initialUiTreeJson);
+            var sessionSuffix = result.ArtifactPath is null
+                ? result.CaptureErrors.Count == 0 ? string.Empty : $" Gua diagnostics capture error: {result.CaptureErrors[0].Message}"
+                : $" Gua diagnostics: {result.ArtifactPath}";
+            Options.Fail(message + sessionSuffix);
+            throw new GuaAssertionException(message + sessionSuffix, failure);
+        }
         var diagnostics = Options.Diagnostics;
         var suffix = diagnostics is null
             ? string.Empty

--- a/bindings/dotnet/src/Gua.Testing/GuaDiagnostics.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaDiagnostics.cs
@@ -10,6 +10,89 @@ public sealed class GuaDiagnosticOptions
     public string OutputDirectory { get; init; } = Path.Combine("artifacts", "gua");
     public IReadOnlyDictionary<string, string> Environment { get; init; } = new Dictionary<string, string>();
     public Func<DateTimeOffset> Clock { get; init; } = () => DateTimeOffset.UtcNow;
+    public IReadOnlyDictionary<string, string> CallerMetadata { get; init; } = new Dictionary<string, string>();
+    public IReadOnlyDictionary<string, Func<string>> TextArtifacts { get; init; } = new Dictionary<string, Func<string>>();
+    public Func<byte[]>? ScreenshotCapture { get; init; }
+    public Action<GuaDiagnosticFile>? AttachmentSink { get; init; }
+}
+
+public sealed record GuaDiagnosticFile(string Path, string MediaType);
+public sealed record GuaDiagnosticError(string Stage, string ErrorType, string Message);
+public sealed record GuaDiagnosticsResult(
+    Exception PrimaryException,
+    string? ArtifactPath,
+    IReadOnlyList<GuaDiagnosticFile> Files,
+    IReadOnlyList<GuaDiagnosticError> CaptureErrors)
+{
+    public bool Succeeded => ArtifactPath is not null;
+}
+
+public sealed class GuaDiagnosticsSession
+{
+    private readonly IGuaContext _context;
+    private readonly GuaDiagnosticOptions _options;
+
+    public GuaDiagnosticsSession(IGuaContext context, GuaDiagnosticOptions options)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public GuaDiagnosticsResult Capture(Exception primaryException, string? initialUiTreeJson = null)
+    {
+        ArgumentNullException.ThrowIfNull(primaryException);
+        var capture = GuaDiagnosticWriter.Capture(_context, primaryException.ToString(), _options, initialUiTreeJson);
+        var errors = new List<GuaDiagnosticError>();
+        if (capture.Error is not null) errors.Add(new("diagnostics", "CaptureError", capture.Error));
+        var files = new List<GuaDiagnosticFile>();
+        if (capture.ArtifactPath is not null)
+        {
+            AddSupplementalArtifacts(capture.ArtifactPath, errors);
+            if (errors.Count > 0)
+                File.WriteAllText(Path.Combine(capture.ArtifactPath, "session-capture-errors.json"), JsonSerializer.Serialize(errors, GuaDiagnosticWriter.JsonOptions), new UTF8Encoding(false));
+            foreach (var path in Directory.EnumerateFiles(capture.ArtifactPath).Order(StringComparer.Ordinal))
+                files.Add(new GuaDiagnosticFile(Path.GetFullPath(path), MediaType(path)));
+            foreach (var file in files)
+            {
+                try { _options.AttachmentSink?.Invoke(file); }
+                catch (Exception error) { errors.Add(new("attachment", error.GetType().Name, error.Message)); }
+            }
+        }
+        return new(primaryException, capture.ArtifactPath, files, errors);
+    }
+
+    private void AddSupplementalArtifacts(string directory, List<GuaDiagnosticError> errors)
+    {
+        WriteJson(directory, "caller-metadata.json", _options.CallerMetadata, errors, "caller-metadata");
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "version.json"), JsonSerializer.Serialize(_context.GetVersion(), GuaDiagnosticWriter.JsonOptions), new UTF8Encoding(false));
+        }
+        catch (Exception error) { errors.Add(new("version", error.GetType().Name, error.Message)); }
+        foreach (var (name, read) in _options.TextArtifacts)
+        {
+            try { File.WriteAllText(Path.Combine(directory, SanitizeFileName(name)), read(), new UTF8Encoding(false)); }
+            catch (Exception error) { errors.Add(new($"text:{name}", error.GetType().Name, error.Message)); }
+        }
+        if (_options.ScreenshotCapture is not null)
+        {
+            try { File.WriteAllBytes(Path.Combine(directory, "screenshot-on-failure.png"), _options.ScreenshotCapture()); }
+            catch (Exception error) { errors.Add(new("screenshot", error.GetType().Name, error.Message)); }
+        }
+    }
+
+    private static void WriteJson(string directory, string name, object value, List<GuaDiagnosticError> errors, string stage)
+    {
+        try { File.WriteAllText(Path.Combine(directory, name), JsonSerializer.Serialize(value, GuaDiagnosticWriter.JsonOptions), new UTF8Encoding(false)); }
+        catch (Exception error) { errors.Add(new(stage, error.GetType().Name, error.Message)); }
+    }
+
+    private static string SanitizeFileName(string value) => string.Concat(value.Select(ch =>
+        Path.GetInvalidFileNameChars().Contains(ch) || char.IsControl(ch) ? '_' : ch));
+    private static string MediaType(string path) => Path.GetExtension(path).ToLowerInvariant() switch
+    {
+        ".json" => "application/json", ".jsonl" => "application/x-ndjson", ".png" => "image/png", _ => "text/plain",
+    };
 }
 
 public sealed record GuaDiagnosticCapture(string? ArtifactPath, string? Error)
@@ -166,5 +249,5 @@ public static class GuaDiagnosticWriter
         stream.Write(bytes);
     }
 
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    internal static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 }

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -129,6 +129,21 @@ using var scope = GuaAssertionScope.Use(new GuaAssertionOptions
 });
 ```
 
+For one framework-independent failure path across assertions and completed
+actions, create a `GuaDiagnosticsSession` and assign it to
+`GuaAssertionOptions.DiagnosticsSession`. `Capture` preserves the primary
+exception and returns absolute artifact paths, media types, and secondary
+capture errors. Directories use the sanitized test name, timestamp, and a
+unique ID so parallel tests do not collide. Caller metadata, runtime version,
+and optional text/screenshot providers are evaluated only after a failure;
+successful tests produce no artifact unless the caller explicitly captures.
+
+`GuaDiagnosticOptions.AttachmentSink` is framework-neutral. NUnit consumers
+can pass `file => TestContext.AddTestAttachment(file.Path, file.MediaType)`;
+other frameworks can use the same typed callback without adding a framework
+dependency to `Gua.Testing`. Screenshot files can contain rendered secrets and
+remain the consumer repository's storage and upload responsibility.
+
 The directory contains the final UI tree, bounded operation/event history,
 pending requests, logs, environment metadata, and an optional PNG. A wait also
 writes its initial tree and a deterministic node-id diff. Sensitive action

--- a/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
@@ -223,6 +223,29 @@ public sealed class GodotVisualIntegrationTests
             rendered.CaptureScreenshotAsync(TimeSpan.FromSeconds(5), cancellation.Token));
     }
 
+    [Test]
+    public void GodotDiagnosticsSessionCapturesLiveProcessOutputAndOnDemandScreenshot()
+    {
+        using var host = StartGodotAutoPort();
+        var session = host.CreateDiagnosticsSession(
+            TestContext.CurrentContext.Test.Name,
+            Path.Combine(_root, "diagnostics"),
+            captureScreenshot: true,
+            callerMetadata: new Dictionary<string, string> { ["fixture"] = "real-renderer" });
+        var primary = new InvalidOperationException("intentional Godot integration failure");
+        var result = session.Capture(primary);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.PrimaryException, Is.SameAs(primary));
+            Assert.That(result.CaptureErrors, Is.Empty);
+            Assert.That(result.Files, Has.Some.Property(nameof(GuaDiagnosticFile.Path)).EndsWith("godot-stdout.txt"));
+            Assert.That(result.Files, Has.Some.Property(nameof(GuaDiagnosticFile.Path)).EndsWith("godot-stderr.txt"));
+            Assert.That(result.Files, Has.Some.Property(nameof(GuaDiagnosticFile.Path)).EndsWith("godot-process.json"));
+            Assert.That(result.Files, Has.Some.Property(nameof(GuaDiagnosticFile.MediaType)).EqualTo("image/png"));
+        });
+    }
+
     private static async Task<IReadOnlyList<GuaActionEvent>> WaitForActionEventsAsync(
         IGuaContext context, int count, TimeSpan timeout)
     {

--- a/examples/dotnet-nunit/GuaNUnitAttachments.cs
+++ b/examples/dotnet-nunit/GuaNUnitAttachments.cs
@@ -1,0 +1,8 @@
+using Gua.Testing;
+using NUnit.Framework;
+
+internal static class GuaNUnitAttachments
+{
+    public static void Add(GuaDiagnosticFile file) =>
+        TestContext.AddTestAttachment(file.Path, $"Gua diagnostic ({file.MediaType})");
+}

--- a/examples/dotnet-nunit/README.md
+++ b/examples/dotnet-nunit/README.md
@@ -15,6 +15,11 @@ public void StartClickShowsLoadingText()
 }
 ```
 
+For typed diagnostic attachments, set `GuaDiagnosticOptions.AttachmentSink` to
+`GuaNUnitAttachments.Add`. The sample helper forwards each absolute path and
+media type to `TestContext.AddTestAttachment` without adding NUnit as a
+dependency of the reusable Gua packages.
+
 This project intentionally references `Gua.Testing` as a NuGet package instead
 of a source `ProjectReference`.
 

--- a/examples/dotnet-nunit/TitleScreenTests.cs
+++ b/examples/dotnet-nunit/TitleScreenTests.cs
@@ -329,6 +329,76 @@ public sealed class TitleScreenTests
     }
 
     [Test]
+    public void DiagnosticsSessionUnifiesAssertionAndActionFailuresWithTypedAttachments()
+    {
+        using var ui = new GuaContext();
+        ui.ConfigureDiagnostics(4, "{\"bridge\":\"local\"}");
+        ui.BeginFrame("test");
+        ui.RegisterNode(new GuaNodeDescriptor("disabled", "button", "Disabled", new GuaBounds(0, 0, 1, 1), Enabled: false));
+        ui.RegisterNode(new GuaNodeDescriptor("secret", "textbox", "Secret", new GuaBounds(0, 1, 1, 1), Value: string.Empty));
+        ui.EndFrame();
+        const string sensitiveValue = "session-sensitive-marker";
+        var sensitiveRequestId = GuaAssertions.GetById(ui, "secret").SetValue(sensitiveValue, sensitive: true);
+        Assert.That(ui.TryConsumeAction(GuaActionType.SetValue, "secret", out var sensitiveRequest), Is.True);
+        Assert.That(ui.EmitActionResult(new GuaActionEvent(sensitiveRequestId, GuaActionType.SetValue, true,
+            GuaActionError.None, "secret", sensitiveRequest.Value!, true)), Is.True);
+        Assert.That(ui.TryPollActionEvent(sensitiveRequestId, out _), Is.True);
+        var output = Path.Combine(TestContext.CurrentContext.WorkDirectory, "gua-session", Guid.NewGuid().ToString("N"));
+        var attached = new List<GuaDiagnosticFile>();
+        try
+        {
+            var session = new GuaDiagnosticsSession(ui, new GuaDiagnosticOptions
+            {
+                TestName = "same-layout",
+                OutputDirectory = output,
+                CallerMetadata = new Dictionary<string, string> { ["suite"] = "nunit" },
+                AttachmentSink = attached.Add,
+                ScreenshotCapture = () => throw new InvalidOperationException("renderer unavailable"),
+            });
+            using var scope = GuaAssertionScope.Use(new GuaAssertionOptions { DiagnosticsSession = session });
+
+            var assertion = Assert.Throws<GuaAssertionException>(() => GuaAssertions.GetById(ui, "disabled").ToBeEnabled());
+            Assert.That(assertion!.Message, Does.Contain("Gua diagnostics:"));
+
+            var action = Assert.Throws<GuaActionException>(() => GuaActionCompletion.EnqueueAndWait(
+                ui, new GuaActionRequest(GuaActionType.Click, NodeId: "missing")));
+            Assert.That(action!.Data["GuaDiagnosticsPath"], Is.Not.Null);
+            Assert.That(action.Data["GuaDiagnosticsCaptureErrors"], Is.Not.Null);
+            Assert.That(attached, Is.Not.Empty);
+            Assert.That(attached.All(file => Path.IsPathFullyQualified(file.Path)), Is.True);
+            Assert.That(attached.Any(file => file.MediaType == "application/json"), Is.True);
+            Assert.That(Directory.EnumerateFiles(output, "version.json", SearchOption.AllDirectories), Is.Not.Empty);
+            Assert.That(Directory.EnumerateFiles(output, "caller-metadata.json", SearchOption.AllDirectories), Is.Not.Empty);
+            Assert.That(string.Join("\n", Directory.EnumerateFiles(output, "*", SearchOption.AllDirectories)
+                .Where(path => Path.GetExtension(path) != ".png").Select(File.ReadAllText)), Does.Not.Contain(sensitiveValue));
+        }
+        finally
+        {
+            if (Directory.Exists(output)) Directory.Delete(output, recursive: true);
+        }
+    }
+
+    [Test]
+    public void DiagnosticsSessionAllocatesParallelSafeDirectories()
+    {
+        using var ui = new GuaContext();
+        ui.ConfigureDiagnostics(1);
+        var output = Path.Combine(TestContext.CurrentContext.WorkDirectory, "gua-session", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var paths = Enumerable.Range(0, 12).AsParallel().Select(_ =>
+                new GuaDiagnosticsSession(ui, new GuaDiagnosticOptions { TestName = "parallel/test", OutputDirectory = output })
+                    .Capture(new InvalidOperationException("failure")).ArtifactPath).ToArray();
+            Assert.That(paths, Has.All.Not.Null);
+            Assert.That(paths.Distinct(StringComparer.Ordinal).Count(), Is.EqualTo(paths.Length));
+        }
+        finally
+        {
+            if (Directory.Exists(output)) Directory.Delete(output, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task AsyncWaitsObserveStateTextValueAndRemovalWithoutFixedSleeps()
     {
         using var _ = GuaAssertionScope.UseNUnit(Assert.Fail);


### PR DESCRIPTION
## 対応 Issue

Closes #48

## 実装内容

- framework非依存の `GuaDiagnosticsSession`、typed file/error/result modelを追加
- assertion failureとaction failureを同じsession/artifact layoutへ統合
- test name + timestamp + unique IDで並列安全なdirectoryを生成
- runtime version、caller metadata、UI tree、history、pending request、logsを収集
- `GodotSceneTestHost.CreateDiagnosticsSession`でprocess metadata、stdout/stderr、任意のオンデマンドscreenshotを追加
- framework非依存attachment callbackとNUnit `TestContext.AddTestAttachment` sample helperを追加
- capture/screenshot/attachment失敗をsecondary errorとして返し、元例外を保持
- sensitive action value非露出、並列capture、Godot実renderer captureをテスト

## Architecture判断

既存 `GuaDiagnosticWriter` と runtime diagnostics schemaを低水準sourceとして維持し、その上に高水準sessionを追加した。runtime coreやprotocol schemaは再実装・変更せず、version/screenshot/Godot process情報はproviderとしてfailure時だけ評価する。NUnitへの必須依存は追加せず、typed attachment callbackをsample側の薄いhelperへ接続した。

## テスト・検証

- `cmake --preset windows-msvc-debug` 成功
- `cmake --build --preset windows-msvc-debug -- /m:1` 成功
- `ctest --test-dir build/windows-msvc-debug -C Debug --output-on-failure` 3/3成功
- `dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj -v:minimal` 成功・警告0
- `dotnet test examples/dotnet-nunit/GuaDotNetNUnitSample.csproj -p:UseProjectReferences=true -v:minimal` 18/18成功
- `dotnet test bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj -v:minimal` 8/8成功
- `dotnet test bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/Gua.Godot.Visual.Integration.Tests.csproj -v:minimal` Godot 4.7実renderer 6/6成功
- `git diff --check` 成功

## 未対応事項

Issue #48範囲内の未対応はない。CI artifact upload設定、screenshot自動redaction、reset/teardown policyの高水準化は範囲外で、後者は前提関係どおりIssue #49へ残す。PNGはrendered secretを含み得るため、保存・添付・公開責任は利用側にある。