### PR TITLE
#49 strict startup/teardown resetとleak診断を高水準化する

### DIFF
--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHost.cs
@@ -4,10 +4,11 @@ using System.Net;
 using System.Net.Sockets;
 using Gua.Core;
 using Gua.Testing;
+using System.Runtime.ExceptionServices;
 
 namespace Gua.Testing.Godot;
 
-public sealed class GodotSceneTestHost : IDisposable
+public sealed class GodotSceneTestHost : IDisposable, IAsyncDisposable
 {
     private readonly GodotSceneTestHostOptions _options;
     private readonly Process _process;
@@ -110,6 +111,10 @@ public sealed class GodotSceneTestHost : IDisposable
                 var clean = context.GetContextStatus();
                 if (!clean.IsClean)
                     throw new InvalidOperationException($"Godot startup reset left queued work: pending={clean.PendingRequestCount}, inFlight={clean.InFlightRequestCount}, events={clean.UnconsumedEventCount}.");
+            }
+            else if (options.StartupResetPolicy.Mode != GuaResetMode.Disabled)
+            {
+                using var startupSession = new GuaTestSession(context, new GuaTestSessionOptions { StartupReset = options.StartupResetPolicy });
             }
             return new GodotSceneTestHost(process, context, options, bridgeUrl, output);
         }
@@ -232,7 +237,21 @@ public sealed class GodotSceneTestHost : IDisposable
         Exception? teardownError = null;
         try
         {
-            if (_options.TeardownReset is { } resetOptions)
+            if (_options.TeardownResetPolicy.Mode != GuaResetMode.Disabled)
+            {
+                var diagnostics = CreateDiagnosticsSession(
+                    _options.DiagnosticsTestName,
+                    _options.DiagnosticsOutputDirectory,
+                    _options.CaptureScreenshotBeforeTeardown);
+                using var session = new GuaTestSession(Context, new GuaTestSessionOptions
+                {
+                    TeardownReset = _options.TeardownResetPolicy,
+                    CaptureDiagnosticsBeforeTeardown = _options.CaptureDiagnosticsBeforeTeardown,
+                    CleanupAfterLeakReport = _options.CleanupAfterLeakReport,
+                    DiagnosticsSession = diagnostics,
+                });
+            }
+            else if (_options.TeardownReset is { } resetOptions)
             {
                 var report = ResetContext(resetOptions);
                 if (report.Result != GuaResetResult.Succeeded)
@@ -250,6 +269,27 @@ public sealed class GodotSceneTestHost : IDisposable
             KillProcess(_process);
         }
         if (teardownError is not null) throw teardownError;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    public void Run(Action<GodotSceneTestHost> body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        Exception? primary = null;
+        try { body(this); }
+        catch (Exception error) { primary = error; }
+        try { Dispose(); }
+        catch (Exception teardown)
+        {
+            if (primary is null) throw;
+            primary.Data["GuaTeardownFailure"] = teardown;
+        }
+        if (primary is not null) ExceptionDispatchInfo.Capture(primary).Throw();
     }
 
     private void ThrowIfDisposed()
@@ -323,6 +363,13 @@ public sealed class GodotSceneTestHost : IDisposable
         EnvironmentVariables = source.EnvironmentVariables,
         StartupReset = source.StartupReset,
         TeardownReset = source.TeardownReset,
+        StartupResetPolicy = source.StartupResetPolicy,
+        TeardownResetPolicy = source.TeardownResetPolicy,
+        CaptureDiagnosticsBeforeTeardown = source.CaptureDiagnosticsBeforeTeardown,
+        CleanupAfterLeakReport = source.CleanupAfterLeakReport,
+        CaptureScreenshotBeforeTeardown = source.CaptureScreenshotBeforeTeardown,
+        DiagnosticsTestName = source.DiagnosticsTestName,
+        DiagnosticsOutputDirectory = source.DiagnosticsOutputDirectory,
     };
 
     private static string ResolveGodotExecutable(string? configuredPath)

--- a/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHostOptions.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GodotSceneTestHostOptions.cs
@@ -1,10 +1,18 @@
 namespace Gua.Testing.Godot;
 
 using Gua.Core;
+using Gua.Testing;
 
 public sealed class GodotSceneTestHostOptions
 {
     public static GodotSceneTestHostOptions Default { get; } = new();
+
+    public static GodotSceneTestHostOptions StrictIsolation { get; } = new()
+    {
+        StartupResetPolicy = GuaResetPolicy.Strict,
+        TeardownResetPolicy = GuaResetPolicy.Strict,
+        CaptureDiagnosticsBeforeTeardown = true,
+    };
 
     public string? GodotExecutablePath { get; init; }
 
@@ -31,4 +39,18 @@ public sealed class GodotSceneTestHostOptions
     public GuaResetOptions? StartupReset { get; init; }
 
     public GuaResetOptions? TeardownReset { get; init; }
+
+    public GuaResetPolicy StartupResetPolicy { get; init; } = GuaResetPolicy.Disabled;
+
+    public GuaResetPolicy TeardownResetPolicy { get; init; } = GuaResetPolicy.Disabled;
+
+    public bool CaptureDiagnosticsBeforeTeardown { get; init; }
+
+    public bool CleanupAfterLeakReport { get; init; }
+
+    public bool CaptureScreenshotBeforeTeardown { get; init; }
+
+    public string DiagnosticsTestName { get; init; } = "godot-scene-teardown";
+
+    public string DiagnosticsOutputDirectory { get; init; } = Path.Combine("artifacts", "gua");
 }

--- a/bindings/dotnet/src/Gua.Testing.Godot/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Godot/README.md
@@ -43,6 +43,27 @@ using var host = GodotSceneTestHost.LoadRendered(scene, new()
 });
 ```
 
+New tests can use lifecycle policies while legacy `StartupReset`,
+`TeardownReset`, and `ResetContext` remain available:
+
+```csharp
+using var host = GodotSceneTestHost.LoadRendered("res://Main.tscn", new GodotSceneTestHostOptions
+{
+    StartupResetPolicy = GuaResetPolicy.Strict,
+    TeardownResetPolicy = GuaResetPolicy.Strict,
+    CaptureDiagnosticsBeforeTeardown = true,
+    CleanupAfterLeakReport = true,
+    CaptureScreenshotBeforeTeardown = true,
+    DiagnosticsTestName = TestContext.CurrentContext.Test.Name,
+});
+```
+
+Teardown diagnostics, optional on-demand screenshot, process metadata, stdout,
+and stderr are captured while the process and bridge are alive. Explicit
+non-strict cleanup may run only afterward. `host.Run(...)` preserves a test-body
+exception as primary and attaches teardown failure as secondary data. Clean
+teardown creates no artifact, and repeated disposal is safe.
+
 Repository-specific factories should retain only game concerns such as locating
 API/database fixtures, choosing repository timeouts, and mapping game-relative
 scene names. Executable discovery, `project.godot` discovery, bridge ports,

--- a/bindings/dotnet/src/Gua.Testing/GuaTestSession.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaTestSession.cs
@@ -1,14 +1,63 @@
 using Gua.Core;
+using System.Runtime.ExceptionServices;
+using System.Text.Json;
 
 namespace Gua.Testing;
 
-public sealed class GuaTestSession
+public enum GuaResetMode
+{
+    Disabled,
+    NonStrict,
+    Strict,
+}
+
+public sealed record GuaResetPolicy(GuaResetMode Mode, GuaResetTargets Targets = GuaResetTargets.Default)
+{
+    public static GuaResetPolicy Disabled { get; } = new(GuaResetMode.Disabled);
+    public static GuaResetPolicy NonStrict { get; } = new(GuaResetMode.NonStrict);
+    public static GuaResetPolicy Strict { get; } = new(GuaResetMode.Strict);
+
+    internal GuaResetOptions ToOptions(ulong epoch) => new(Targets, Mode == GuaResetMode.Strict, epoch);
+}
+
+public sealed class GuaTestSessionOptions
+{
+    public static GuaTestSessionOptions Strict { get; } = new()
+    {
+        StartupReset = GuaResetPolicy.Strict,
+        TeardownReset = GuaResetPolicy.Strict,
+        CaptureDiagnosticsBeforeTeardown = true,
+    };
+
+    public GuaResetPolicy StartupReset { get; init; } = GuaResetPolicy.Disabled;
+    public GuaResetPolicy TeardownReset { get; init; } = GuaResetPolicy.Disabled;
+    public bool CaptureDiagnosticsBeforeTeardown { get; init; }
+    public bool CleanupAfterLeakReport { get; init; }
+    public GuaDiagnosticsSession? DiagnosticsSession { get; init; }
+}
+
+public sealed record GuaLeakItem(ulong? RequestId, string Kind, string Action, string NodeId);
+public sealed record GuaLeakReport(
+    ulong SessionEpoch,
+    uint PendingRequestCount,
+    uint InFlightRequestCount,
+    uint UnconsumedEventCount,
+    IReadOnlyList<GuaLeakItem> Items)
+{
+    public bool IsClean => PendingRequestCount == 0 && InFlightRequestCount == 0 && UnconsumedEventCount == 0;
+}
+
+public sealed class GuaTestSession : IDisposable, IAsyncDisposable
 {
     private readonly IGuaContext _context;
+    private readonly GuaTestSessionOptions _options;
+    private bool _disposed;
 
-    public GuaTestSession(IGuaContext context)
+    public GuaTestSession(IGuaContext context, GuaTestSessionOptions? options = null)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
+        _options = options ?? new GuaTestSessionOptions();
+        ApplyReset(_options.StartupReset, "startup");
     }
 
     public GuaContextStatus Inspect() => _context.GetContextStatus();
@@ -49,5 +98,130 @@ public sealed class GuaTestSession
     public Task<GuaResetReport> ResetAsync(GuaResetOptions? options = null, CancellationToken cancellationToken = default)
     {
         return Task.Run(() => Reset(options), cancellationToken);
+    }
+
+    public GuaLeakReport InspectLeaks()
+    {
+        var status = Inspect();
+        var items = new List<GuaLeakItem>();
+        try
+        {
+            using var document = JsonDocument.Parse(_context.GetDiagnosticsJson());
+            var root = document.RootElement;
+            AddItems(root, "pendingRequests", "request", items);
+            if (status.UnconsumedEventCount > 0)
+                AddItems(root, "events", "event", items, (int)Math.Min(status.UnconsumedEventCount, (uint)int.MaxValue));
+        }
+        catch
+        {
+            if (status.FirstPendingAction is { } requestAction)
+                items.Add(new(null, "request", requestAction.ToString(), status.FirstPendingNodeId));
+            if (status.FirstEventAction is { } eventAction)
+                items.Add(new(null, "event", eventAction.ToString(), status.FirstEventNodeId));
+        }
+        return new(status.SessionEpoch, status.PendingRequestCount, status.InFlightRequestCount, status.UnconsumedEventCount, items);
+    }
+
+    public void Run(Action body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        Exception? primary = null;
+        try { body(); }
+        catch (Exception error) { primary = error; }
+
+        var teardown = Teardown(primary);
+        _disposed = true;
+        if (primary is not null)
+        {
+            if (teardown is not null) primary.Data["GuaTeardownFailure"] = teardown;
+            ExceptionDispatchInfo.Capture(primary).Throw();
+        }
+        if (teardown is not null) throw teardown;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        var error = Teardown(null);
+        if (error is not null) throw error;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private Exception? Teardown(Exception? primary)
+    {
+        var leak = InspectLeaks();
+        var failures = new List<Exception>();
+        if ((_options.CaptureDiagnosticsBeforeTeardown && (!leak.IsClean || primary is not null)) && _options.DiagnosticsSession is { } diagnostics)
+        {
+            var cause = primary ?? new GuaAssertionException(FormatLeak(leak));
+            var result = diagnostics.Capture(cause);
+            if (primary is not null) primary.Data["GuaDiagnosticsResult"] = result;
+            if (result.CaptureErrors.Count > 0)
+                failures.Add(new InvalidOperationException(string.Join("; ", result.CaptureErrors.Select(e => $"{e.Stage}: {e.ErrorType}: {e.Message}"))));
+        }
+
+        try { ApplyReset(_options.TeardownReset, "teardown"); }
+        catch (Exception error)
+        {
+            failures.Add(error);
+            if (_options.CleanupAfterLeakReport && !leak.IsClean)
+            {
+                try { Reset(new GuaResetOptions(_options.TeardownReset.Targets, Strict: false)); }
+                catch (Exception cleanupError) { failures.Add(cleanupError); }
+            }
+        }
+        return failures.Count switch
+        {
+            0 => null,
+            1 => failures[0],
+            _ => new AggregateException("Gua teardown reported multiple secondary failures.", failures),
+        };
+    }
+
+    private void ApplyReset(GuaResetPolicy policy, string stage)
+    {
+        if (policy.Mode == GuaResetMode.Disabled) return;
+        var status = Inspect();
+        try { Reset(policy.ToOptions(status.SessionEpoch)); }
+        catch (Exception error)
+        {
+            var leak = InspectLeaks();
+            throw new GuaAssertionException($"Gua {stage} reset failed. {FormatLeak(leak)} {error.Message}", error);
+        }
+    }
+
+    private static string FormatLeak(GuaLeakReport leak)
+    {
+        var details = string.Join(", ", leak.Items.Select(item =>
+            $"{item.Kind}[requestId={item.RequestId?.ToString() ?? "unknown"}, action={item.Action}, nodeId={item.NodeId}]"));
+        return $"Gua session {leak.SessionEpoch} leaked pending={leak.PendingRequestCount}, inFlight={leak.InFlightRequestCount}, events={leak.UnconsumedEventCount}" +
+            (details.Length == 0 ? string.Empty : $"; {details}") + ". Payload values are redacted.";
+    }
+
+    private static void AddItems(JsonElement root, string property, string kind, List<GuaLeakItem> items, int? tailCount = null)
+    {
+        if (!root.TryGetProperty(property, out var array) || array.ValueKind != JsonValueKind.Array) return;
+        var selected = array.EnumerateArray().ToArray();
+        if (tailCount is { } count && selected.Length > count) selected = selected[^count..];
+        foreach (var item in selected)
+        {
+            ulong? requestId = item.TryGetProperty("requestId", out var id) && id.TryGetUInt64(out var value) ? value : null;
+            var action = ReadString(item, "action", "type");
+            var nodeId = ReadString(item, "nodeId");
+            items.Add(new(requestId, kind, action, nodeId));
+        }
+    }
+
+    private static string ReadString(JsonElement item, params string[] names)
+    {
+        foreach (var name in names)
+            if (item.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String) return value.GetString() ?? string.Empty;
+        return string.Empty;
     }
 }

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -85,6 +85,32 @@ session.Reset(); // setup; starts a new session epoch
 session.Reset(new GuaResetOptions(Strict: true)); // teardown; throws if dirty
 ```
 
+For high-level isolation, construct `GuaTestSession` with lifecycle options.
+`GuaTestSessionOptions.Strict` enables strict startup and teardown reset.
+Policies can also be selected independently with `GuaResetPolicy.Disabled`,
+`NonStrict`, or `Strict`; their default targets are nodes, requests, events,
+and retained history. Logs and screenshots remain preserved unless selected.
+
+```csharp
+using var session = new GuaTestSession(context, new GuaTestSessionOptions
+{
+    StartupReset = GuaResetPolicy.Strict,
+    TeardownReset = GuaResetPolicy.Strict,
+    CaptureDiagnosticsBeforeTeardown = true,
+    CleanupAfterLeakReport = true,
+    DiagnosticsSession = diagnostics,
+});
+
+session.Run(() => RunTestBody());
+```
+
+`Run` rethrows the original test-body exception with its type and stack trace.
+A teardown failure is attached as `GuaTeardownFailure`, and a typed diagnostic
+result as `GuaDiagnosticsResult`. Leak inspection reports epoch, counts,
+request ID, action/event type, and node ID without action payload values.
+Cleanup runs only after diagnostics were attempted and only when enabled.
+Clean completion creates no artifact, and `Dispose` is idempotent.
+
 `ResetAsync` provides the same contract for remote contexts and honors
 `CancellationToken`. Remote reset always includes the inspected session epoch,
 so a stale client cannot reset a newer shared runtime session.

--- a/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/GodotVisualIntegrationTests.cs
@@ -246,6 +246,53 @@ public sealed class GodotVisualIntegrationTests
         });
     }
 
+    [Test]
+    public void StrictGodotTeardownCapturesBeforeProcessExitAndCleansLeakedRequest()
+    {
+        var output = Path.Combine(_root, "teardown-diagnostics", Guid.NewGuid().ToString("N"));
+        var host = GodotSceneTestHost.LoadRendered("res://Main.tscn", new GodotSceneTestHostOptions
+        {
+            GodotExecutablePath = Environment.GetEnvironmentVariable("GODOT_EXECUTABLE"),
+            ProjectPath = Path.Combine(FindRepositoryRoot(), "examples", "godot-gdscript"),
+            UseAvailableBridgePort = true,
+            ConnectTimeout = TimeSpan.FromSeconds(15),
+            RequestTimeout = TimeSpan.FromSeconds(10),
+            SceneTimeout = TimeSpan.FromSeconds(15),
+            StartupResetPolicy = GuaResetPolicy.Strict,
+            TeardownResetPolicy = GuaResetPolicy.Strict,
+            CaptureDiagnosticsBeforeTeardown = true,
+            CleanupAfterLeakReport = true,
+            CaptureScreenshotBeforeTeardown = true,
+            DiagnosticsTestName = "strict-godot-teardown",
+            DiagnosticsOutputDirectory = output,
+            EnvironmentVariables = new Dictionary<string, string> { ["GUA_VISUAL_E2E"] = "1", ["GUA_V2_E2E"] = "1" },
+            AdditionalArguments = ["--display-driver", "windows", "--rendering-method", "gl_compatibility", "--resolution", "1280x720"],
+        });
+        try
+        {
+            GuaAssertions.WaitForId(host.Context, "v2-user-name", timeout: TimeSpan.FromSeconds(10));
+            Assert.That(GuaAssertions.GetById(host.Context, "v2-user-name").SetValue("godot-secret-marker", sensitive: true), Is.GreaterThan(0));
+            var error = Assert.Throws<GuaAssertionException>(host.Dispose);
+            Assert.Multiple(() =>
+            {
+                Assert.That(error!.Message, Does.Contain("teardown reset failed").And.Not.Contain("godot-secret-marker"));
+                Assert.That(Directory.EnumerateFiles(output, "godot-process.json", SearchOption.AllDirectories), Is.Not.Empty);
+                Assert.That(Directory.EnumerateFiles(output, "screenshot-on-failure.png", SearchOption.AllDirectories), Is.Not.Empty);
+                Assert.That(JsonDocument.Parse(File.ReadAllText(Directory.EnumerateFiles(output, "godot-process.json", SearchOption.AllDirectories).Single()))
+                    .RootElement.GetProperty("hasExited").GetBoolean(), Is.False);
+                Assert.That(string.Join("\n", Directory.EnumerateFiles(output, "*", SearchOption.AllDirectories)
+                    .Where(path => Path.GetExtension(path) != ".png").Select(File.ReadAllText)), Does.Not.Contain("godot-secret-marker"));
+            });
+            Assert.DoesNotThrow(host.Dispose);
+            Assert.DoesNotThrow(() => host.DisposeAsync().GetAwaiter().GetResult());
+        }
+        finally
+        {
+            try { host.Dispose(); } catch { }
+            if (Directory.Exists(output)) Directory.Delete(output, recursive: true);
+        }
+    }
+
     private static async Task<IReadOnlyList<GuaActionEvent>> WaitForActionEventsAsync(
         IGuaContext context, int count, TimeSpan timeout)
     {

--- a/examples/dotnet-nunit/TitleScreenTests.cs
+++ b/examples/dotnet-nunit/TitleScreenTests.cs
@@ -192,6 +192,109 @@ public sealed class TitleScreenTests
     }
 
     [Test]
+    public void LifecycleSessionPreservesPrimaryFailureReportsLeakAndCleansAfterDiagnostics()
+    {
+        using var ui = new GuaContext();
+        ui.BeginFrame("form");
+        ui.RegisterNode(new GuaNodeDescriptor("password", "textbox", "Password", new GuaBounds(0, 0, 100, 20)));
+        ui.RegisterNode(new GuaNodeDescriptor("submit", "button", "Submit", new GuaBounds(0, 30, 100, 20)));
+        ui.EndFrame();
+        var output = Path.Combine(TestContext.CurrentContext.WorkDirectory, "gua-lifecycle", Guid.NewGuid().ToString("N"));
+        var primary = new InvalidOperationException("primary-test-failure");
+        try
+        {
+            var diagnostics = new GuaDiagnosticsSession(ui, new GuaDiagnosticOptions
+            {
+                TestName = "strict-teardown",
+                OutputDirectory = output,
+            });
+            using var session = new GuaTestSession(ui, new GuaTestSessionOptions
+            {
+                TeardownReset = GuaResetPolicy.Strict,
+                CaptureDiagnosticsBeforeTeardown = true,
+                CleanupAfterLeakReport = true,
+                DiagnosticsSession = diagnostics,
+            });
+
+            var thrown = Assert.Throws<InvalidOperationException>(() => session.Run(() =>
+            {
+                Assert.That(GuaAssertions.GetById(ui, "password").SetValue("secret-lifecycle-marker", sensitive: true), Is.GreaterThan(0));
+                Assert.That(ui.EnqueueAction(new GuaActionRequest(GuaActionType.Click, "submit"), out var clickId), Is.EqualTo(GuaActionError.None));
+                Assert.That(ui.TryConsumeAction(GuaActionType.Click, "submit", out _), Is.True);
+                Assert.That(ui.EmitActionResult(new GuaActionEvent(clickId, GuaActionType.Click, true, GuaActionError.None, "submit", "", false)), Is.True);
+                var leak = session.InspectLeaks();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(leak.SessionEpoch, Is.EqualTo(1));
+                    Assert.That(leak.PendingRequestCount, Is.EqualTo(1));
+                    Assert.That(leak.UnconsumedEventCount, Is.EqualTo(1));
+                    Assert.That(leak.Items, Has.Some.Matches<GuaLeakItem>(item => item.RequestId is not null && item.Action == "set_value" && item.NodeId == "password"));
+                    Assert.That(leak.Items, Has.Some.Matches<GuaLeakItem>(item => item.RequestId == clickId && item.Kind == "event" && item.Action == "click" && item.NodeId == "submit"));
+                });
+                throw primary;
+            }));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(thrown, Is.SameAs(primary));
+                Assert.That(thrown!.Data["GuaTeardownFailure"], Is.TypeOf<GuaAssertionException>());
+                Assert.That(thrown.Data["GuaDiagnosticsResult"], Is.TypeOf<GuaDiagnosticsResult>());
+                Assert.That(session.Inspect().IsClean, Is.True);
+                Assert.That(string.Join("\n", Directory.EnumerateFiles(output, "*", SearchOption.AllDirectories)
+                    .Where(path => Path.GetExtension(path) != ".png").Select(File.ReadAllText)),
+                    Does.Not.Contain("secret-lifecycle-marker"));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(output)) Directory.Delete(output, recursive: true);
+        }
+    }
+
+    [Test]
+    public void LifecycleSessionDoesNotCaptureArtifactsOnCleanSuccessAndDisposeIsIdempotent()
+    {
+        using var ui = new GuaContext();
+        var output = Path.Combine(TestContext.CurrentContext.WorkDirectory, "gua-lifecycle", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var session = new GuaTestSession(ui, new GuaTestSessionOptions
+            {
+                TeardownReset = GuaResetPolicy.Strict,
+                CaptureDiagnosticsBeforeTeardown = true,
+                DiagnosticsSession = new GuaDiagnosticsSession(ui, new GuaDiagnosticOptions
+                {
+                    TestName = "clean-success",
+                    OutputDirectory = output,
+                }),
+            });
+            session.Run(() => { });
+            Assert.DoesNotThrow(session.Dispose);
+            Assert.DoesNotThrow(() => session.DisposeAsync().GetAwaiter().GetResult());
+            Assert.That(Directory.Exists(output), Is.False);
+        }
+        finally
+        {
+            if (Directory.Exists(output)) Directory.Delete(output, recursive: true);
+        }
+    }
+
+    [Test]
+    public void LifecycleStartupAndTeardownPoliciesAdvanceTheExpectedEpoch()
+    {
+        using var ui = new GuaContext();
+        var session = new GuaTestSession(ui, new GuaTestSessionOptions
+        {
+            StartupReset = GuaResetPolicy.NonStrict,
+            TeardownReset = GuaResetPolicy.NonStrict,
+        });
+        Assert.That(session.Inspect().SessionEpoch, Is.EqualTo(2));
+        session.Run(() => Assert.That(session.Inspect().SessionEpoch, Is.EqualTo(2)));
+        Assert.That(ui.GetContextStatus().SessionEpoch, Is.EqualTo(3));
+        Assert.DoesNotThrow(session.Dispose);
+    }
+
+    [Test]
     public void NonStrictResetStartsNewEpochAndPreservesOptionalStateByDefault()
     {
         using var ui = new GuaContext();

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -72,6 +72,14 @@ epoch is rejected without mutation. Multiple clients of one runtime observe the
 same reset because the isolation boundary is the shared runtime context, not a
 WebSocket connection.
 
+High-level testing clients may compose status, reset, diagnostics, and screenshot
+APIs into independent startup/teardown policies. Teardown capture runs before
+the context, bridge, or engine process is destroyed; optional non-strict cleanup
+runs only after leak diagnostics were attempted. Test-body failures remain
+primary, with teardown/capture failures reported as secondary information. Leak
+reports may include request ID, action or event type, node ID, counts, and session
+epoch, but never action payload values. Clean sessions do not create artifacts.
+
 ## Failure diagnostics and artifact version 1
 
 `diagnostics.schema.json` is the source of truth for a best-effort failure


### PR DESCRIPTION
## 対応Issue

Closes #49

## 実装内容

- `GuaResetPolicy` と `GuaTestSessionOptions` を追加し、startup / teardown の disabled・non-strict・strict を独立指定可能にした
- `GuaTestSession.Run` で元のtest body例外を型・stack traceごと保持し、teardown failureと型付きdiagnostics resultをsecondary dataとして併記した
- session epoch、queue count、request ID、action/event type、node IDをpayload非露出で返す `GuaLeakReport` を追加した
- leak診断を試行した後に限り、明示設定でnon-strict cleanupを実行する契約を追加した
- `GodotSceneTestHost` がprocess/bridge破棄前にdiagnostics、stdout/stderr、process metadata、任意のon-demand screenshotを取得するようにした
- session/hostの同期・非同期Disposeを二重実行安全にした
- protocol docs、Gua.Testing / Godot README、NUnit sampleを同期した

## Architecture判断

- runtime coreやreset ABIは再実装せず、既存のstatus/reset/diagnostics/screenshot APIを高水準testing seamで合成した
- strict resetのtransactional契約を維持し、cleanupは診断後の明示的non-strict resetに限定した
- leak詳細は既存diagnosticsのredacted request/event情報から構成し、sensitive action valueはfile名・error・artifactへ出さない
- 既存の `GuaResetOptions`、`StartupReset` / `TeardownReset`、`ResetContext` は互換維持した

## テスト・検証

- MSVC相当構成: `cmake -S . -B build/issue49-msvc-debug -G "Visual Studio 18 2026" -A x64` 成功
- MSVC full build: `cmake --build build/issue49-msvc-debug --config Debug` 成功
- `ctest --test-dir build/issue49-msvc-debug -C Debug --output-on-failure` 成功（3/3）
- `dotnet test bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj` 成功（8/8）
- `dotnet test examples/dotnet-nunit/GuaDotNetNUnitSample.csproj -p:UseProjectReferences=true` 成功（21/21）
- `GUA_GODOT_REAL_RENDERER_TEST=1 dotnet test bindings/dotnet/tests/Gua.Godot.Visual.Integration.Tests/Gua.Godot.Visual.Integration.Tests.csproj` 成功（7/7）
- managed build 警告0
- `git diff --check` 成功

既定 `cmake --preset windows-msvc-debug` は初回FetchContent中に実行上限へ達し、残留processが既定build directoryを保持したため、同じgenerator/architectureを別build directoryで再構成した。最初のcloneで一度network resetが発生したが、再試行後のconfigure/full buildは成功している。

## 未対応事項

Issue #49 範囲内の未対応事項はありません。CI固有artifact uploadやscreenshot自動redactionは引き続き利用側／範囲外です。
