### PR TITLE
GitHub ActionsのGodot・Unity利用手順を更新する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,6 +47,7 @@ Playwrightスタイル自動化レイヤーだと考えると分かりやすい�
 - Godotと同じSemantic APIでControlを検索・操作
 - ゲーム側アダプターと外部NUnitテストホストを分離
 - Unityテスト失敗時にログ、スクリーンショット、診断情報を保存
+- [`link1345/gua-tester`](https://github.com/link1345/gua-tester)でWindows x64 Mono PlayerをCIビルド・テスト
 
 ### AIコーディングとAIプレイテスト
 
@@ -77,6 +78,44 @@ Editor Play Modeまたはビルド済みMono Playerを起動できます。現�
 Unity 6000.0以降、Windows x64、Monoです。IL2CPP、Windows以外、Unity IMGUI、
 EditorWindowの自動化には未対応です。導入・検証手順は
 [Unity 6 Windows x64](#unity-6-windows-x64)を参照してください。
+
+## GitHub Actions
+
+[`link1345/gua-tester`](https://github.com/link1345/gua-tester)は、Godotと
+Unityの両方に対応する公開CI部品です。Godotでは、Godot本体と配布済みアドオンを
+準備して外部.NETテストを実行します。
+
+```yaml
+- uses: link1345/gua-tester/godot@v2
+  with:
+    project-path: game
+    test-project: tests/GuaTester.Tests.csproj
+    godot-version: "4.7"
+    godot-status: stable
+```
+
+Unityでは、LinuxでWindows x64 Mono Playerをビルドし、Windows runnerへ渡して
+`Gua.Testing.Unity`のNUnitテストを実行します。
+
+```yaml
+jobs:
+  unity:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    uses: link1345/gua-tester/.github/workflows/unity.yml@v2
+    with:
+      project-path: game
+      scene-path: Assets/Scenes/Title.unity
+      test-project: tests/GuaTester.Unity.Tests.csproj
+      unity-version: auto
+      gua-tag: gua-v0.15.0
+    secrets:
+      UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+      UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+      UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+```
+
+`gua-tag`で選ぶUPM packageと`Gua.Testing.Unity`のNuGetバージョンは揃えてください。
+fork PRにはUnity credentialsが渡らないため、未信頼forkではUnity jobをskipします。
 
 ## NuGetパッケージ
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ screenshots, and visual comparisons operate against the live game runtime.
 - Locate and operate controls through the same semantic API used for Godot.
 - Keep game-side adapter code separate from external NUnit test hosts.
 - Capture logs, screenshots, and diagnostics when a Unity test fails.
+- Build and test a Windows x64 Mono Player in CI with [`link1345/gua-tester`](https://github.com/link1345/gua-tester).
 
 ### AI coding and AI playtesting
 
@@ -229,14 +230,14 @@ tests do not create artifacts unless capture is explicitly requested.
 
 Want to try that in GitHub Actions without wiring every setup step by hand?
 [`link1345/gua-tester`](https://github.com/link1345/gua-tester) provides
-reusable Actions for Godot GDScript projects. It downloads Godot on the runner,
-links the released Gua Godot addon into your project, sets `GODOT_EXECUTABLE`,
-and runs your .NET tests that use `Gua.Testing.Godot`.
+versioned workflows for both Godot and Unity. The Godot action downloads Godot,
+links the released addon, sets `GODOT_EXECUTABLE`, and runs the external .NET
+tests:
 
 For a typical consumer repository, the workflow can be as small as:
 
 ```yaml
-- uses: link1345/gua-tester@v1
+- uses: link1345/gua-tester/godot@v2
   with:
     project-path: game
     test-project: tests/GuaTester.Tests.csproj
@@ -244,8 +245,30 @@ For a typical consumer repository, the workflow can be as small as:
     godot-status: stable
 ```
 
-If you have a Godot project that starts the Gua bridge, give it a spin in CI and
-see whether the semantic UI tree catches regressions before they land.
+The Unity reusable workflow installs the released UPM package, builds a Windows
+x64 Mono Player on Linux, transfers it to a Windows runner, and runs the
+`Gua.Testing.Unity` NUnit project:
+
+```yaml
+jobs:
+  unity:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    uses: link1345/gua-tester/.github/workflows/unity.yml@v2
+    with:
+      project-path: game
+      scene-path: Assets/Scenes/Title.unity
+      test-project: tests/GuaTester.Unity.Tests.csproj
+      unity-version: auto
+      gua-tag: gua-v0.15.0
+    secrets:
+      UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+      UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+      UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+```
+
+Keep the UPM release selected by `gua-tag` aligned with the
+`Gua.Testing.Unity` NuGet version. Unity credentials are unavailable to fork
+pull requests, so skip the Unity job for untrusted forks.
 
 ```cpp
 context.log(gua::LogLevel::info, "title screen opened");


### PR DESCRIPTION
## 概要

- `link1345/gua-tester` v2のGodot Action利用例を更新
- Unity向け再利用可能ワークフローの利用例を追加
- Windows x64 Mono PlayerのCIビルド・NUnitテスト手順を説明
- UPM packageとNuGetバージョンの整合、およびfork PRでの認証情報制限を明記
- 英語・日本語READMEの内容を同期

## テスト

- Not run (not requested)