### PR TITLE
一致したビジュアル比較のアーティファクト出力を追加

### DIFF
--- a/bindings/dotnet/src/Gua.Testing.Visual/GuaScreenshotComparison.cs
+++ b/bindings/dotnet/src/Gua.Testing.Visual/GuaScreenshotComparison.cs
@@ -106,7 +106,29 @@ public static class GuaVisualAssertions
         }
         var ratio = compared == 0 ? 0 : (double)different / compared;
         if (ratio <= options.MaxDifferentPixelRatio)
-            return new(true, actual.Width, actual.Height, compared, different, ratio, baseline, null, false);
+        {
+            var matchedDirectory = CreateArtifactDirectory(options, safeName);
+            File.WriteAllBytes(Path.Combine(matchedDirectory, "actual.png"), actualBytes);
+            WriteComparison(matchedDirectory, new
+            {
+                schemaVersion = 1,
+                name,
+                variant = options.BaselineVariant,
+                matched = true,
+                baselineCreated = false,
+                reason = "matched",
+                actual.Width,
+                actual.Height,
+                comparedPixels = compared,
+                differentPixels = different,
+                differentPixelRatio = ratio,
+                options.PixelThreshold,
+                options.MaxDifferentPixelRatio,
+                masks = options.Masks,
+                baselinePath = baseline
+            });
+            return new(true, actual.Width, actual.Height, compared, different, ratio, baseline, matchedDirectory, false);
+        }
         var directory = CreateArtifactDirectory(options, safeName);
         var diffBytes = PngBytes(diff, actual.Width, actual.Height);
         File.WriteAllBytes(Path.Combine(directory, "expected.png"), expectedBytes);

--- a/bindings/dotnet/src/Gua.Testing.Visual/README.md
+++ b/bindings/dotnet/src/Gua.Testing.Visual/README.md
@@ -27,7 +27,9 @@ var result = await GuaVisualAssertions.ExpectScreenshotAsync(host.Context, "titl
 ```
 
 Missing baselines fail unless `UpdateBaselines = true` or
-`GUA_UPDATE_BASELINES=1` is explicit. A pixel-difference failure writes
+`GUA_UPDATE_BASELINES=1` is explicit. A successful comparison writes its current
+`actual.png` and a `comparison.json` manifest with reason `matched`, allowing a
+visual report to show the screen even when no difference was found. A pixel-difference failure writes
 `expected.png`, `actual.png`, `diff.png`, and `comparison.json`. Missing-baseline
 and dimension-mismatch failures write the same manifest with only the PNGs that
 exist for that failure. The manifest records the comparison name, variant,

--- a/bindings/dotnet/tests/Gua.Visual.Tests/VisualTests.cs
+++ b/bindings/dotnet/tests/Gua.Visual.Tests/VisualTests.cs
@@ -19,7 +19,19 @@ public sealed class VisualTests
         var updated = await GuaVisualAssertions.ExpectScreenshotAsync(context, "title", options);
         Assert.That(updated.BaselineUpdated, Is.True);
         var matched = await GuaVisualAssertions.ExpectScreenshotAsync(context, "title", Options("windows"));
-        Assert.Multiple(() => { Assert.That(matched.Matched, Is.True); Assert.That(matched.BaselinePath, Does.EndWith(Path.Combine("title", "windows.png"))); });
+        Assert.Multiple(() =>
+        {
+            Assert.That(matched.Matched, Is.True);
+            Assert.That(matched.BaselinePath, Does.EndWith(Path.Combine("title", "windows.png")));
+            Assert.That(matched.ArtifactPath, Is.Not.Null);
+            Assert.That(Directory.GetFiles(matched.ArtifactPath!).Select(Path.GetFileName), Is.EquivalentTo(new[] { "actual.png", "comparison.json" }));
+        });
+        using var metadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(matched.ArtifactPath!, "comparison.json")));
+        Assert.Multiple(() =>
+        {
+            Assert.That(metadata.RootElement.GetProperty("matched").GetBoolean(), Is.True);
+            Assert.That(metadata.RootElement.GetProperty("reason").GetString(), Is.EqualTo("matched"));
+        });
     }
 
     [Test]


### PR DESCRIPTION
## 概要

- ビジュアル比較が成功した場合も `actual.png` と `comparison.json` を出力
- 一致結果のマニフェストに比較メタデータと `reason: matched` を記録
- 成功時のアーティファクトとマニフェスト内容をテストで検証
- ドキュメントに成功時の出力仕様を追記

## テスト

- NUnit のビジュアルテストで成功時のアーティファクトファイルとマニフェスト内容を検証