### PR TITLE
READMEのCI参照をv2.1へ更新

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -86,7 +86,7 @@ Unityの両方に対応する公開CI部品です。Godotでは、Godot本体と
 準備して外部.NETテストを実行します。
 
 ```yaml
-- uses: link1345/gua-tester/godot@v2
+- uses: link1345/gua-tester/godot@v2.1
   with:
     project-path: game
     test-project: tests/GuaTester.Tests.csproj
@@ -101,7 +101,7 @@ Unityでは、LinuxでWindows x64 Mono Playerをビルドし、Windows runnerへ
 jobs:
   unity:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: link1345/gua-tester/.github/workflows/unity.yml@v2
+    uses: link1345/gua-tester/.github/workflows/unity.yml@v2.1
     with:
       project-path: game
       scene-path: Assets/Scenes/Title.unity

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ tests:
 For a typical consumer repository, the workflow can be as small as:
 
 ```yaml
-- uses: link1345/gua-tester/godot@v2
+- uses: link1345/gua-tester/godot@v2.1
   with:
     project-path: game
     test-project: tests/GuaTester.Tests.csproj
@@ -253,7 +253,7 @@ x64 Mono Player on Linux, transfers it to a Windows runner, and runs the
 jobs:
   unity:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: link1345/gua-tester/.github/workflows/unity.yml@v2
+    uses: link1345/gua-tester/.github/workflows/unity.yml@v2.1
     with:
       project-path: game
       scene-path: Assets/Scenes/Title.unity


### PR DESCRIPTION
## 概要

- README.md と README.ja.md のGodot CI参照を `v2.1` に更新
- README.md と README.ja.md のUnityワークフロー参照を `v2.1` に更新

## テスト

- 未実施（依頼されていないため）