### PR TITLE
Unity統合テストの画面スケール検証と実行設定を更新する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -106,16 +106,19 @@ jobs:
       project-path: game
       scene-path: Assets/Scenes/Title.unity
       test-project: tests/GuaTester.Unity.Tests.csproj
+      artifact-key: game
       unity-version: auto
       gua-tag: gua-v0.15.0
     secrets:
       UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
       UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
 ```
 
 `gua-tag`で選ぶUPM packageと`Gua.Testing.Unity`のNuGetバージョンは揃えてください。
 fork PRにはUnity credentialsが渡らないため、未信頼forkではUnity jobをskipします。
+reusable workflowはPlayer起動前にWindows test runnerの画面解像度を1920x1080へ固定します。
 
 ## NuGetパッケージ
 

--- a/README.md
+++ b/README.md
@@ -258,17 +258,20 @@ jobs:
       project-path: game
       scene-path: Assets/Scenes/Title.unity
       test-project: tests/GuaTester.Unity.Tests.csproj
+      artifact-key: game
       unity-version: auto
       gua-tag: gua-v0.15.0
     secrets:
       UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
       UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
       UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
 ```
 
 Keep the UPM release selected by `gua-tag` aligned with the
 `Gua.Testing.Unity` NuGet version. Unity credentials are unavailable to fork
-pull requests, so skip the Unity job for untrusted forks.
+pull requests, so skip the Unity job for untrusted forks. The reusable workflow
+fixes the Windows test runner display at 1920x1080 before launching the Player.
 
 ```cpp
 context.log(gua::LogLevel::info, "title screen opened");

--- a/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
@@ -135,14 +135,21 @@ public sealed class UnityIntegrationTests
         Assert.That(tmpKeyResult.Succeeded, Is.True, $"TMP press_key failed: {tmpKeyResult.Error}");
         Assert.That(tmpKeyResult.Value, Does.Contain("Z"));
 
+        var titleScreenshot = host.CaptureScreenshot(TimeSpan.FromSeconds(15));
+        Assert.That(titleScreenshot.Width, Is.GreaterThan(0));
+        Assert.That(titleScreenshot.Height, Is.GreaterThan(0));
+        var panelScale = titleScreenshot.Width / 640f;
+        Assert.That(titleScreenshot.Height / 360f, Is.EqualTo(panelScale).Within(0.01f),
+            "The scaled UI Toolkit fixture requires a 16:9 render surface.");
+
         Assert.That(WaitForBounds(host, "scaled-box", out var scaledBounds), Is.True);
-        Assert.That(scaledBounds.X, Is.EqualTo(200).Within(1));
-        Assert.That(scaledBounds.Y, Is.EqualTo(120).Within(1));
-        Assert.That(scaledBounds.Width, Is.EqualTo(400).Within(1));
-        Assert.That(scaledBounds.Height, Is.EqualTo(80).Within(1));
+        Assert.That(scaledBounds.X, Is.EqualTo(100 * panelScale).Within(1));
+        Assert.That(scaledBounds.Y, Is.EqualTo(60 * panelScale).Within(1));
+        Assert.That(scaledBounds.Width, Is.EqualTo(200 * panelScale).Within(1));
+        Assert.That(scaledBounds.Height, Is.EqualTo(40 * panelScale).Within(1));
         var remoteScaledBounds = host.RemoteContext.GetRemoteTree().Nodes.Single(node => node.Label == "scaled-box").Bounds;
-        Assert.That(remoteScaledBounds.Width, Is.EqualTo(400).Within(1));
-        Assert.That(remoteScaledBounds.Height, Is.EqualTo(80).Within(1));
+        Assert.That(remoteScaledBounds.Width, Is.EqualTo(200 * panelScale).Within(1));
+        Assert.That(remoteScaledBounds.Height, Is.EqualTo(40 * panelScale).Within(1));
 
         var settings = host.Context.FindNodeByRole("button", "Settings");
         var settingsError = host.Context.EnqueueAction(new GuaActionRequest(GuaActionType.Click, settings), out var settingsRequestId);


### PR DESCRIPTION
## 概要

- Unity reusable workflowの利用例に`artifact-key`と`UNITY_SERIAL`を追加
- Windows test runnerの画面解像度を1920x1080に固定する旨をドキュメントへ追記
- Unity統合テストでスクリーンショットの16:9比率を検証し、UI境界値を画面スケールに対応

## テスト

- Unity UI統合テストの検証内容を更新
- 実行結果は未確認（依頼されていないため未実行）