### PR TITLE
視覚比較アーティファクトを静的レポート向けに整備する

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ for installation and verification details.
   Shared managed wrapper for authors of engine adapters. Use it to publish semantic frames, consume actions, complete screenshot requests, and host the Inspector bridge without duplicating P/Invoke code. Application test projects normally use an engine package instead.
 - **Gua.Testing.Visual:** [![NuGet Version](https://img.shields.io/nuget/v/Gua.Testing.Visual)](https://www.nuget.org/packages/Gua.Testing.Visual) ![NuGet Downloads](https://img.shields.io/nuget/dt/Gua.Testing.Visual)<br>
   Adds opt-in PNG baseline comparison for rendering regressions that semantic assertions cannot detect, such as clipping, misplaced controls, incorrect assets, and unexpected overlays. Failures retain expected, actual, diff, and machine-readable comparison artifacts.
+  `gua-tester` can combine those artifacts with its prebuilt Astro viewer for workflow artifacts and GitHub Pages.
 - **Gua.Testing.Recording:** [![NuGet Version](https://img.shields.io/nuget/v/Gua.Testing.Recording)](https://www.nuget.org/packages/Gua.Testing.Recording) ![NuGet Downloads](https://img.shields.io/nuget/dt/Gua.Testing.Recording)<br>
   Records repeatable user journeys as semantic operations and replays every step with correlated host completion. Use it for regression flows, bug reproduction, and sharing a scenario without storing fragile coordinates or plaintext secrets.
 

--- a/bindings/dotnet/src/Gua.Testing.Visual/GuaScreenshotComparison.cs
+++ b/bindings/dotnet/src/Gua.Testing.Visual/GuaScreenshotComparison.cs
@@ -54,15 +54,33 @@ public static class GuaVisualAssertions
             }
             var missingDir = CreateArtifactDirectory(options, safeName);
             File.WriteAllBytes(Path.Combine(missingDir, "actual.png"), actualBytes);
-            WriteComparison(missingDir, new { schemaVersion = 1, matched = false, reason = "baseline_missing", baselinePath = baseline });
-            throw new InvalidOperationException($"Screenshot baseline is missing: {baseline}. Actual artifact: {missingDir}");
+            var missingActual = ImageResult.FromMemory(actualBytes, StbImageSharp.ColorComponents.RedGreenBlueAlpha);
+            WriteComparison(missingDir, new
+            {
+                schemaVersion = 1,
+                name,
+                variant = options.BaselineVariant,
+                matched = false,
+                baselineCreated = false,
+                reason = "baseline_missing",
+                width = missingActual.Width,
+                height = missingActual.Height,
+                comparedPixels = 0,
+                differentPixels = 0,
+                differentPixelRatio = 0,
+                options.PixelThreshold,
+                options.MaxDifferentPixelRatio,
+                masks = options.Masks,
+                baselinePath = baseline
+            });
+            throw new InvalidOperationException($"Screenshot baseline is missing: {baseline}. Artifacts: {missingDir}");
         }
 
         var expectedBytes = File.ReadAllBytes(baseline);
         var expected = ImageResult.FromMemory(expectedBytes, StbImageSharp.ColorComponents.RedGreenBlueAlpha);
         var actual = ImageResult.FromMemory(actualBytes, StbImageSharp.ColorComponents.RedGreenBlueAlpha);
         if (expected.Width != actual.Width || expected.Height != actual.Height)
-            return FailDimension(expectedBytes, actualBytes, expected, actual, baseline, options, safeName);
+            return FailDimension(expectedBytes, actualBytes, expected, actual, baseline, options, safeName, name);
 
         var diff = new byte[actual.Data.Length];
         long compared = 0, different = 0;
@@ -90,19 +108,56 @@ public static class GuaVisualAssertions
         if (ratio <= options.MaxDifferentPixelRatio)
             return new(true, actual.Width, actual.Height, compared, different, ratio, baseline, null, false);
         var directory = CreateArtifactDirectory(options, safeName);
+        var diffBytes = PngBytes(diff, actual.Width, actual.Height);
         File.WriteAllBytes(Path.Combine(directory, "expected.png"), expectedBytes);
         File.WriteAllBytes(Path.Combine(directory, "actual.png"), actualBytes);
-        WritePng(Path.Combine(directory, "diff.png"), diff, actual.Width, actual.Height);
-        WriteComparison(directory, new { schemaVersion = 1, matched = false, actual.Width, actual.Height, comparedPixels = compared, differentPixels = different, differentPixelRatio = ratio, options.PixelThreshold, options.MaxDifferentPixelRatio, masks = options.Masks, baselinePath = baseline });
+        File.WriteAllBytes(Path.Combine(directory, "diff.png"), diffBytes);
+        WriteComparison(directory, new
+        {
+            schemaVersion = 1,
+            name,
+            variant = options.BaselineVariant,
+            matched = false,
+            baselineCreated = false,
+            reason = "pixel_difference",
+            actual.Width,
+            actual.Height,
+            comparedPixels = compared,
+            differentPixels = different,
+            differentPixelRatio = ratio,
+            options.PixelThreshold,
+            options.MaxDifferentPixelRatio,
+            masks = options.Masks,
+            baselinePath = baseline
+        });
         throw new InvalidOperationException($"Screenshot comparison failed: ratio {ratio:F6} exceeds {options.MaxDifferentPixelRatio:F6}. Artifacts: {directory}");
     }
 
-    private static ScreenshotComparisonResult FailDimension(byte[] expectedBytes, byte[] actualBytes, ImageResult expected, ImageResult actual, string baseline, ScreenshotOptions options, string name)
+    private static ScreenshotComparisonResult FailDimension(byte[] expectedBytes, byte[] actualBytes, ImageResult expected, ImageResult actual, string baseline, ScreenshotOptions options, string safeName, string name)
     {
-        var directory = CreateArtifactDirectory(options, name);
+        var directory = CreateArtifactDirectory(options, safeName);
         File.WriteAllBytes(Path.Combine(directory, "expected.png"), expectedBytes);
         File.WriteAllBytes(Path.Combine(directory, "actual.png"), actualBytes);
-        WriteComparison(directory, new { schemaVersion = 1, matched = false, reason = "dimension_mismatch", expected = new { expected.Width, expected.Height }, actual = new { actual.Width, actual.Height }, baselinePath = baseline });
+        WriteComparison(directory, new
+        {
+            schemaVersion = 1,
+            name,
+            variant = options.BaselineVariant,
+            matched = false,
+            baselineCreated = false,
+            reason = "dimension_mismatch",
+            width = actual.Width,
+            height = actual.Height,
+            expectedWidth = expected.Width,
+            expectedHeight = expected.Height,
+            comparedPixels = 0,
+            differentPixels = 0,
+            differentPixelRatio = 0,
+            options.PixelThreshold,
+            options.MaxDifferentPixelRatio,
+            masks = options.Masks,
+            baselinePath = baseline
+        });
         throw new InvalidOperationException($"Screenshot dimensions differ: expected {expected.Width}x{expected.Height}, actual {actual.Width}x{actual.Height}. Artifacts: {directory}");
     }
 
@@ -133,7 +188,7 @@ public static class GuaVisualAssertions
         var path = Path.Combine(parent, $"visual-{DateTimeOffset.UtcNow:yyyyMMddTHHmmssfffZ}-{Guid.NewGuid():N}");
         Directory.CreateDirectory(path); return path;
     }
-    private static void WriteComparison(string directory, object value) => File.WriteAllText(Path.Combine(directory, "comparison.json"), JsonSerializer.Serialize(value, new JsonSerializerOptions { WriteIndented = true }));
-    private static void WritePng(string path, byte[] data, int width, int height) { using var stream = File.Create(path); new ImageWriter().WritePng(data, width, height, StbImageWriteSharp.ColorComponents.RedGreenBlueAlpha, stream); }
+    private static void WriteComparison(string directory, object value) => File.WriteAllText(Path.Combine(directory, "comparison.json"), JsonSerializer.Serialize(value, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
+    private static byte[] PngBytes(byte[] data, int width, int height) { using var stream = new MemoryStream(); new ImageWriter().WritePng(data, width, height, StbImageWriteSharp.ColorComponents.RedGreenBlueAlpha, stream); return stream.ToArray(); }
     internal static string Sanitize(string value) { var invalid = Path.GetInvalidFileNameChars(); var result = new string(value.Select(c => invalid.Contains(c) || char.IsControl(c) ? '_' : c).ToArray()).Trim(); return string.IsNullOrEmpty(result) ? "unnamed" : result; }
 }

--- a/bindings/dotnet/src/Gua.Testing.Visual/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Visual/README.md
@@ -27,10 +27,14 @@ var result = await GuaVisualAssertions.ExpectScreenshotAsync(host.Context, "titl
 ```
 
 Missing baselines fail unless `UpdateBaselines = true` or
-`GUA_UPDATE_BASELINES=1` is explicit. A failed comparison writes
-`expected.png`, `actual.png`, `diff.png`, and `comparison.json`. Pass the failure
-artifact path returned by `GuaDiagnosticWriter` as `FailureDirectory` when visual
-artifacts should share the same diagnostic directory.
+`GUA_UPDATE_BASELINES=1` is explicit. A pixel-difference failure writes
+`expected.png`, `actual.png`, `diff.png`, and `comparison.json`. Missing-baseline
+and dimension-mismatch failures write the same manifest with only the PNGs that
+exist for that failure. The manifest records the comparison name, variant,
+dimensions, reason, metrics, thresholds, masks, and diagnostic baseline path.
+Pass the failure artifact path returned by `GuaDiagnosticWriter` as
+`FailureDirectory` when visual artifacts should share the same diagnostic
+directory.
 
 Use masks only for genuinely nondeterministic regions such as a clock or generated
 avatar. Masks are excluded from both the diff and the compared-pixel denominator;
@@ -62,6 +66,15 @@ Example GitHub Actions steps:
     path: artifacts/gua
     if-no-files-found: ignore
 ```
+
+To render these data artifacts as a static report or publish the latest `main`
+result through GitHub Pages, use the separate
+`link1345/gua-tester/visual-report` action. It combines the manifests and PNGs
+with a prebuilt Astro viewer without adding JavaScript dependencies to this
+package or installing Astro in the consumer test job.
+
+Screenshots can contain rendered secrets or personal information. Review the
+captured content before enabling Pages, especially for public repositories.
 
 ## OS and renderer variants
 

--- a/bindings/dotnet/tests/Gua.Visual.Tests/VisualTests.cs
+++ b/bindings/dotnet/tests/Gua.Visual.Tests/VisualTests.cs
@@ -38,11 +38,70 @@ public sealed class VisualTests
         var context = new FakeContext(Png(1, 1, 1));
         var missing = Assert.ThrowsAsync<InvalidOperationException>(() => GuaVisualAssertions.ExpectScreenshotAsync(context, "missing", Options("default")));
         Assert.That(missing!.Message, Does.Contain("baseline is missing"));
+        var missingDirectory = Directory.GetDirectories(Path.Combine(_root, "artifacts", "missing")).Single();
+        using var missingMetadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(missingDirectory, "comparison.json")));
+        Assert.Multiple(() =>
+        {
+            Assert.That(Directory.GetFiles(missingDirectory).Select(Path.GetFileName), Is.EquivalentTo(new[] { "actual.png", "comparison.json" }));
+            Assert.That(missingMetadata.RootElement.GetProperty("name").GetString(), Is.EqualTo("missing"));
+            Assert.That(missingMetadata.RootElement.GetProperty("variant").GetString(), Is.EqualTo("default"));
+            Assert.That(missingMetadata.RootElement.GetProperty("baselineCreated").GetBoolean(), Is.False);
+            Assert.That(missingMetadata.RootElement.GetProperty("reason").GetString(), Is.EqualTo("baseline_missing"));
+            Assert.That(missingMetadata.RootElement.GetProperty("width").GetInt32(), Is.EqualTo(1));
+            Assert.That(missingMetadata.RootElement.GetProperty("height").GetInt32(), Is.EqualTo(1));
+        });
         await GuaVisualAssertions.ExpectScreenshotAsync(context, "size", Options("default", update: true));
         context.Set(Png(2, 1, 1));
         var mismatch = Assert.ThrowsAsync<InvalidOperationException>(() => GuaVisualAssertions.ExpectScreenshotAsync(context, "size", Options("default")));
         Assert.That(mismatch!.Message, Does.Contain("dimensions differ"));
-        Assert.That(Directory.GetFiles(Path.Combine(_root, "artifacts"), "comparison.json", SearchOption.AllDirectories), Is.Not.Empty);
+        var mismatchDirectory = Directory.GetDirectories(Path.Combine(_root, "artifacts", "size")).Single();
+        using var mismatchMetadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(mismatchDirectory, "comparison.json")));
+        Assert.Multiple(() =>
+        {
+            Assert.That(Directory.GetFiles(mismatchDirectory).Select(Path.GetFileName), Is.EquivalentTo(new[] { "expected.png", "actual.png", "comparison.json" }));
+            Assert.That(mismatchMetadata.RootElement.GetProperty("reason").GetString(), Is.EqualTo("dimension_mismatch"));
+            Assert.That(mismatchMetadata.RootElement.GetProperty("width").GetInt32(), Is.EqualTo(2));
+            Assert.That(mismatchMetadata.RootElement.GetProperty("height").GetInt32(), Is.EqualTo(1));
+            Assert.That(mismatchMetadata.RootElement.GetProperty("expectedWidth").GetInt32(), Is.EqualTo(1));
+            Assert.That(mismatchMetadata.RootElement.GetProperty("expectedHeight").GetInt32(), Is.EqualTo(1));
+            Assert.That(Directory.GetFiles(Path.Combine(_root, "artifacts"), "index.html", SearchOption.AllDirectories), Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task PixelDifferenceWritesPortableDataAndPreservesNamesAsJson()
+    {
+        const string name = "danger<script>alert(1)<script>";
+        const string variant = "variant<script>alert(2)<script>";
+        var context = new FakeContext(Png(2, 1, 10));
+        await GuaVisualAssertions.ExpectScreenshotAsync(context, name, Options(variant, update: true));
+        context.Set(Png(2, 1, 200));
+
+        var failure = Assert.ThrowsAsync<InvalidOperationException>(
+            () => GuaVisualAssertions.ExpectScreenshotAsync(context, name, Options(variant, threshold: .1f, ratio: .2, masks: [new(0, 0, 0, 0)])));
+        var comparison = Directory.GetFiles(Path.Combine(_root, "artifacts"), "comparison.json", SearchOption.AllDirectories).Single();
+        using var metadata = JsonDocument.Parse(File.ReadAllText(comparison));
+        var directory = Path.GetDirectoryName(comparison)!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain(Path.GetFullPath(directory)));
+            Assert.That(Directory.GetFiles(directory).Select(Path.GetFileName), Is.EquivalentTo(new[] { "expected.png", "actual.png", "diff.png", "comparison.json" }));
+            Assert.That(Directory.GetFiles(directory, "*.html"), Is.Empty);
+            Assert.That(metadata.RootElement.GetProperty("name").GetString(), Is.EqualTo(name));
+            Assert.That(metadata.RootElement.GetProperty("variant").GetString(), Is.EqualTo(variant));
+            Assert.That(metadata.RootElement.GetProperty("baselineCreated").GetBoolean(), Is.False);
+            Assert.That(metadata.RootElement.GetProperty("reason").GetString(), Is.EqualTo("pixel_difference"));
+            Assert.That(metadata.RootElement.GetProperty("width").GetInt32(), Is.EqualTo(2));
+            Assert.That(metadata.RootElement.GetProperty("height").GetInt32(), Is.EqualTo(1));
+            Assert.That(metadata.RootElement.GetProperty("comparedPixels").GetInt64(), Is.EqualTo(2));
+            Assert.That(metadata.RootElement.GetProperty("differentPixels").GetInt64(), Is.EqualTo(2));
+            Assert.That(metadata.RootElement.GetProperty("differentPixelRatio").GetDouble(), Is.EqualTo(1));
+            Assert.That(metadata.RootElement.GetProperty("pixelThreshold").GetSingle(), Is.EqualTo(.1f));
+            Assert.That(metadata.RootElement.GetProperty("maxDifferentPixelRatio").GetDouble(), Is.EqualTo(.2));
+            Assert.That(metadata.RootElement.GetProperty("masks")[0].GetProperty("x").GetInt32(), Is.Zero);
+            Assert.That(Path.IsPathFullyQualified(metadata.RootElement.GetProperty("baselinePath").GetString()!), Is.True);
+        });
     }
 
     private ScreenshotOptions Options(string variant, bool update = false, float threshold = 0, double ratio = 0, IReadOnlyList<GuaMaskRectangle>? masks = null) => new() { BaselineDirectory = Path.Combine(_root, "baselines"), ArtifactDirectory = Path.Combine(_root, "artifacts"), BaselineVariant = variant, UpdateBaselines = update, PixelThreshold = threshold, MaxDifferentPixelRatio = ratio, Masks = masks ?? [] };


### PR DESCRIPTION
## 概要

- 視覚比較の失敗アーティファクトに名前、バリアント、寸法、理由、比較メトリクス、閾値、マスク情報を記録
- 差分PNGをメモリ上で生成し、JSONプロパティをcamelCaseで出力
- `gua-tester/visual-report` による静的レポート生成とGitHub Pages公開の手順をドキュメント化
- スクリーンショットに含まれる秘密情報や個人情報への注意事項を追加

## テスト

- 欠落ベースライン、寸法不一致、ピクセル差分のユニットテストを追加
- 特殊文字を含む比較名・バリアント、マスク、比較メトリクス、アーティファクト構成を検証