### PR TITLE
#58 C#ライブラリを.NET Standard 2.1へ対応する

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -68,9 +68,18 @@ jobs:
         run: cmake --build --preset windows-msvc-release --target gua --config Release
 
       - name: Restore
-        run: dotnet restore bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj
+        run: |
+          dotnet restore bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj
+          dotnet restore bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj
 
-      - name: Build
+      - name: Build Gua.Core and Gua.Testing target frameworks
+        run: |
+          dotnet build bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release --framework net10.0 --no-restore -p:Version=${{ steps.version.outputs.version }}
+          dotnet build bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release --framework netstandard2.1 --no-restore -p:Version=${{ steps.version.outputs.version }}
+          dotnet build bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release --framework net10.0 --no-restore -p:Version=${{ steps.version.outputs.version }}
+          dotnet build bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release --framework netstandard2.1 --no-restore -p:Version=${{ steps.version.outputs.version }}
+
+      - name: Build existing consumers
         run: dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release --no-restore -p:Version=${{ steps.version.outputs.version }}
 
       - name: Pack Gua.Core

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -33,10 +33,22 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Restore
-        run: dotnet restore bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj
+        run: |
+          dotnet restore bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj
+          dotnet restore bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj
+          dotnet restore examples/unity-smoke/Gua.UnitySmoke.csproj
 
-      - name: Build
-        run: dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release --no-restore
+      - name: Build Gua.Core and Gua.Testing target frameworks
+        run: |
+          dotnet build bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release --framework net10.0 --no-restore
+          dotnet build bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release --framework netstandard2.1 --no-restore
+          dotnet build bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release --framework net10.0 --no-restore
+          dotnet build bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release --framework netstandard2.1 --no-restore
+
+      - name: Build existing consumers and Unity smoke host
+        run: |
+          dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release --no-restore
+          dotnet build examples/unity-smoke/Gua.UnitySmoke.csproj --configuration Release --no-restore
 
   typescript:
     name: TypeScript / tsc

--- a/README.ja.md
+++ b/README.ja.md
@@ -113,6 +113,21 @@ NUnitサンプルは次のコマンドで実行できます。
 dotnet test examples/dotnet-nunit/GuaDotNetNUnitSample.csproj
 ```
 
+### Unity 6 Windows Editor
+
+`Gua.Core`と`Gua.Testing`は`net10.0`と`netstandard2.1`の両方を対象にします。
+既定の**.NET Standard 2.1** API Compatibility Levelを使うUnity 6では、
+native C ABIを変えずにmanaged assemblyを読み込めます。最初の検証対象は
+Windows Editor x64です。managed assemblyとNuGet依存assemblyを
+`Assets/Plugins/Gua/Managed`へ、`gua.dll`を`Assets/Plugins/x86_64`へ配置し、
+UnityのPlugin Import SettingsでWindows EditorとWindows Standalone x86_64を
+有効にします。
+
+最小`MonoBehaviour`、具体的なビルド・配置手順、Unityなしでも同じ
+`netstandard2.1` assemblyとnative呼び出しを検証できるsmoke hostは
+[`examples/unity-smoke`](examples/unity-smoke/README.md)を参照してください。
+IL2CPP/AOTとWindows以外のnative targetは個別検証が必要です。
+
 ## Inspector
 
 InspectorはGuaプロトコルのスナップショットを表示するReactアプリケーションです。MCPには依存せず、`GuaInspectorClient`抽象化を通じてWebSocketブリッジやネイティブランタイムへ接続します。

--- a/README.md
+++ b/README.md
@@ -270,6 +270,22 @@ dotnet pack bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration R
 dotnet test examples/dotnet-nunit/GuaDotNetNUnitSample.csproj
 ```
 
+### Unity 6 Windows Editor
+
+`Gua.Core` and `Gua.Testing` target both `net10.0` and `netstandard2.1`.
+Unity 6 projects using the default **.NET Standard 2.1** API Compatibility
+Level can load the managed assemblies without changing the native C ABI.
+The first verified native configuration is Windows Editor x64: place the
+managed assemblies and their NuGet dependency closure under
+`Assets/Plugins/Gua/Managed`, and place `gua.dll` under
+`Assets/Plugins/x86_64`. Unity's Plugin Import Settings must enable the DLL for
+the Windows Editor and Windows Standalone x86_64 targets.
+
+See [`examples/unity-smoke`](examples/unity-smoke/README.md) for the minimal
+`MonoBehaviour`, exact build and placement steps, and the command-line smoke
+host. IL2CPP/AOT and non-Windows native targets remain separately verified
+platform work.
+
 ## Inspector
 
 The Inspector is a React application that consumes Gua protocol snapshots. It is

--- a/bindings/dotnet/src/Gua.Core/Compatibility.cs
+++ b/bindings/dotnet/src/Gua.Core/Compatibility.cs
@@ -1,0 +1,24 @@
+namespace Gua.Core
+{
+    internal static class Guard
+    {
+        internal static void NotNull(object? value, string parameterName)
+        {
+            if (value is null) throw new ArgumentNullException(parameterName);
+        }
+
+        internal static void NotZero(ulong value, string parameterName)
+        {
+            if (value == 0) throw new ArgumentOutOfRangeException(parameterName);
+        }
+    }
+}
+
+#if NETSTANDARD2_1
+namespace System.Runtime.CompilerServices
+{
+    internal sealed class IsExternalInit
+    {
+    }
+}
+#endif

--- a/bindings/dotnet/src/Gua.Core/Gua.Core.csproj
+++ b/bindings/dotnet/src/Gua.Core/Gua.Core.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Gua.Core</PackageId>
@@ -19,6 +20,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -21,7 +21,7 @@ public sealed class GuaContext : IGuaContext, IDisposable
             throw new InvalidOperationException(Native.NativeLoadErrorMessage(ex), ex);
         }
 
-        if (_handle == nint.Zero)
+        if (_handle == 0)
         {
             throw new InvalidOperationException("Failed to create a Gua context.");
         }
@@ -60,7 +60,7 @@ public sealed class GuaContext : IGuaContext, IDisposable
 
     public void RegisterNode(GuaNodeDescriptor descriptor)
     {
-        ArgumentNullException.ThrowIfNull(descriptor);
+        Guard.NotNull(descriptor, nameof(descriptor));
         ThrowIfDisposed();
 
         var known = GuaNodeKnownState.None;
@@ -82,7 +82,7 @@ public sealed class GuaContext : IGuaContext, IDisposable
         if (descriptor.SelectedIndex.HasValue) known |= GuaNodeKnownState.SelectedIndex;
 
         var strings = new[] { descriptor.Id, descriptor.ParentId, descriptor.Role, descriptor.Label, descriptor.Text, descriptor.Value };
-        var pointers = strings.Select(value => value is null ? nint.Zero : System.Runtime.InteropServices.Marshal.StringToCoTaskMemUTF8(value)).ToArray();
+        var pointers = strings.Select<string?, nint>(value => value is null ? default : System.Runtime.InteropServices.Marshal.StringToCoTaskMemUTF8(value)).ToArray();
         try
         {
             var native = new Native.GuaNativeNodeDescriptorV2
@@ -120,7 +120,7 @@ public sealed class GuaContext : IGuaContext, IDisposable
         }
         finally
         {
-            foreach (var pointer in pointers.Where(pointer => pointer != nint.Zero))
+            foreach (var pointer in pointers.Where(pointer => pointer != 0))
             {
                 System.Runtime.InteropServices.Marshal.FreeCoTaskMem(pointer);
             }
@@ -319,10 +319,10 @@ public sealed class GuaContext : IGuaContext, IDisposable
 
     public GuaQueryResult Query(GuaSelector selector)
     {
-        ArgumentNullException.ThrowIfNull(selector);
+        Guard.NotNull(selector, nameof(selector));
         ThrowIfDisposed();
         var values = new[] { selector.Id, selector.Role, selector.Name, selector.Text, selector.ParentId };
-        var pointers = values.Select(value => value is null ? nint.Zero : System.Runtime.InteropServices.Marshal.StringToCoTaskMemUTF8(value)).ToArray();
+        var pointers = values.Select<string?, nint>(value => value is null ? default : System.Runtime.InteropServices.Marshal.StringToCoTaskMemUTF8(value)).ToArray();
         try
         {
             var native = new Native.GuaNativeSelectorV1
@@ -351,7 +351,7 @@ public sealed class GuaContext : IGuaContext, IDisposable
         }
         finally
         {
-            foreach (var pointer in pointers.Where(pointer => pointer != nint.Zero))
+            foreach (var pointer in pointers.Where(pointer => pointer != 0))
                 System.Runtime.InteropServices.Marshal.FreeCoTaskMem(pointer);
         }
     }
@@ -402,7 +402,7 @@ public sealed class GuaContext : IGuaContext, IDisposable
 
     public bool TryPollActionEvent(ulong requestId, out GuaActionEvent e)
     {
-        ArgumentOutOfRangeException.ThrowIfZero(requestId);
+        Guard.NotZero(requestId, nameof(requestId));
         return TryPollActionEventCore(requestId, out e);
     }
 
@@ -525,18 +525,18 @@ public sealed class GuaContext : IGuaContext, IDisposable
 
     public void Dispose()
     {
-        if (_handle == nint.Zero)
+        if (_handle == 0)
         {
             return;
         }
 
         Native.gua_destroy_context(_handle);
-        _handle = nint.Zero;
+        _handle = 0;
     }
 
     private void ThrowIfDisposed()
     {
-        if (_handle == nint.Zero)
+        if (_handle == 0)
         {
             throw new ObjectDisposedException(nameof(GuaContext));
         }

--- a/bindings/dotnet/src/Gua.Core/Native.NetStandard.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.NetStandard.cs
@@ -1,0 +1,138 @@
+#if NETSTANDARD2_1
+using System.Runtime.InteropServices;
+
+namespace Gua.Core;
+
+internal static partial class Native
+{
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint gua_create_context();
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void gua_destroy_context(nint context);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void gua_begin_frame(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string screen);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void gua_end_frame(nint context);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void gua_register_node(
+        nint context,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string id,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string role,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string label,
+        GuaBounds bounds,
+        int visible,
+        int enabled);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int gua_register_node_v2(nint context, in GuaNativeNodeDescriptorV2 descriptor);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int gua_register_node_v3(nint context, in GuaNativeNodeDescriptorV3 descriptor);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint gua_get_ui_tree_json(nint context);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_copy_ui_tree_json(nint context, byte* outJson, int outJsonSize);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void gua_add_log(nint context, int level, [MarshalAs(UnmanagedType.LPUTF8Str)] string message);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint gua_get_logs_json(nint context);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_copy_logs_json(nint context, byte* outJson, int outJsonSize);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void gua_set_screenshot(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string dataUri, int width, int height);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern nint gua_get_screenshot_json(nint context);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_copy_screenshot_json(nint context, byte* outJson, int outJsonSize);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int gua_set_diagnostics_history_limit(nint context, uint historyLimit);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int gua_set_diagnostics_environment_json(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string environmentJson);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_copy_diagnostics_json(nint context, byte* outJson, int outJsonSize);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_copy_version_json(byte* outJson, int outJsonSize);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int gua_get_node_state(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeId, out GuaNodeState state);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_get_node_state_v2(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeId, GuaNativeNodeStateV2* state);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_find_node_by_id(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeId, byte* outNodeId, int outNodeIdSize);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_find_node_by_role(
+        nint context,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string role,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? name,
+        byte* outNodeId,
+        int outNodeIdSize);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_find_node_by_text(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string text, byte* outNodeId, int outNodeIdSize);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_query_nodes_json(nint context, in GuaNativeSelectorV1 selector, byte* outJson, int outJsonSize);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int gua_enqueue_click(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeId);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int gua_consume_click_request(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeId);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int gua_emit_click(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeId);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_poll_event(nint context, GuaNativeEvent* outEvent);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int gua_enqueue_action(nint context, in GuaNativeActionRequestDescriptor descriptor, out ulong requestId);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_poll_event_v2(nint context, GuaNativeEventV2* outEvent);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_poll_event_v2_for_request(nint context, ulong requestId, GuaNativeEventV2* outEvent);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_poll_event_v3(nint context, GuaNativeEventV3* outEvent);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_poll_event_v3_for_request(nint context, ulong requestId, GuaNativeEventV3* outEvent);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_consume_action_request(
+        nint context,
+        int action,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? nodeId,
+        GuaNativeActionRequest* outRequest);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int gua_emit_action_result(nint context, in GuaNativeActionResult result);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_get_context_status(nint context, GuaNativeContextStatus* status);
+
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern unsafe int gua_reset_context(nint context, in GuaNativeResetOptions options, GuaNativeResetReport* report);
+}
+#endif

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -203,9 +203,12 @@ internal static partial class Native
 
     static Native()
     {
+#if !NETSTANDARD2_1
         NativeLibrary.SetDllImportResolver(typeof(Native).Assembly, ResolveGuaLibrary);
+#endif
     }
 
+#if !NETSTANDARD2_1
     private static nint ResolveGuaLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
         if (!string.Equals(libraryName, "gua", StringComparison.Ordinal))
@@ -238,12 +241,13 @@ internal static partial class Native
             ? fallbackHandle
             : nint.Zero;
     }
+#endif
 
     internal static string NativeLoadErrorMessage(Exception exception)
     {
-        var fileName = OperatingSystem.IsWindows()
+        var fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? "gua.dll"
-            : OperatingSystem.IsMacOS()
+            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
                 ? "libgua.dylib"
                 : "libgua.so";
 
@@ -259,18 +263,26 @@ internal static partial class Native
         }
 
         var searched = string.Join(Environment.NewLine, directories.Select(directory => $"  - {Path.Combine(directory, fileName)}"));
+#if NETSTANDARD2_1
+        return
+            $"Failed to load the native Gua runtime '{fileName}'. Place it in the application output directory or configure it as a Unity native plug-in. The netstandard2.1 target uses the host's normal P/Invoke resolution." +
+            $"{Environment.NewLine}Expected locations:{Environment.NewLine}{searched}{Environment.NewLine}Original error: {exception.Message}";
+#else
         return
             $"Failed to load the native Gua runtime '{fileName}'. Build native/gua-core and make the library discoverable with GUA_NATIVE_DIR, the .NET output directory, or the current directory." +
             $"{Environment.NewLine}Searched:{Environment.NewLine}{searched}{Environment.NewLine}Original error: {exception.Message}";
+#endif
     }
 
     private static IEnumerable<string> CandidateNativeDirectories(Assembly assembly)
     {
+#if !NETSTANDARD2_1
         var configured = Environment.GetEnvironmentVariable("GUA_NATIVE_DIR");
         if (!string.IsNullOrWhiteSpace(configured))
         {
             yield return configured;
         }
+#endif
 
         yield return AppContext.BaseDirectory;
 
@@ -287,6 +299,7 @@ internal static partial class Native
         yield return Environment.CurrentDirectory;
     }
 
+#if !NETSTANDARD2_1
     [LibraryImport("gua")]
     internal static partial nint gua_create_context();
 
@@ -407,4 +420,5 @@ internal static partial class Native
 
     [LibraryImport("gua")]
     internal static unsafe partial int gua_reset_context(nint context, in GuaNativeResetOptions options, GuaNativeResetReport* report);
+#endif
 }

--- a/bindings/dotnet/src/Gua.Core/README.md
+++ b/bindings/dotnet/src/Gua.Core/README.md
@@ -2,6 +2,12 @@
 
 `Gua.Core` is the .NET binding for the native Gua C ABI.
 
+The package includes `net10.0` and `netstandard2.1` managed assemblies. The
+`net10.0` target keeps Gua's development-time native resolver and
+`GUA_NATIVE_DIR` override. The `netstandard2.1` target uses ordinary UTF-8
+`DllImport` declarations so Unity owns native discovery through its Plugin
+Import Settings.
+
 The NuGet package includes the Windows x64 native runtime at:
 
 ```text
@@ -11,6 +17,10 @@ runtimes/win-x64/native/gua.dll
 .NET copies that native asset to the consuming app or test output as part of
 normal package restore/build. `GUA_NATIVE_DIR` remains available when you want to
 override the packaged runtime with a locally built one.
+
+For Unity 6 Windows Editor x64 setup, including managed dependencies and native
+plugin placement, see the
+[Unity smoke guide](https://github.com/link1345/gua/tree/main/examples/unity-smoke).
 
 Semantic operations use `EnqueueAction` and return a `requestId`. The host adapter
 consumes the request, performs the real UI operation, then calls

--- a/bindings/dotnet/src/Gua.Testing/Compatibility.cs
+++ b/bindings/dotnet/src/Gua.Testing/Compatibility.cs
@@ -1,0 +1,38 @@
+namespace Gua.Testing
+{
+    internal static class Guard
+    {
+        internal static void NotNull(object? value, string parameterName)
+        {
+            if (value is null) throw new ArgumentNullException(parameterName);
+        }
+
+        internal static void NotNullOrWhiteSpace(string? value, string parameterName)
+        {
+            if (value is null) throw new ArgumentNullException(parameterName);
+            if (string.IsNullOrWhiteSpace(value)) throw new ArgumentException("Value cannot be empty or whitespace.", parameterName);
+        }
+    }
+}
+
+#if NETSTANDARD2_1
+namespace System.Runtime.CompilerServices
+{
+    internal sealed class IsExternalInit
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
+        public CompilerFeatureRequiredAttribute(string featureName) => FeatureName = featureName;
+        public string FeatureName { get; }
+        public bool IsOptional { get; init; }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
+    internal sealed class RequiredMemberAttribute : Attribute
+    {
+    }
+}
+#endif

--- a/bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj
+++ b/bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj
@@ -4,8 +4,9 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>Gua.Testing</PackageId>
     <Version>$(GuaPackageVersion)</Version>
@@ -22,6 +23,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/bindings/dotnet/src/Gua.Testing/GuaActionCompletion.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaActionCompletion.cs
@@ -55,7 +55,7 @@ public static class GuaActionCompletion
         TimeSpan? pollInterval = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(context);
+        Guard.NotNull(context, nameof(context));
         var limit = timeout ?? DefaultTimeout;
         var interval = pollInterval ?? DefaultPollInterval;
         if (limit < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertionScope.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertionScope.cs
@@ -12,7 +12,7 @@ public sealed class GuaAssertionScope : IDisposable
 
     public static GuaAssertionScope Use(GuaAssertionOptions options)
     {
-        ArgumentNullException.ThrowIfNull(options);
+        Guard.NotNull(options, nameof(options));
         return new GuaAssertionScope(options);
     }
 
@@ -38,7 +38,7 @@ public sealed class GuaAssertionScope : IDisposable
 
     private static GuaAssertionScope UseNamedFramework(string frameworkName, Action<string> fail)
     {
-        ArgumentNullException.ThrowIfNull(fail);
+        Guard.NotNull(fail, nameof(fail));
         return Use(new GuaAssertionOptions
         {
             Fail = message => fail($"Gua assertion failed for {frameworkName}: {message}"),

--- a/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaAssertions.cs
@@ -16,29 +16,29 @@ public static partial class GuaAssertions
 
     public static GuaNodeExpectation GetById(IGuaContext context, string id)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        Guard.NotNull(context, nameof(context));
+        Guard.NotNullOrWhiteSpace(id, nameof(id));
         return Query(context).ById(id).Get();
     }
 
     public static GuaNodeExpectation GetByRole(IGuaContext context, string role, string? name = null)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentException.ThrowIfNullOrWhiteSpace(role);
+        Guard.NotNull(context, nameof(context));
+        Guard.NotNullOrWhiteSpace(role, nameof(role));
 
         return Query(context).ByRole(role, name).Get();
     }
 
     public static GuaNodeExpectation GetByText(IGuaContext context, string text)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+        Guard.NotNull(context, nameof(context));
+        Guard.NotNullOrWhiteSpace(text, nameof(text));
         return Query(context).ByText(text).Get();
     }
 
     public static GuaLocatorQuery Query(IGuaContext context)
     {
-        ArgumentNullException.ThrowIfNull(context);
+        Guard.NotNull(context, nameof(context));
         return new GuaLocatorQuery(context);
     }
 
@@ -49,7 +49,7 @@ public static partial class GuaAssertions
 
     public static void WaitFor(GuaNodeExpectation expectation, TimeSpan? timeout = null)
     {
-        ArgumentNullException.ThrowIfNull(expectation);
+        Guard.NotNull(expectation, nameof(expectation));
         expectation.WaitFor(timeout);
     }
 
@@ -265,7 +265,7 @@ public static partial class GuaAssertions
 
         var last = ReadWaitSnapshot(context);
         Fail(context, $"Timed out after {FormatTimeout(timeout)} (elapsed {stopwatch.Elapsed:g}) waiting for Gua node by {description}. Last frameSequence={Format(last.FrameSequence)}, revision={Format(last.Revision)}. {lastException?.Message}", initialUiTreeJson);
-        throw new UnreachableException();
+        throw new InvalidOperationException("Gua assertion failure handler returned unexpectedly.");
     }
 
     private static string FormatTimeout(TimeSpan? timeout)
@@ -365,7 +365,7 @@ public sealed class GuaNodeExpectation
 
     public GuaNodeExpectation ToHaveRole(string role)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(role);
+        Guard.NotNullOrWhiteSpace(role, nameof(role));
         var snapshot = GetSnapshotOrFail();
         if (!string.Equals(snapshot.Role, role, StringComparison.Ordinal))
         {
@@ -377,7 +377,7 @@ public sealed class GuaNodeExpectation
 
     public GuaNodeExpectation ToHaveLabel(string label)
     {
-        ArgumentNullException.ThrowIfNull(label);
+        Guard.NotNull(label, nameof(label));
         var snapshot = GetSnapshotOrFail();
         if (!string.Equals(snapshot.Label, label, StringComparison.Ordinal))
         {
@@ -389,7 +389,7 @@ public sealed class GuaNodeExpectation
 
     public GuaNodeExpectation ToHaveAction(string action)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(action);
+        Guard.NotNullOrWhiteSpace(action, nameof(action));
         var snapshot = GetSnapshotOrFail();
         if (!snapshot.Actions.Contains(action, StringComparer.Ordinal))
         {
@@ -405,7 +405,7 @@ public sealed class GuaNodeExpectation
 
     public GuaNodeExpectation ToHaveText(string expected)
     {
-        ArgumentNullException.ThrowIfNull(expected);
+        Guard.NotNull(expected, nameof(expected));
         var actual = GetSnapshotOrFail().Text;
         if (!string.Equals(actual, expected, StringComparison.Ordinal))
             GuaAssertions.Fail(_context, $"Expected Gua node {_description} to have text '{expected}', but it had '{actual ?? "<unknown>"}'.");
@@ -414,7 +414,7 @@ public sealed class GuaNodeExpectation
 
     public GuaNodeExpectation ToHaveValue(string expected)
     {
-        ArgumentNullException.ThrowIfNull(expected);
+        Guard.NotNull(expected, nameof(expected));
         var actual = GetSnapshotOrFail().Value;
         if (!string.Equals(actual, expected, StringComparison.Ordinal))
             GuaAssertions.Fail(_context, $"Expected Gua node {_description} to have value '{expected}', but it had '{actual ?? "<unknown>"}'.");
@@ -585,7 +585,7 @@ public sealed class GuaNodeExpectation
         if (snapshot is null)
         {
             GuaAssertions.Fail(_context, $"Expected Gua node {_description} to exist. {GuaAssertions.DescribeTree(_context)}");
-            throw new UnreachableException();
+            throw new InvalidOperationException("Gua assertion failure handler returned unexpectedly.");
         }
 
         return snapshot;

--- a/bindings/dotnet/src/Gua.Testing/GuaDiagnostics.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaDiagnostics.cs
@@ -40,7 +40,7 @@ public sealed class GuaDiagnosticsSession
 
     public GuaDiagnosticsResult Capture(Exception primaryException, string? initialUiTreeJson = null)
     {
-        ArgumentNullException.ThrowIfNull(primaryException);
+        Guard.NotNull(primaryException, nameof(primaryException));
         var capture = GuaDiagnosticWriter.Capture(_context, primaryException.ToString(), _options, initialUiTreeJson);
         var errors = new List<GuaDiagnosticError>();
         if (capture.Error is not null) errors.Add(new("diagnostics", "CaptureError", capture.Error));
@@ -50,7 +50,7 @@ public sealed class GuaDiagnosticsSession
             AddSupplementalArtifacts(capture.ArtifactPath, errors);
             if (errors.Count > 0)
                 File.WriteAllText(Path.Combine(capture.ArtifactPath, "session-capture-errors.json"), JsonSerializer.Serialize(errors, GuaDiagnosticWriter.JsonOptions), new UTF8Encoding(false));
-            foreach (var path in Directory.EnumerateFiles(capture.ArtifactPath).Order(StringComparer.Ordinal))
+            foreach (var path in Directory.EnumerateFiles(capture.ArtifactPath).OrderBy(path => path, StringComparer.Ordinal))
                 files.Add(new GuaDiagnosticFile(Path.GetFullPath(path), MediaType(path)));
             foreach (var file in files)
             {
@@ -107,8 +107,8 @@ public static class GuaDiagnosticWriter
     public static GuaDiagnosticCapture Capture(
         IGuaContext context, string failureMessage, GuaDiagnosticOptions options, string? initialUiTreeJson = null)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(options);
+        Guard.NotNull(context, nameof(context));
+        Guard.NotNull(options, nameof(options));
         var errors = new List<string>();
         string diagnosticsJson;
         try
@@ -129,7 +129,7 @@ public static class GuaDiagnosticWriter
             var environment = new Dictionary<string, object?>
             {
                 ["testName"] = options.TestName,
-                ["processId"] = Environment.ProcessId,
+                ["processId"] = CurrentProcessId(),
                 ["framework"] = ".NET",
                 ["runtime"] = Environment.Version.ToString(),
                 ["capturedAt"] = options.Clock().ToString("O"),
@@ -195,6 +195,12 @@ public static class GuaDiagnosticWriter
         return string.IsNullOrWhiteSpace(sanitized) ? "unnamed-test" : sanitized;
     }
 
+    private static int CurrentProcessId()
+    {
+        using var process = System.Diagnostics.Process.GetCurrentProcess();
+        return process.Id;
+    }
+
     private static void WriteNew(string path, string contents)
     {
         using var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
@@ -223,11 +229,11 @@ public static class GuaDiagnosticWriter
         using var after = JsonDocument.Parse(afterJson);
         var oldNodes = NodesById(before.RootElement);
         var newNodes = NodesById(after.RootElement);
-        var added = newNodes.Keys.Except(oldNodes.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
-        var removed = oldNodes.Keys.Except(newNodes.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+        var added = newNodes.Keys.Except(oldNodes.Keys, StringComparer.Ordinal).OrderBy(id => id, StringComparer.Ordinal).ToArray();
+        var removed = oldNodes.Keys.Except(newNodes.Keys, StringComparer.Ordinal).OrderBy(id => id, StringComparer.Ordinal).ToArray();
         var changed = oldNodes.Keys.Intersect(newNodes.Keys, StringComparer.Ordinal)
             .Where(id => !string.Equals(oldNodes[id], newNodes[id], StringComparison.Ordinal))
-            .Order(StringComparer.Ordinal).ToArray();
+            .OrderBy(id => id, StringComparer.Ordinal).ToArray();
         return JsonSerializer.Serialize(new { schemaVersion = 1, added, removed, changed }, JsonOptions);
     }
 

--- a/bindings/dotnet/src/Gua.Testing/GuaLocatorQuery.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaLocatorQuery.cs
@@ -104,7 +104,7 @@ public sealed record GuaLocatorQuery
         Func<int, bool> condition, string expected, TimeSpan? timeout, TimeSpan? pollInterval,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(condition);
+        Guard.NotNull(condition, nameof(condition));
         var limit = timeout ?? TimeSpan.FromSeconds(1);
         var interval = pollInterval ?? TimeSpan.FromMilliseconds(10);
         if (limit < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -122,7 +122,7 @@ public sealed record GuaLocatorQuery
 
         GuaAssertions.Fail(_context,
             $"Timed out after {limit:g} waiting for selector {Describe()} to match {expected}; last count={lastCount}. {GuaAssertions.DescribeSnapshot(_context)}");
-        throw new UnreachableException();
+        throw new InvalidOperationException("Gua assertion failure handler returned unexpectedly.");
     }
 
     private GuaQueryResult Execute()

--- a/bindings/dotnet/src/Gua.Testing/GuaTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaTestHost.cs
@@ -13,8 +13,8 @@ public sealed class GuaTestHost
 
     public void Frame(string screen, Action<GuaTestHost> buildUi)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(screen);
-        ArgumentNullException.ThrowIfNull(buildUi);
+        Guard.NotNullOrWhiteSpace(screen, nameof(screen));
+        Guard.NotNull(buildUi, nameof(buildUi));
 
         _context.BeginFrame(screen);
         buildUi(this);
@@ -64,14 +64,14 @@ public sealed class GuaTestHost
         bool visible = true,
         bool enabled = true)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(id);
-        ArgumentException.ThrowIfNullOrWhiteSpace(role);
+        Guard.NotNullOrWhiteSpace(id, nameof(id));
+        Guard.NotNullOrWhiteSpace(role, nameof(role));
         _context.RegisterNode(id, role, label, bounds, visible, enabled);
     }
 
     public bool DrainClickEvents(Action<string> onClick)
     {
-        ArgumentNullException.ThrowIfNull(onClick);
+        Guard.NotNull(onClick, nameof(onClick));
 
         var handled = false;
         while (_context.TryPollEvent(out var e))

--- a/bindings/dotnet/src/Gua.Testing/GuaTestSession.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaTestSession.cs
@@ -124,7 +124,7 @@ public sealed class GuaTestSession : IDisposable, IAsyncDisposable
 
     public void Run(Action body)
     {
-        ArgumentNullException.ThrowIfNull(body);
+        Guard.NotNull(body, nameof(body));
         Exception? primary = null;
         try { body(); }
         catch (Exception error) { primary = error; }
@@ -150,7 +150,7 @@ public sealed class GuaTestSession : IDisposable, IAsyncDisposable
     public ValueTask DisposeAsync()
     {
         Dispose();
-        return ValueTask.CompletedTask;
+        return default;
     }
 
     private Exception? Teardown(Exception? primary)

--- a/bindings/dotnet/src/Gua.Testing/GuaWaits.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWaits.cs
@@ -63,7 +63,7 @@ public static partial class GuaAssertions
         IGuaContext context, string id, Func<GuaNodeSnapshot, bool> predicate, string description = "match semantic state",
         TimeSpan? timeout = null, TimeSpan? pollInterval = null, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(predicate);
+        Guard.NotNull(predicate, nameof(predicate));
         return WaitForNodeAsync(context, id, node => node is not null && predicate(node), description, timeout, pollInterval, cancellationToken);
     }
 
@@ -98,8 +98,8 @@ public static partial class GuaAssertions
         Func<bool> condition, string description, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(condition);
-        ArgumentException.ThrowIfNullOrWhiteSpace(description);
+        Guard.NotNull(condition, nameof(condition));
+        Guard.NotNullOrWhiteSpace(description, nameof(description));
         var (limit, interval) = ValidateWait(timeout, pollInterval);
         var stopwatch = Stopwatch.StartNew();
         do
@@ -118,7 +118,7 @@ public static partial class GuaAssertions
         IGuaContext context, int stableFrames = 3, TimeSpan? timeout = null, TimeSpan? pollInterval = null,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(context);
+        Guard.NotNull(context, nameof(context));
         if (stableFrames <= 0) throw new ArgumentOutOfRangeException(nameof(stableFrames));
         var (limit, interval) = ValidateWait(timeout, pollInterval);
         var stopwatch = Stopwatch.StartNew();
@@ -164,8 +164,8 @@ public static partial class GuaAssertions
         IGuaContext context, string id, Func<GuaNodeSnapshot?, bool> condition, string description,
         TimeSpan? timeout, TimeSpan? pollInterval, CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        Guard.NotNull(context, nameof(context));
+        Guard.NotNullOrWhiteSpace(id, nameof(id));
         var (limit, interval) = ValidateWait(timeout, pollInterval);
         var stopwatch = Stopwatch.StartNew();
         var initialUiTreeJson = context.GetUiTreeJson();
@@ -183,7 +183,7 @@ public static partial class GuaAssertions
         while (true);
 
         Fail(context, $"Timed out after {limit:g} (elapsed {stopwatch.Elapsed:g}) waiting for Gua node id '{id}' to {description}. Last state: {DescribeNode(node)}; frameSequence={Format(last?.FrameSequence)}, revision={Format(last?.Revision)}.", initialUiTreeJson);
-        throw new UnreachableException();
+        throw new InvalidOperationException("Gua assertion failure handler returned unexpectedly.");
     }
 
     private static (TimeSpan Timeout, TimeSpan PollInterval) ValidateWait(TimeSpan? timeout, TimeSpan? pollInterval)

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -3,6 +3,11 @@
 `Gua.Testing` adds locator, assertion, wait, and test-host helpers on top of
 `Gua.Core`.
 
+The package targets both `net10.0` and `netstandard2.1`. The latter is intended
+for Unity 6's .NET Standard 2.1 API Compatibility Level; the initial verified
+native configuration is the Windows x64 Editor described in the
+[Unity smoke guide](https://github.com/link1345/gua/tree/main/examples/unity-smoke).
+
 ```csharp
 using var ui = new GuaContext();
 var host = new GuaTestHost(ui);

--- a/examples/unity-smoke/Assets/GuaUnitySmoke.cs
+++ b/examples/unity-smoke/Assets/GuaUnitySmoke.cs
@@ -1,0 +1,33 @@
+using Gua.Core;
+using UnityEngine;
+
+public sealed class GuaUnitySmoke : MonoBehaviour
+{
+    private GuaContext _context;
+
+    private void Start()
+    {
+        _context = new GuaContext();
+        _context.BeginFrame("unity-smoke");
+        _context.RegisterNode(
+            "unity-start",
+            "button",
+            "開始",
+            new GuaBounds(10, 20, 160, 40));
+        _context.EndFrame();
+
+        var tree = _context.GetUiTreeJson();
+        if (!tree.Contains("unity-start") || !tree.Contains("開始"))
+        {
+            throw new System.InvalidOperationException("Gua Unity smoke tree did not round-trip UTF-8 node data.");
+        }
+
+        Debug.Log("Gua netstandard2.1 Unity smoke passed: " + tree);
+    }
+
+    private void OnDestroy()
+    {
+        _context?.Dispose();
+        _context = null;
+    }
+}

--- a/examples/unity-smoke/Gua.UnitySmoke.csproj
+++ b/examples/unity-smoke/Gua.UnitySmoke.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\bindings\dotnet\src\Gua.Core\Gua.Core.csproj" AdditionalProperties="TargetFramework=netstandard2.1" />
+    <ProjectReference Include="..\..\bindings\dotnet\src\Gua.Testing\Gua.Testing.csproj" AdditionalProperties="TargetFramework=netstandard2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Assets\**\*.cs" />
+    <None Include="Assets\**\*.cs" />
+  </ItemGroup>
+</Project>

--- a/examples/unity-smoke/Program.cs
+++ b/examples/unity-smoke/Program.cs
@@ -1,0 +1,21 @@
+using Gua.Core;
+using Gua.Testing;
+
+using var context = new GuaContext();
+var host = new GuaTestHost(context);
+_ = new GuaDiagnosticOptions { TestName = "unity-smoke" };
+
+host.Frame("unity-smoke", frame =>
+{
+    frame.Button("unity-start", "開始", new GuaBounds(10, 20, 160, 40));
+});
+
+GuaAssertions.GetById(context, "unity-start").ToBeVisible();
+var json = context.GetUiTreeJson();
+if (!json.Contains("unity-start", StringComparison.Ordinal) ||
+    !json.Contains("開始", StringComparison.Ordinal))
+{
+    throw new InvalidOperationException($"Unity smoke tree did not round-trip UTF-8 node data: {json}");
+}
+
+Console.WriteLine("Gua netstandard2.1 Unity smoke passed.");

--- a/examples/unity-smoke/README.md
+++ b/examples/unity-smoke/README.md
@@ -1,0 +1,58 @@
+# Unity 6 Windows Editor smoke test
+
+This sample verifies the first supported Unity configuration: Unity 6 on the
+Windows x64 Editor with **Api Compatibility Level** set to **.NET Standard 2.1**.
+It does not add a Unity-specific runtime; `Gua.Core` remains a thin P/Invoke
+binding over the stable native C ABI.
+
+## Prepare the managed plug-ins
+
+Build both Unity-compatible assemblies:
+
+```powershell
+dotnet restore bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj
+dotnet build bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release --framework netstandard2.1 --no-restore
+dotnet build bindings/dotnet/src/Gua.Testing/Gua.Testing.csproj --configuration Release --framework netstandard2.1 --no-restore
+```
+
+Copy `Gua.Core.dll` and `Gua.Testing.dll` from their
+`bin/Release/netstandard2.1` directories into
+`Assets/Plugins/Gua/Managed` in the Unity project. When consuming the NuGet
+packages, also install their dependency closure, including `System.Text.Json`;
+.NET Standard itself does not provide that library. A Unity NuGet client may do
+this automatically, or the dependency assemblies can be copied beside the Gua
+managed plug-ins.
+
+## Prepare the Windows x64 native plug-in
+
+```powershell
+cmake --preset windows-msvc-release
+cmake --build --preset windows-msvc-release --target gua --config Release
+```
+
+Copy `build/windows-msvc-release/native/gua-core/Release/gua.dll` to
+`Assets/Plugins/x86_64/gua.dll`. In Unity's Plugin Inspector, enable it for the
+Windows Editor and Windows Standalone x86_64 targets. The `netstandard2.1`
+binding intentionally uses normal `[DllImport("gua")]` resolution so Unity's
+Plugin Import Settings own native loading.
+
+Copy `Assets/GuaUnitySmoke.cs` from this directory into the Unity project,
+attach `GuaUnitySmoke` to a GameObject, and enter Play Mode. A successful run
+logs a semantic tree containing the UTF-8 label `開始`. This exercises managed
+assembly loading, `GuaContext` creation/destruction, native P/Invoke, and the
+minimal UI tree round trip.
+
+The checked-in command-line host exercises the same `netstandard2.1` Gua
+assemblies and native calls without requiring Unity:
+
+```powershell
+dotnet build examples/unity-smoke/Gua.UnitySmoke.csproj --configuration Release
+Copy-Item build/windows-msvc-release/native/gua-core/Release/gua.dll examples/unity-smoke/bin/Release/net10.0/gua.dll
+dotnet run --project examples/unity-smoke/Gua.UnitySmoke.csproj --configuration Release
+```
+
+Only Unity 6 Windows Editor x64 is in the verified scope. IL2CPP/AOT, Android,
+iOS, macOS, and player architectures other than Windows x64 require separate
+native packaging and marshalling verification.
+
+Unity reference: [.NET profile support](https://docs.unity3d.com/ja/current/Manual/dotnet-profile-support.html).


### PR DESCRIPTION
## 対応Issue

Closes #58

## 実装内容

- `Gua.Core` / `Gua.Testing` を `net10.0;netstandard2.1` のマルチターゲット化
- `netstandard2.1` 向けに通常の `DllImport` と明示的UTF-8マーシャリングを追加
- `net10.0` の `LibraryImport` / `GUA_NATIVE_DIR` resolverを維持
- `ThrowIfNull`、`Order`、`Environment.ProcessId`、`ValueTask.CompletedTask`、record/init/required関連を互換化
- `.NET Standard 2.1` 向け `System.Text.Json` NuGet依存を追加
- NuGet build/pack workflowとsyntax checkで両TFMを明示build
- Unity 6 Windows Editor x64向けのmanaged/native配置手順と最小`MonoBehaviour`を追加
- 同じ`netstandard2.1` assemblyでcontext生成・UTF-8 UI tree往復を行うcommand-line smoke hostを追加

## Architecture判断

- protocol/schemaと公開C ABIは変更していません。
- .NET側の別runtimeは作らず、既存C ABIへの薄いP/Invoke bindingを維持しました。
- Unityでは`NativeLibrary.SetDllImportResolver`へ依存せず、Plugin Import Settingsと通常のP/Invoke解決を使用します。
- 既存.NET利用者は従来どおり`net10.0` assetと開発用native resolverを選択します。

## テスト・検証

- `cmake --preset windows-msvc-debug`: 成功
- `cmake --build --preset windows-msvc-debug`: 成功
- `ctest --test-dir build/windows-msvc-debug -C Debug --output-on-failure`: 3/3成功
- `dotnet build ...Gua.Core.csproj --configuration Release --framework net10.0`: 成功、警告0
- `dotnet build ...Gua.Core.csproj --configuration Release --framework netstandard2.1`: 成功、警告0
- `dotnet build ...Gua.Testing.csproj --configuration Release --framework net10.0`: 成功、警告0
- `dotnet build ...Gua.Testing.csproj --configuration Release --framework netstandard2.1`: 成功、警告0
- `dotnet run --project examples/unity-smoke/Gua.UnitySmoke.csproj --configuration Release`: 成功。`netstandard2.1` assemblyからnative contextを生成・破棄し、`開始`を含むUI treeを往復
- `dotnet test bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj --configuration Release`: 8/8成功
- `dotnet test examples/dotnet-nunit/GuaDotNetNUnitSample.csproj --configuration Release -p:UseProjectReferences=true`: 21/21成功
- `dotnet build examples/dotnet-godot/GuaGodotSample.csproj --configuration Release`: 成功、警告0
- `dotnet build bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj --configuration Release`: 成功、警告0
- `dotnet pack`（Gua.Core / Gua.Testing）: 成功。両nupkgに`lib/net10.0`と`lib/netstandard2.1`を確認し、Gua.Coreには`runtimes/win-x64/native/gua.dll`も確認
- `git diff --check`: 成功

## 未対応・実行不能な検証

- この実行環境にはUnity Editorがないため、Unity 6 Windows Editor x64上のPlay Mode実行そのものは未実施です。代替として、Unityが参照する同じ`netstandard2.1` managed assembly、通常のP/Invoke解決、native context生成・破棄、UTF-8 UI tree往復をcommand-line smokeで検証しました。
- IL2CPP/AOT、Android、iOS、macOS、Windows x64以外のnative配置はIssue範囲外で、個別検証が必要です。
- open Draft PR #59とREADME / NuGet・syntax workflowの一部が重なります。#59が先にmainへ入った場合は、そのVisual/Recording package追加を保持してmainを統合します。
