### PR TITLE
全体にわたる決定論的な仮想時計サポートを追加

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -7,6 +7,32 @@ on:
       - main
 
 jobs:
+  remote-clock:
+    name: .NET remote clock
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build native runtime
+        run: |
+          cmake -S . -B build/dotnet-clock -DGUA_BUILD_EXAMPLES=OFF -DGUA_BUILD_GODOT=OFF
+          cmake --build build/dotnet-clock --config Release --target gua gua-runtime --parallel
+
+      - name: Restore selector tests
+        run: dotnet restore bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj
+
+      - name: Test remote clock and selector contracts
+        run: dotnet test bindings/dotnet/tests/Gua.Selector.Tests/Gua.Selector.Tests.csproj --configuration Release --no-restore
+        env:
+          GUA_NATIVE_DIR: ${{ github.workspace }}\build\dotnet-clock\native\gua-core\Release
+          GUA_RUNTIME_NATIVE_DIR: ${{ github.workspace }}\build\dotnet-clock\native\gua-runtime\Release
+
   cpp:
     name: C++ / CMake
     runs-on: ubuntu-latest
@@ -92,7 +118,8 @@ jobs:
       - name: Check
         run: bun run check
 
-      - name: Test MCP automation
+      - name: Test TypeScript packages
         run: |
+          bun run --filter @gua/bridge-ws test
           bun run --filter gui-mcp test
           bun run --filter @gua/inspector test

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Build native runtime for managed clock tests
+        run: |
+          cmake -S . -B build/dotnet-native -DCMAKE_BUILD_TYPE=Release -DGUA_BUILD_EXAMPLES=OFF -DGUA_BUILD_GODOT=OFF
+          cmake --build build/dotnet-native --config Release --target gua --parallel
+
       - name: Restore
         run: |
           dotnet restore bindings/dotnet/src/Gua.Testing.Godot/Gua.Testing.Godot.csproj
@@ -68,6 +73,8 @@ jobs:
 
       - name: Test Visual and Recording packages
         run: dotnet test bindings/dotnet/tests/Gua.Visual.Tests/Gua.Visual.Tests.csproj --configuration Release --no-restore
+        env:
+          GUA_NATIVE_DIR: ${{ github.workspace }}/build/dotnet-native/native/gua-core
 
   typescript:
     name: TypeScript / tsc

--- a/README.ja.md
+++ b/README.ja.md
@@ -150,19 +150,27 @@ reusable workflowはPlayer起動前にWindows test runnerの画面解像度を19
 
 ### 決定論的な仮想時間
 
-Guaは、時間依存のゲームロジック向けにオプトインの仮想時計を提供する。
-`GuaClock`へ処理を登録し、時計を停止してから、実時間を待たずに進められる。
+GuaClockを時刻源にしたゲームロジックは、停止したり、実時間を待たずに
+進めたりできる。既存のengine timerを自動的に置き換える機能ではない。
+まずゲーム本体の対象ロジックを、Godotの`Timer`、Unityの`Time.deltaTime`や
+Coroutineなどではなく、GuaClockのScheduleまたはTickを使う実装へ変更する。
+その後、テストから共有ClockをInstallして操作する。
 
 ```csharp
-var clock = new GuaClock(ui);
+// ゲーム側の組み込み。production codeで一度行う。
+var clock = runtime.Clock;
 clock.Install();
 clock.Schedule(TimeSpan.FromSeconds(2), ShowMessage);
+
+// テスト側から同じClockを操作する。
 clock.Pause();
 clock.RunFor(TimeSpan.FromSeconds(2));
 ```
 
-`Pause`の対象はGuaClockのSchedulerとTick購読処理だけだ。エンジン標準の
-Timer、物理、Animation、Audio、OS時刻、ネットワークは停止しない。
+ここで`Install`が行うのは共有仮想Clockの有効化であり、任意のgame objectへ
+Clockを自動注入することではない。`Pause`の対象は、あらかじめGuaClockの
+SchedulerまたはTickへ接続したゲームロジックだけだ。engine標準のTimer、
+物理、Animation、Audio、OS時刻、ネットワークは停止しない。
 bridge、MCP、Inspectorでも`get_clock`、`clock_install`、`clock_pause`、
 `clock_run_for`、`clock_resume`を利用できる。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -148,6 +148,24 @@ reusable workflowはPlayer起動前にWindows test runnerの画面解像度を19
 
 ## MCPとInspector
 
+### 決定論的な仮想時間
+
+Guaは、時間依存のゲームロジック向けにオプトインの仮想時計を提供する。
+`GuaClock`へ処理を登録し、時計を停止してから、実時間を待たずに進められる。
+
+```csharp
+var clock = new GuaClock(ui);
+clock.Install();
+clock.Schedule(TimeSpan.FromSeconds(2), ShowMessage);
+clock.Pause();
+clock.RunFor(TimeSpan.FromSeconds(2));
+```
+
+`Pause`の対象はGuaClockのSchedulerとTick購読処理だけだ。エンジン標準の
+Timer、物理、Animation、Audio、OS時刻、ネットワークは停止しない。
+bridge、MCP、Inspectorでも`get_clock`、`clock_install`、`clock_pause`、
+`clock_run_for`、`clock_resume`を利用できる。
+
 - **gui-mcp:** [![NPM Version](https://img.shields.io/npm/v/gui-mcp)](https://www.npmjs.com/package/gui-mcp) ![NPM Downloads](https://img.shields.io/npm/dw/gui-mcp)<br>
   Inspectorと同じWebSocketブリッジを通じて、Guaのランタイム操作を
   AIエージェントへ公開する薄いMCPサーバーです。

--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ workflows and diagrams.
 
 ## MCP and Inspector
 
+### Deterministic virtual time
+
+Gua exposes an opt-in virtual clock for time-dependent game logic. Install and
+pause it, schedule work through `GuaClock`, then advance it without waiting for
+wall time:
+
+```csharp
+var clock = new GuaClock(ui);
+clock.Install();
+clock.Schedule(TimeSpan.FromSeconds(2), ShowMessage);
+clock.Pause();
+clock.RunFor(TimeSpan.FromSeconds(2));
+```
+
+`Pause` affects only GuaClock schedules and tick subscribers. Engine-native
+timers, physics, animations, audio, OS time, and networking continue normally.
+The bridge, MCP, and Inspector expose `get_clock`, `clock_install`,
+`clock_pause`, `clock_run_for`, and `clock_resume`.
+
 - **gui-mcp:** [![NPM Version](https://img.shields.io/npm/v/gui-mcp)](https://www.npmjs.com/package/gui-mcp) ![NPM Downloads](https://img.shields.io/npm/dw/gui-mcp)<br>
   A thin MCP server that exposes Gua runtime actions to AI agents through the
   same WebSocket bridge used by the Inspector.

--- a/README.md
+++ b/README.md
@@ -109,20 +109,27 @@ workflows and diagrams.
 
 ### Deterministic virtual time
 
-Gua exposes an opt-in virtual clock for time-dependent game logic. Install and
-pause it, schedule work through `GuaClock`, then advance it without waiting for
-wall time:
+Gua can pause and advance game logic that uses GuaClock as its time source. It
+does not replace existing engine timers automatically. First change the game
+logic to use GuaClock schedules or ticks instead of Godot `Timer`, Unity
+`Time.deltaTime` / coroutines, or another native time source. Tests can then
+install and control that shared clock without waiting for wall time:
 
 ```csharp
-var clock = new GuaClock(ui);
+// Game-side integration (done once in the production code).
+var clock = runtime.Clock;
 clock.Install();
 clock.Schedule(TimeSpan.FromSeconds(2), ShowMessage);
+
+// Test-side control of the same clock.
 clock.Pause();
 clock.RunFor(TimeSpan.FromSeconds(2));
 ```
 
-`Pause` affects only GuaClock schedules and tick subscribers. Engine-native
-timers, physics, animations, audio, OS time, and networking continue normally.
+Here, `Install` activates Gua's shared virtual clock; it does not inject the
+clock into arbitrary game objects. `Pause` affects only game logic already
+wired to GuaClock schedules or ticks. Engine-native timers, physics, animations,
+audio, OS time, and networking continue normally.
 The bridge, MCP, and Inspector expose `get_clock`, `clock_install`,
 `clock_pause`, `clock_run_for`, and `clock_resume`.
 

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -1,0 +1,78 @@
+namespace Gua.Core;
+
+public enum GuaClockResult { Ok = 1, InvalidArgument = -1, NotInstalled = -2, InvalidState = -3, ExecutionLimit = -4 }
+
+public sealed record GuaClockStatus(bool Installed, bool Paused, double NowMilliseconds,
+    double DefaultStepMilliseconds, double PendingMilliseconds, ulong Generation)
+{
+    public TimeSpan Now => TimeSpan.FromMilliseconds(NowMilliseconds);
+}
+
+public readonly record struct GuaClockStep(TimeSpan Delta, bool FinalStep, ulong Generation);
+
+public interface IGuaClockContext
+{
+    GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null);
+    GuaClockResult PauseClock();
+    GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null);
+    GuaClockResult ResumeClock();
+    GuaClockStatus GetClockStatus();
+}
+
+public sealed class GuaClock
+{
+    private const int CallbackLimit = 1_000_000;
+    private readonly GuaContext context;
+    private readonly List<Scheduled> scheduled = [];
+    private long sequence;
+    public GuaClock(GuaContext context) => this.context = context ?? throw new ArgumentNullException(nameof(context));
+    public event Action<TimeSpan>? Tick;
+    public GuaClockStatus Status => context.GetClockStatus();
+
+    public void Install(TimeSpan? initialTime = null, TimeSpan? step = null) => Ensure(context.InstallClock(initialTime, step));
+    public void Pause() => Ensure(context.PauseClock());
+    public void Resume() => Ensure(context.ResumeClock());
+    public void RunFor(TimeSpan duration, TimeSpan? step = null)
+    {
+        Ensure(context.RunClockFor(duration, step));
+        DrainPendingSteps();
+    }
+
+    public IDisposable Schedule(TimeSpan delay, Action callback, TimeSpan? interval = null)
+    {
+        if (callback is null) throw new ArgumentNullException(nameof(callback));
+        if (delay < TimeSpan.Zero || interval is { } repeat && repeat <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
+        var item = new Scheduled(++sequence, Status.NowMilliseconds + delay.TotalMilliseconds,
+            interval?.TotalMilliseconds, callback);
+        scheduled.Add(item);
+        return new Cancellation(item);
+    }
+
+    public void DrainPendingSteps()
+    {
+        var callbacks = 0;
+        while (context.TryConsumeClockStep(out var step))
+        {
+            var now = context.GetClockStatus().NowMilliseconds;
+            while (scheduled.Where(item => !item.Cancelled && item.DueMs <= now)
+                       .OrderBy(item => item.DueMs).ThenBy(item => item.Sequence).FirstOrDefault() is { } item)
+            {
+                if (++callbacks > CallbackLimit) throw new InvalidOperationException("Gua clock execution_limit.");
+                if (item.Cancelled) continue;
+                item.Callback();
+                if (item.IntervalMs is { } interval) item.DueMs += interval;
+                else item.Cancelled = true;
+            }
+            scheduled.RemoveAll(item => item.Cancelled);
+            Tick?.Invoke(step.Delta);
+        }
+    }
+
+    private static void Ensure(GuaClockResult result)
+    {
+        if (result != GuaClockResult.Ok) throw new InvalidOperationException($"Gua clock operation failed: {result}.");
+    }
+    private sealed class Scheduled(long sequence, double dueMs, double? intervalMs, Action callback)
+    { public long Sequence { get; } = sequence; public double DueMs { get; set; } = dueMs; public double? IntervalMs { get; } = intervalMs; public Action Callback { get; } = callback; public bool Cancelled { get; set; } }
+    private sealed class Cancellation(Scheduled item) : IDisposable { public void Dispose() => item.Cancelled = true; }
+}

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -17,16 +17,20 @@ public readonly record struct GuaClockDelta(double TotalMilliseconds)
     public static implicit operator TimeSpan(GuaClockDelta value) => value.TimeSpan;
 }
 
-public interface IGuaClockContext
+public interface IGuaClockStatusContext
+{
+    GuaClockStatus GetClockStatus();
+}
+
+public interface IGuaClockContext : IGuaClockStatusContext
 {
     GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null);
     GuaClockResult PauseClock();
     GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null);
     GuaClockResult ResumeClock();
-    GuaClockStatus GetClockStatus();
 }
 
-public interface IGuaAsyncClockContext
+public interface IGuaAsyncClockContext : IGuaClockStatusContext
 {
     Task<GuaClockResult> InstallClockAsync(TimeSpan? initialTime = null, TimeSpan? step = null, CancellationToken cancellationToken = default);
     Task<GuaClockResult> PauseClockAsync(CancellationToken cancellationToken = default);

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -19,6 +19,11 @@ public interface IGuaClockContext
     GuaClockStatus GetClockStatus();
 }
 
+public interface IGuaAsyncClockContext
+{
+    Task<GuaClockResult> RunClockForAsync(TimeSpan duration, TimeSpan? step = null, CancellationToken cancellationToken = default);
+}
+
 public sealed class GuaClock
 {
     private const int CallbackLimit = 1_000_000;
@@ -61,8 +66,13 @@ public sealed class GuaClock
             {
                 if (++callbacks > CallbackLimit) throw new InvalidOperationException("Gua clock execution_limit.");
                 if (item.Cancelled) continue;
+                scheduled.Remove(item);
                 item.Callback();
-                if (item.IntervalMs is { } interval) item.DueMs += interval;
+                if (item.IntervalMs is { } interval && !item.Cancelled)
+                {
+                    item.DueMs += interval;
+                    scheduled.Add(item);
+                }
                 else item.Cancelled = true;
             }
             scheduled.RemoveAll(item => item.Cancelled);

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -21,7 +21,10 @@ public interface IGuaClockContext
 
 public interface IGuaAsyncClockContext
 {
+    Task<GuaClockResult> InstallClockAsync(TimeSpan? initialTime = null, TimeSpan? step = null, CancellationToken cancellationToken = default);
+    Task<GuaClockResult> PauseClockAsync(CancellationToken cancellationToken = default);
     Task<GuaClockResult> RunClockForAsync(TimeSpan duration, TimeSpan? step = null, CancellationToken cancellationToken = default);
+    Task<GuaClockResult> ResumeClockAsync(CancellationToken cancellationToken = default);
 }
 
 public sealed class GuaClock

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -42,7 +42,8 @@ public sealed class GuaClock
     {
         if (callback is null) throw new ArgumentNullException(nameof(callback));
         if (delay < TimeSpan.Zero || interval is { } repeat && repeat <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
-        var item = new Scheduled(++sequence, Status.NowMilliseconds + delay.TotalMilliseconds,
+        var status = Status;
+        var item = new Scheduled(++sequence, status.Generation, status.NowMilliseconds + delay.TotalMilliseconds,
             interval?.TotalMilliseconds, callback);
         scheduled.Add(item);
         return new Cancellation(item);
@@ -53,6 +54,7 @@ public sealed class GuaClock
         var callbacks = 0;
         while (context.TryConsumeClockStep(out var step))
         {
+            scheduled.RemoveAll(item => item.Generation != step.Generation);
             var now = context.GetClockStatus().NowMilliseconds;
             while (scheduled.Where(item => !item.Cancelled && item.DueMs <= now)
                        .OrderBy(item => item.DueMs).ThenBy(item => item.Sequence).FirstOrDefault() is { } item)
@@ -72,7 +74,7 @@ public sealed class GuaClock
     {
         if (result != GuaClockResult.Ok) throw new InvalidOperationException($"Gua clock operation failed: {result}.");
     }
-    private sealed class Scheduled(long sequence, double dueMs, double? intervalMs, Action callback)
-    { public long Sequence { get; } = sequence; public double DueMs { get; set; } = dueMs; public double? IntervalMs { get; } = intervalMs; public Action Callback { get; } = callback; public bool Cancelled { get; set; } }
+    private sealed class Scheduled(long sequence, ulong generation, double dueMs, double? intervalMs, Action callback)
+    { public long Sequence { get; } = sequence; public ulong Generation { get; } = generation; public double DueMs { get; set; } = dueMs; public double? IntervalMs { get; } = intervalMs; public Action Callback { get; } = callback; public bool Cancelled { get; set; } }
     private sealed class Cancellation(Scheduled item) : IDisposable { public void Dispose() => item.Cancelled = true; }
 }

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -129,7 +129,12 @@ public sealed class GuaClock
             }
             scheduled.RemoveAll(item => item.Cancelled);
             if (context.GetClockStatus().Generation != step.Generation) continue;
-            Tick?.Invoke(new GuaClockDelta(step.Delta.TotalMilliseconds));
+            if (Tick is not null)
+                foreach (Action<GuaClockDelta> handler in Tick.GetInvocationList())
+                {
+                    handler(new GuaClockDelta(step.Delta.TotalMilliseconds));
+                    if (context.GetClockStatus().Generation != step.Generation) break;
+                }
         }
         }
         finally { draining = false; }

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -10,6 +10,13 @@ public sealed record GuaClockStatus(bool Installed, bool Paused, double NowMilli
 
 public readonly record struct GuaClockStep(TimeSpan Delta, bool FinalStep, ulong Generation);
 
+public readonly record struct GuaClockDelta(double TotalMilliseconds)
+{
+    public double TotalSeconds => TotalMilliseconds / 1000.0;
+    public TimeSpan TimeSpan => TimeSpan.FromMilliseconds(TotalMilliseconds);
+    public static implicit operator TimeSpan(GuaClockDelta value) => value.TimeSpan;
+}
+
 public interface IGuaClockContext
 {
     GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null);
@@ -34,7 +41,7 @@ public sealed class GuaClock
     private readonly List<Scheduled> scheduled = [];
     private long sequence;
     public GuaClock(GuaContext context) => this.context = context ?? throw new ArgumentNullException(nameof(context));
-    public event Action<TimeSpan>? Tick;
+    public event Action<GuaClockDelta>? Tick;
     public GuaClockStatus Status => context.GetClockStatus();
 
     public void Install(TimeSpan? initialTime = null, TimeSpan? step = null) => Ensure(context.InstallClock(initialTime, step));
@@ -56,7 +63,7 @@ public sealed class GuaClock
             bindOnInstall ? delay.TotalMilliseconds : status.NowMilliseconds + delay.TotalMilliseconds,
             interval?.TotalMilliseconds, callback, bindOnInstall);
         scheduled.Add(item);
-        return new Cancellation(item);
+        return new Cancellation(this, item);
     }
 
     public void DrainPendingSteps()
@@ -78,7 +85,7 @@ public sealed class GuaClock
                 }
                 if (item.Cancelled) continue;
                 scheduled.Remove(item);
-                item.Callback();
+                item.Callback?.Invoke();
                 var generation = context.GetClockStatus().Generation;
                 if (generation != step.Generation)
                 {
@@ -94,7 +101,7 @@ public sealed class GuaClock
                 else item.Cancelled = true;
             }
             scheduled.RemoveAll(item => item.Cancelled);
-            Tick?.Invoke(step.Delta);
+            Tick?.Invoke(new GuaClockDelta(step.Delta.TotalMilliseconds));
         }
     }
 
@@ -115,7 +122,14 @@ public sealed class GuaClock
     {
         if (result != GuaClockResult.Ok) throw new InvalidOperationException($"Gua clock operation failed: {result}.");
     }
+    private void Cancel(Scheduled item)
+    {
+        item.Cancelled = true;
+        item.Callback = null;
+        scheduled.Remove(item);
+    }
     private sealed class Scheduled(long sequence, ulong generation, double dueMs, double? intervalMs, Action callback, bool bindOnInstall)
-    { public long Sequence { get; } = sequence; public ulong Generation { get; set; } = generation; public double DueMs { get; set; } = dueMs; public double? IntervalMs { get; } = intervalMs; public Action Callback { get; } = callback; public bool BindOnInstall { get; set; } = bindOnInstall; public bool Cancelled { get; set; } }
-    private sealed class Cancellation(Scheduled item) : IDisposable { public void Dispose() => item.Cancelled = true; }
+    { public long Sequence { get; } = sequence; public ulong Generation { get; set; } = generation; public double DueMs { get; set; } = dueMs; public double? IntervalMs { get; } = intervalMs; public Action? Callback { get; set; } = callback; public bool BindOnInstall { get; set; } = bindOnInstall; public bool Cancelled { get; set; } }
+    private sealed class Cancellation(GuaClock owner, Scheduled item) : IDisposable
+    { private GuaClock? Owner { get; set; } = owner; public void Dispose() { Owner?.Cancel(item); Owner = null; } }
 }

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -51,14 +51,17 @@ public sealed class GuaClock
         if (callback is null) throw new ArgumentNullException(nameof(callback));
         if (delay < TimeSpan.Zero || interval is { } repeat && repeat <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
         var status = Status;
-        var item = new Scheduled(++sequence, status.Generation, status.NowMilliseconds + delay.TotalMilliseconds,
-            interval?.TotalMilliseconds, callback);
+        var bindOnInstall = !status.Installed;
+        var item = new Scheduled(++sequence, status.Generation,
+            bindOnInstall ? delay.TotalMilliseconds : status.NowMilliseconds + delay.TotalMilliseconds,
+            interval?.TotalMilliseconds, callback, bindOnInstall);
         scheduled.Add(item);
         return new Cancellation(item);
     }
 
     public void DrainPendingSteps()
     {
+        BindPendingSchedules();
         var callbacks = 0;
         while (context.TryConsumeClockStep(out var step))
         {
@@ -83,11 +86,24 @@ public sealed class GuaClock
         }
     }
 
+    private void BindPendingSchedules()
+    {
+        var status = Status;
+        if (!status.Installed) return;
+        scheduled.RemoveAll(item => item.BindOnInstall && status.Generation != item.Generation + 1);
+        foreach (var item in scheduled.Where(item => item.BindOnInstall))
+        {
+            item.Generation = status.Generation;
+            item.DueMs = status.NowMilliseconds + item.DueMs;
+            item.BindOnInstall = false;
+        }
+    }
+
     private static void Ensure(GuaClockResult result)
     {
         if (result != GuaClockResult.Ok) throw new InvalidOperationException($"Gua clock operation failed: {result}.");
     }
-    private sealed class Scheduled(long sequence, ulong generation, double dueMs, double? intervalMs, Action callback)
-    { public long Sequence { get; } = sequence; public ulong Generation { get; } = generation; public double DueMs { get; set; } = dueMs; public double? IntervalMs { get; } = intervalMs; public Action Callback { get; } = callback; public bool Cancelled { get; set; } }
+    private sealed class Scheduled(long sequence, ulong generation, double dueMs, double? intervalMs, Action callback, bool bindOnInstall)
+    { public long Sequence { get; } = sequence; public ulong Generation { get; set; } = generation; public double DueMs { get; set; } = dueMs; public double? IntervalMs { get; } = intervalMs; public Action Callback { get; } = callback; public bool BindOnInstall { get; set; } = bindOnInstall; public bool Cancelled { get; set; } }
     private sealed class Cancellation(Scheduled item) : IDisposable { public void Dispose() => item.Cancelled = true; }
 }

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -70,7 +70,12 @@ public sealed class GuaClock
             while (scheduled.Where(item => !item.Cancelled && item.DueMs <= now)
                        .OrderBy(item => item.DueMs).ThenBy(item => item.Sequence).FirstOrDefault() is { } item)
             {
-                if (++callbacks > CallbackLimit) throw new InvalidOperationException("Gua clock execution_limit.");
+                if (++callbacks > CallbackLimit)
+                {
+                    scheduled.ForEach(candidate => candidate.Cancelled = true);
+                    scheduled.Clear();
+                    throw new InvalidOperationException("Gua clock execution_limit.");
+                }
                 if (item.Cancelled) continue;
                 scheduled.Remove(item);
                 item.Callback();

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -70,12 +70,16 @@ public sealed class GuaClock
     public IDisposable Schedule(TimeSpan delay, Action callback, TimeSpan? interval = null)
     {
         if (callback is null) throw new ArgumentNullException(nameof(callback));
-        if (delay < TimeSpan.Zero || interval is { } repeat && repeat <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
+        if (delay < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
+        if (interval is { } repeat && repeat <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(interval));
         var status = Status;
         var bindOnInstall = !status.Installed;
-        var item = new Scheduled(++sequence, status.Generation,
-            bindOnInstall ? delay.TotalMilliseconds : status.NowMilliseconds + delay.TotalMilliseconds,
-            interval?.TotalMilliseconds, callback, bindOnInstall);
+        var delayMs = delay.TotalMilliseconds;
+        var intervalMs = interval?.TotalMilliseconds;
+        var dueMs = bindOnInstall ? delayMs : status.NowMilliseconds + delayMs;
+        if (!bindOnInstall) ValidateRepresentableSchedule(status.NowMilliseconds, delayMs, dueMs, intervalMs);
+        var item = new Scheduled(++sequence, status.Generation, dueMs,
+            intervalMs, callback, bindOnInstall);
         scheduled.Add(item);
         return new Cancellation(this, item);
     }
@@ -113,8 +117,13 @@ public sealed class GuaClock
                 }
                 if (item.IntervalMs is { } interval && !item.Cancelled)
                 {
-                    item.DueMs += interval;
-                    scheduled.Add(item);
+                    var nextDueMs = item.DueMs + interval;
+                    if (double.IsFinite(nextDueMs) && nextDueMs > item.DueMs)
+                    {
+                        item.DueMs = nextDueMs;
+                        scheduled.Add(item);
+                    }
+                    else item.Cancelled = true;
                 }
                 else item.Cancelled = true;
             }
@@ -131,10 +140,17 @@ public sealed class GuaClock
         var status = Status;
         if (!status.Installed) return;
         scheduled.RemoveAll(item => item.BindOnInstall && status.Generation != item.Generation + 1);
-        foreach (var item in scheduled.Where(item => item.BindOnInstall))
+        foreach (var item in scheduled.Where(item => item.BindOnInstall).ToArray())
         {
+            var dueMs = status.NowMilliseconds + item.DueMs;
+            try { ValidateRepresentableSchedule(status.NowMilliseconds, item.DueMs, dueMs, item.IntervalMs); }
+            catch (ArgumentOutOfRangeException)
+            {
+                Cancel(item);
+                continue;
+            }
             item.Generation = status.Generation;
-            item.DueMs = status.NowMilliseconds + item.DueMs;
+            item.DueMs = dueMs;
             item.BindOnInstall = false;
         }
     }
@@ -147,6 +163,17 @@ public sealed class GuaClock
     private static void Ensure(GuaClockResult result)
     {
         if (result != GuaClockResult.Ok) throw new InvalidOperationException($"Gua clock operation failed: {result}.");
+    }
+    private static void ValidateRepresentableSchedule(double now, double delay, double due, double? interval)
+    {
+        if (!double.IsFinite(due) || delay > 0 && due <= now)
+            throw new ArgumentOutOfRangeException(nameof(delay), "The delay cannot advance the current Gua clock timeline.");
+        if (interval is { } repeat)
+        {
+            var nextDue = due + repeat;
+            if (!double.IsFinite(nextDue) || nextDue <= due)
+                throw new ArgumentOutOfRangeException(nameof(interval), "The interval cannot advance its representable Gua clock deadline.");
+        }
     }
     private void Cancel(Scheduled item)
     {

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -79,6 +79,13 @@ public sealed class GuaClock
                 if (item.Cancelled) continue;
                 scheduled.Remove(item);
                 item.Callback();
+                var generation = context.GetClockStatus().Generation;
+                if (generation != step.Generation)
+                {
+                    item.Cancelled = true;
+                    scheduled.RemoveAll(candidate => candidate.Generation != generation);
+                    break;
+                }
                 if (item.IntervalMs is { } interval && !item.Cancelled)
                 {
                     item.DueMs += interval;

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -8,7 +8,7 @@ public sealed record GuaClockStatus(bool Installed, bool Paused, double NowMilli
     public TimeSpan Now => TimeSpan.FromMilliseconds(NowMilliseconds);
 }
 
-public readonly record struct GuaClockStep(TimeSpan Delta, bool FinalStep, ulong Generation);
+public readonly record struct GuaClockStep(GuaClockDelta Delta, bool FinalStep, ulong Generation);
 
 public readonly record struct GuaClockDelta(double TotalMilliseconds)
 {
@@ -132,7 +132,7 @@ public sealed class GuaClock
             if (Tick is not null)
                 foreach (Action<GuaClockDelta> handler in Tick.GetInvocationList())
                 {
-                    handler(new GuaClockDelta(step.Delta.TotalMilliseconds));
+                    handler(step.Delta);
                     if (context.GetClockStatus().Generation != step.Generation) break;
                 }
         }

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -40,6 +40,7 @@ public sealed class GuaClock
     private readonly GuaContext context;
     private readonly List<Scheduled> scheduled = [];
     private long sequence;
+    private bool draining;
     public GuaClock(GuaContext context) => this.context = context ?? throw new ArgumentNullException(nameof(context));
     public event Action<GuaClockDelta>? Tick;
     public GuaClockStatus Status => context.GetClockStatus();
@@ -68,6 +69,10 @@ public sealed class GuaClock
 
     public void DrainPendingSteps()
     {
+        if (draining) return;
+        draining = true;
+        try
+        {
         BindPendingSchedules();
         var callbacks = 0;
         while (context.TryConsumeClockStep(out var step))
@@ -101,8 +106,11 @@ public sealed class GuaClock
                 else item.Cancelled = true;
             }
             scheduled.RemoveAll(item => item.Cancelled);
+            if (context.GetClockStatus().Generation != step.Generation) continue;
             Tick?.Invoke(new GuaClockDelta(step.Delta.TotalMilliseconds));
         }
+        }
+        finally { draining = false; }
     }
 
     private void BindPendingSchedules()

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -5,7 +5,15 @@ public enum GuaClockResult { Ok = 1, InvalidArgument = -1, NotInstalled = -2, In
 public sealed record GuaClockStatus(bool Installed, bool Paused, double NowMilliseconds,
     double DefaultStepMilliseconds, double PendingMilliseconds, ulong Generation)
 {
-    public TimeSpan Now => TimeSpan.FromMilliseconds(NowMilliseconds);
+    /// <summary>
+    /// Gets the current time as a <see cref="TimeSpan"/> when it is within the
+    /// considerably smaller range supported by <see cref="TimeSpan"/>.
+    /// Use <see cref="NowMilliseconds"/> for the full protocol range.
+    /// </summary>
+    public TimeSpan? Now => TryGetNow(out var value) ? value : null;
+
+    public bool TryGetNow(out TimeSpan value) =>
+        GuaClockTimeSpan.TryFromMilliseconds(NowMilliseconds, out value);
 }
 
 public readonly record struct GuaClockStep(GuaClockDelta Delta, bool FinalStep, ulong Generation);
@@ -13,8 +21,43 @@ public readonly record struct GuaClockStep(GuaClockDelta Delta, bool FinalStep, 
 public readonly record struct GuaClockDelta(double TotalMilliseconds)
 {
     public double TotalSeconds => TotalMilliseconds / 1000.0;
-    public TimeSpan TimeSpan => TimeSpan.FromMilliseconds(TotalMilliseconds);
-    public static implicit operator TimeSpan(GuaClockDelta value) => value.TimeSpan;
+    /// <summary>Gets a bounded <see cref="System.TimeSpan"/> projection, or null when the protocol value is outside its range.</summary>
+    public TimeSpan? TimeSpan => TryGetTimeSpan(out var value) ? value : null;
+    public bool TryGetTimeSpan(out TimeSpan value) =>
+        GuaClockTimeSpan.TryFromMilliseconds(TotalMilliseconds, out value);
+}
+
+internal static class GuaClockTimeSpan
+{
+    private static readonly double MaxMilliseconds = (double)long.MaxValue / System.TimeSpan.TicksPerMillisecond;
+    private static readonly double MinMilliseconds = (double)long.MinValue / System.TimeSpan.TicksPerMillisecond;
+
+    public static bool TryFromMilliseconds(double milliseconds, out TimeSpan value)
+    {
+        if (!double.IsFinite(milliseconds) || milliseconds < MinMilliseconds || milliseconds > MaxMilliseconds)
+        {
+            value = default;
+            return false;
+        }
+
+        var ticks = milliseconds * System.TimeSpan.TicksPerMillisecond;
+        if (ticks < long.MinValue || ticks > long.MaxValue)
+        {
+            value = default;
+            return false;
+        }
+
+        try
+        {
+            value = System.TimeSpan.FromTicks(checked((long)ticks));
+            return true;
+        }
+        catch (OverflowException)
+        {
+            value = default;
+            return false;
+        }
+    }
 }
 
 public interface IGuaClockStatusContext

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -48,7 +48,15 @@ public sealed class GuaClock
         if (registerWithContext) context.RegisterClock(this);
     }
     public event Action<GuaClockDelta>? Tick;
-    public GuaClockStatus Status => context.GetClockStatus();
+    public GuaClockStatus Status
+    {
+        get
+        {
+            var status = context.GetClockStatus();
+            ObserveStatus(status);
+            return status;
+        }
+    }
 
     public void Install(TimeSpan? initialTime = null, TimeSpan? step = null) => Ensure(context.InstallClock(initialTime, step));
     public void Pause() => Ensure(context.PauseClock());
@@ -129,6 +137,11 @@ public sealed class GuaClock
             item.DueMs = status.NowMilliseconds + item.DueMs;
             item.BindOnInstall = false;
         }
+    }
+
+    internal void ObserveStatus(GuaClockStatus status)
+    {
+        scheduled.RemoveAll(item => item.Cancelled || !status.Installed && item.Generation != status.Generation);
     }
 
     private static void Ensure(GuaClockResult result)

--- a/bindings/dotnet/src/Gua.Core/GuaClock.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaClock.cs
@@ -41,7 +41,12 @@ public sealed class GuaClock
     private readonly List<Scheduled> scheduled = [];
     private long sequence;
     private bool draining;
-    public GuaClock(GuaContext context) => this.context = context ?? throw new ArgumentNullException(nameof(context));
+    public GuaClock(GuaContext context) : this(context, registerWithContext: true) { }
+    internal GuaClock(GuaContext context, bool registerWithContext)
+    {
+        this.context = context ?? throw new ArgumentNullException(nameof(context));
+        if (registerWithContext) context.RegisterClock(this);
+    }
     public event Action<GuaClockDelta>? Tick;
     public GuaClockStatus Status => context.GetClockStatus();
 

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -179,7 +179,7 @@ public sealed class GuaContext : IGuaContext, IGuaClockContext, IDisposable
     {
         ThrowIfDisposed(); var value = new Native.GuaNativeClockStep { StructSize = (uint)Marshal.SizeOf<Native.GuaNativeClockStep>() };
         if (Native.gua_clock_consume_step(_handle, ref value) == 0) { step = default; return false; }
-        step = new(TimeSpan.FromMilliseconds(value.DeltaMs), value.FinalStep != 0, value.Generation); return true;
+        step = new(new GuaClockDelta(value.DeltaMs), value.FinalStep != 0, value.Generation); return true;
     }
 
     public void ConfigureDiagnostics(uint historyLimit, string environmentJson = "{}")

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 namespace Gua.Core;
 
-public sealed class GuaContext : IGuaContext, IDisposable
+public sealed class GuaContext : IGuaContext, IGuaClockContext, IDisposable
 {
     private nint _handle;
 
@@ -143,6 +143,25 @@ public sealed class GuaContext : IGuaContext, IDisposable
     {
         ThrowIfDisposed();
         return GuaVersion.Parse(ReadCopiedJson(JsonSource.Version, _handle));
+    }
+
+    public GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null)
+    { ThrowIfDisposed(); return (GuaClockResult)Native.gua_clock_install(_handle, (initialTime ?? TimeSpan.Zero).TotalMilliseconds, (step ?? TimeSpan.FromSeconds(1.0 / 60.0)).TotalMilliseconds); }
+    public GuaClockResult PauseClock() { ThrowIfDisposed(); return (GuaClockResult)Native.gua_clock_pause(_handle); }
+    public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
+    { ThrowIfDisposed(); return (GuaClockResult)Native.gua_clock_run_for(_handle, duration.TotalMilliseconds, (step ?? TimeSpan.FromMilliseconds(GetClockStatus().DefaultStepMilliseconds)).TotalMilliseconds); }
+    public GuaClockResult ResumeClock() { ThrowIfDisposed(); return (GuaClockResult)Native.gua_clock_resume(_handle); }
+    public GuaClockStatus GetClockStatus()
+    {
+        ThrowIfDisposed(); var value = new Native.GuaNativeClockStatus { StructSize = (uint)Marshal.SizeOf<Native.GuaNativeClockStatus>() };
+        if (Native.gua_clock_get_status(_handle, ref value) == 0) throw new InvalidOperationException("Failed to read Gua clock status.");
+        return new(value.Installed != 0, value.Paused != 0, value.NowMs, value.DefaultStepMs, value.PendingMs, value.Generation);
+    }
+    public bool TryConsumeClockStep(out GuaClockStep step)
+    {
+        ThrowIfDisposed(); var value = new Native.GuaNativeClockStep { StructSize = (uint)Marshal.SizeOf<Native.GuaNativeClockStep>() };
+        if (Native.gua_clock_consume_step(_handle, ref value) == 0) { step = default; return false; }
+        step = new(TimeSpan.FromMilliseconds(value.DeltaMs), value.FinalStep != 0, value.Generation); return true;
     }
 
     public void ConfigureDiagnostics(uint historyLimit, string environmentJson = "{}")

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -219,6 +219,7 @@ public sealed class GuaContext : IGuaContext, IGuaClockContext, IDisposable
             Flags = (uint)options.Targets,
             Strict = options.Strict ? 1 : 0,
             ExpectedSessionEpoch = options.ExpectedSessionEpoch ?? 0,
+            FlagsVersion = 1,
         };
         Native.GuaNativeResetReport report = default;
         report.StructSize = (uint)sizeof(Native.GuaNativeResetReport);
@@ -226,6 +227,10 @@ public sealed class GuaContext : IGuaContext, IGuaClockContext, IDisposable
         if (result == (int)GuaResetResult.InvalidArgument)
         {
             throw new ArgumentException("Invalid Gua reset options.", nameof(options));
+        }
+        if (result == (int)GuaResetResult.Succeeded && _clock is not null)
+        {
+            _clock.ObserveStatus(GetClockStatus());
         }
         return new GuaResetReport(
             (GuaResetResult)result, report.PreviousSessionEpoch, report.SessionEpoch,

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -158,6 +158,8 @@ public sealed class GuaContext : IGuaContext, IGuaClockContext, IDisposable
     internal void RegisterClock(GuaClock clock)
     {
         ThrowIfDisposed();
+        if (_clock is not null && !ReferenceEquals(_clock, clock))
+            throw new InvalidOperationException("A GuaContext can own only one GuaClock. Reuse context.Clock instead of constructing another clock.");
         _clock = clock;
     }
 

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -5,6 +5,7 @@ namespace Gua.Core;
 public sealed class GuaContext : IGuaContext, IGuaClockContext, IDisposable
 {
     private nint _handle;
+    private GuaClock? _clock;
 
     public GuaContext()
     {
@@ -143,6 +144,21 @@ public sealed class GuaContext : IGuaContext, IGuaClockContext, IDisposable
     {
         ThrowIfDisposed();
         return GuaVersion.Parse(ReadCopiedJson(JsonSource.Version, _handle));
+    }
+
+    public GuaClock Clock
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _clock ??= new GuaClock(this, registerWithContext: false);
+        }
+    }
+
+    internal void RegisterClock(GuaClock clock)
+    {
+        ThrowIfDisposed();
+        _clock = clock;
     }
 
     public GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null)

--- a/bindings/dotnet/src/Gua.Core/GuaContext.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaContext.cs
@@ -164,10 +164,12 @@ public sealed class GuaContext : IGuaContext, IGuaClockContext, IDisposable
     }
 
     public GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null)
-    { ThrowIfDisposed(); return (GuaClockResult)Native.gua_clock_install(_handle, (initialTime ?? TimeSpan.Zero).TotalMilliseconds, (step ?? TimeSpan.FromSeconds(1.0 / 60.0)).TotalMilliseconds); }
+    { ThrowIfDisposed(); return (GuaClockResult)Native.gua_clock_install(_handle,
+        initialTime?.TotalMilliseconds ?? 0.0, step?.TotalMilliseconds ?? 1000.0 / 60.0); }
     public GuaClockResult PauseClock() { ThrowIfDisposed(); return (GuaClockResult)Native.gua_clock_pause(_handle); }
     public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
-    { ThrowIfDisposed(); return (GuaClockResult)Native.gua_clock_run_for(_handle, duration.TotalMilliseconds, (step ?? TimeSpan.FromMilliseconds(GetClockStatus().DefaultStepMilliseconds)).TotalMilliseconds); }
+    { ThrowIfDisposed(); return (GuaClockResult)Native.gua_clock_run_for(_handle, duration.TotalMilliseconds,
+        step?.TotalMilliseconds ?? GetClockStatus().DefaultStepMilliseconds); }
     public GuaClockResult ResumeClock() { ThrowIfDisposed(); return (GuaClockResult)Native.gua_clock_resume(_handle); }
     public GuaClockStatus GetClockStatus()
     {

--- a/bindings/dotnet/src/Gua.Core/GuaReset.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaReset.cs
@@ -10,7 +10,8 @@ public enum GuaResetTargets : uint
     History = 1 << 3,
     Logs = 1 << 4,
     Screenshot = 1 << 5,
-    Default = Nodes | Requests | Events | History,
+    Clock = 1 << 6,
+    Default = Nodes | Requests | Events | History | Clock,
     All = Default | Logs | Screenshot,
 }
 

--- a/bindings/dotnet/src/Gua.Core/GuaReset.cs
+++ b/bindings/dotnet/src/Gua.Core/GuaReset.cs
@@ -11,8 +11,10 @@ public enum GuaResetTargets : uint
     Logs = 1 << 4,
     Screenshot = 1 << 5,
     Clock = 1 << 6,
-    Default = Nodes | Requests | Events | History | Clock,
+    Default = Nodes | Requests | Events | History,
+    SessionDefault = Default | Clock,
     All = Default | Logs | Screenshot,
+    AllWithClock = All | Clock,
 }
 
 public enum GuaResetResult
@@ -24,7 +26,7 @@ public enum GuaResetResult
 }
 
 public sealed record GuaResetOptions(
-    GuaResetTargets Targets = GuaResetTargets.Default,
+    GuaResetTargets Targets = GuaResetTargets.SessionDefault,
     bool Strict = false,
     ulong? ExpectedSessionEpoch = null);
 

--- a/bindings/dotnet/src/Gua.Core/Native.NetStandard.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.NetStandard.cs
@@ -69,6 +69,13 @@ internal static partial class Native
     [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
     internal static extern unsafe int gua_copy_version_json(byte* outJson, int outJsonSize);
 
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_clock_install(nint context, double initialTimeMs, double stepMs);
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_clock_pause(nint context);
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_clock_run_for(nint context, double durationMs, double stepMs);
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_clock_resume(nint context);
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_clock_get_status(nint context, ref GuaNativeClockStatus status);
+    [DllImport("gua", CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_clock_consume_step(nint context, ref GuaNativeClockStep step);
+
     [DllImport("gua", CallingConvention = CallingConvention.Cdecl)]
     internal static extern int gua_get_node_state(nint context, [MarshalAs(UnmanagedType.LPUTF8Str)] string nodeId, out GuaNodeState state);
 

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -64,6 +64,14 @@ internal static partial class Native
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    internal struct GuaNativeClockStatus
+    { public uint StructSize; public int Installed; public int Paused; public double NowMs; public double DefaultStepMs; public double PendingMs; public ulong Generation; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct GuaNativeClockStep
+    { public uint StructSize; public double DeltaMs; public int FinalStep; public ulong Generation; }
+
+    [StructLayout(LayoutKind.Sequential)]
     internal struct GuaNativeResetOptions
     {
         public uint StructSize;
@@ -363,6 +371,13 @@ internal static partial class Native
 
     [LibraryImport("gua")]
     internal static unsafe partial int gua_copy_version_json(byte* outJson, int outJsonSize);
+
+    [LibraryImport("gua")] internal static partial int gua_clock_install(nint context, double initialTimeMs, double stepMs);
+    [LibraryImport("gua")] internal static partial int gua_clock_pause(nint context);
+    [LibraryImport("gua")] internal static partial int gua_clock_run_for(nint context, double durationMs, double stepMs);
+    [LibraryImport("gua")] internal static partial int gua_clock_resume(nint context);
+    [LibraryImport("gua")] internal static partial int gua_clock_get_status(nint context, ref GuaNativeClockStatus status);
+    [LibraryImport("gua")] internal static partial int gua_clock_consume_step(nint context, ref GuaNativeClockStep step);
 
     [LibraryImport("gua", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int gua_get_node_state(nint context, string nodeId, out GuaNodeState state);

--- a/bindings/dotnet/src/Gua.Core/Native.cs
+++ b/bindings/dotnet/src/Gua.Core/Native.cs
@@ -78,6 +78,7 @@ internal static partial class Native
         public uint Flags;
         public int Strict;
         public ulong ExpectedSessionEpoch;
+        public uint FlagsVersion;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/bindings/dotnet/src/Gua.Core/README.md
+++ b/bindings/dotnet/src/Gua.Core/README.md
@@ -30,7 +30,9 @@ Click remains available through the original API and shares the same queue.
 
 `GuaContext.Clock` is the context-owned `GuaClock` Scheduler/Tick surface.
 Constructing `new GuaClock(context)` registers that instance as the owned clock,
-so test controls and game code drain the same scheduled work.
+so test controls and game code drain the same scheduled work. A context accepts
+only one managed clock; reuse `context.Clock` instead of constructing a second
+instance.
 
 At runtime the resolver checks:
 

--- a/bindings/dotnet/src/Gua.Core/README.md
+++ b/bindings/dotnet/src/Gua.Core/README.md
@@ -28,6 +28,10 @@ consumes the request, performs the real UI operation, then calls
 v1 actions are focus, set value, set checked, select, scroll, and key press.
 Click remains available through the original API and shares the same queue.
 
+`GuaContext.Clock` is the context-owned `GuaClock` Scheduler/Tick surface.
+Constructing `new GuaClock(context)` registers that instance as the owned clock,
+so test controls and game code drain the same scheduled work.
+
 At runtime the resolver checks:
 
 1. `GUA_NATIVE_DIR`

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntime.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntime.cs
@@ -25,7 +25,11 @@ public sealed class GuaRuntime : IDisposable
         catch (Exception error) when (error is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
         { throw new InvalidOperationException("Failed to load the native Gua runtime. Ensure gua.dll and gua_runtime.dll match the current platform and architecture.", error); }
         if (_handle == 0) throw new InvalidOperationException("Failed to create a Gua runtime.");
+        Clock = new GuaRuntimeClock(this);
     }
+
+    public GuaRuntimeClock Clock { get; }
+    internal nint Handle { get { ThrowIfDisposed(); return _handle; } }
 
     public bool InspectorBridgeRunning { get { ThrowIfDisposed(); return Native.gua_runtime_inspector_bridge_running(_handle) != 0; } }
     public string InspectorBridgeUrl { get { ThrowIfDisposed(); return ReadUtf8(Native.gua_runtime_inspector_bridge_url(_handle)); } }

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntime.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntime.cs
@@ -54,6 +54,8 @@ public sealed class GuaRuntime : IDisposable
     }
 
     public void SetGodotPluginVersion(string version) { ThrowIfDisposed(); Native.gua_runtime_set_godot_plugin_version(_handle, version ?? string.Empty); }
+    /// <summary>Advertises virtual_clock_v1 after an adapter has installed an unscaled clock pump.</summary>
+    public void EnableVirtualClockAdapter() { ThrowIfDisposed(); Native.gua_runtime_set_virtual_clock_enabled(_handle, 1); }
     public bool EnqueueClick(string id) { ThrowIfDisposed(); return Native.gua_runtime_enqueue_click(_handle, id) != 0; }
     public bool ConsumeClickRequest(string id) { ThrowIfDisposed(); return Native.gua_runtime_consume_click_request(_handle, id) != 0; }
     public bool EmitClick(string id) { ThrowIfDisposed(); return Native.gua_runtime_emit_click(_handle, id) != 0; }

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -26,7 +26,8 @@ public sealed class GuaRuntimeClock
     {
         if (callback is null) throw new ArgumentNullException(nameof(callback));
         if (delay < TimeSpan.Zero || interval is { } repeat && repeat <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
-        var item = new Scheduled(++sequence, Status.NowMilliseconds + delay.TotalMilliseconds, interval?.TotalMilliseconds, callback); scheduled.Add(item); return new Cancel(item);
+        var status = Status;
+        var item = new Scheduled(++sequence, status.Generation, status.NowMilliseconds + delay.TotalMilliseconds, interval?.TotalMilliseconds, callback); scheduled.Add(item); return new Cancel(item);
     }
     public void Drain()
     {
@@ -34,6 +35,7 @@ public sealed class GuaRuntimeClock
         var step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
         while (Native.gua_runtime_clock_consume_step(runtime.Handle, ref step) != 0)
         {
+            scheduled.RemoveAll(x => x.Generation != step.Generation);
             var now = Status.NowMilliseconds;
             while (scheduled.Where(x => !x.Cancelled && x.Due <= now).OrderBy(x => x.Due).ThenBy(x => x.Sequence).FirstOrDefault() is { } item)
             { if (++callbackCount > 1_000_000) throw new InvalidOperationException("Gua clock execution_limit.");
@@ -43,7 +45,7 @@ public sealed class GuaRuntimeClock
         }
     }
     private static void Check(int result) { if (result != 1) throw new InvalidOperationException($"Gua clock operation failed: {(GuaClockResult)result}."); }
-    private sealed class Scheduled(long sequence, double due, double? interval, Action callback)
-    { public long Sequence { get; } = sequence; public double Due { get; set; } = due; public double? Interval { get; } = interval; public Action Callback { get; } = callback; public bool Cancelled { get; set; } }
+    private sealed class Scheduled(long sequence, ulong generation, double due, double? interval, Action callback)
+    { public long Sequence { get; } = sequence; public ulong Generation { get; } = generation; public double Due { get; set; } = due; public double? Interval { get; } = interval; public Action Callback { get; } = callback; public bool Cancelled { get; set; } }
     private sealed class Cancel(Scheduled item) : IDisposable { public void Dispose() => item.Cancelled = true; }
 }

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -23,7 +23,15 @@ public sealed class GuaRuntimeClock
     { Check(Native.gua_runtime_clock_run_for(runtime.Handle, duration.TotalMilliseconds, (step ?? TimeSpan.FromMilliseconds(Status.DefaultStepMilliseconds)).TotalMilliseconds)); Drain(); }
     public void Advance(TimeSpan unscaledDelta)
     { var status = Status; PurgeInactive(status); if (!status.Installed) return; if (status.PendingMilliseconds > 0) { Drain(); return; }
-      if (status.Paused || unscaledDelta <= TimeSpan.Zero) return; Check(Native.gua_runtime_clock_advance(runtime.Handle, unscaledDelta.TotalMilliseconds)); Drain(); }
+      if (status.Paused || unscaledDelta <= TimeSpan.Zero) return;
+      var result = Native.gua_runtime_clock_advance(runtime.Handle, unscaledDelta.TotalMilliseconds);
+      if (result != (int)GuaClockResult.Ok)
+      {
+          var latest = Status;
+          if ((GuaClockResult)result == GuaClockResult.InvalidState && latest.Installed && latest.Paused) return;
+          Check(result);
+      }
+      Drain(); }
     public IDisposable Schedule(TimeSpan delay, Action callback, TimeSpan? interval = null)
     {
         if (callback is null) throw new ArgumentNullException(nameof(callback));
@@ -55,7 +63,10 @@ public sealed class GuaRuntimeClock
               { item.Cancelled = true; scheduled.RemoveAll(candidate => candidate.Generation != generation); break; }
               if (item.Interval is { } interval && !item.Cancelled) { item.Due += interval; scheduled.Add(item); } else item.Cancelled = true; }
             scheduled.RemoveAll(x => x.Cancelled);
-            Tick?.Invoke(new GuaClockDelta(step.DeltaMs));
+            if (Tick is not null)
+                foreach (Action<GuaClockDelta> handler in Tick.GetInvocationList())
+                    try { handler(new GuaClockDelta(step.DeltaMs)); }
+                    catch (Exception error) { ReportCallbackFailure(error); }
             step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
         }
     }

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -10,7 +10,8 @@ public sealed class GuaRuntimeClock
     private readonly List<Scheduled> scheduled = [];
     private long sequence;
     internal GuaRuntimeClock(GuaRuntime runtime) => this.runtime = runtime;
-    public event Action<TimeSpan>? Tick;
+    public event Action<GuaClockDelta>? Tick;
+    public event Action<Exception>? CallbackFailed;
     public GuaClockStatus Status { get { var value = new Native.ClockStatus { StructSize = (uint)Marshal.SizeOf<Native.ClockStatus>() };
         if (Native.gua_runtime_clock_get_status(runtime.Handle, ref value) == 0) throw new InvalidOperationException("Failed to inspect Gua clock.");
         return new(value.Installed != 0, value.Paused != 0, value.NowMs, value.DefaultStepMs, value.PendingMs, value.Generation); } }
@@ -21,7 +22,7 @@ public sealed class GuaRuntimeClock
     public void RunFor(TimeSpan duration, TimeSpan? step = null)
     { Check(Native.gua_runtime_clock_run_for(runtime.Handle, duration.TotalMilliseconds, (step ?? TimeSpan.FromMilliseconds(Status.DefaultStepMilliseconds)).TotalMilliseconds)); Drain(); }
     public void Advance(TimeSpan unscaledDelta)
-    { var status = Status; if (!status.Installed) return; if (status.PendingMilliseconds > 0) { Drain(); return; }
+    { var status = Status; PurgeInactive(status); if (!status.Installed) return; if (status.PendingMilliseconds > 0) { Drain(); return; }
       if (status.Paused || unscaledDelta <= TimeSpan.Zero) return; Check(Native.gua_runtime_clock_advance(runtime.Handle, unscaledDelta.TotalMilliseconds)); Drain(); }
     public IDisposable Schedule(TimeSpan delay, Action callback, TimeSpan? interval = null)
     {
@@ -31,7 +32,7 @@ public sealed class GuaRuntimeClock
         var bindOnInstall = !status.Installed;
         var item = new Scheduled(++sequence, status.Generation,
             bindOnInstall ? delay.TotalMilliseconds : status.NowMilliseconds + delay.TotalMilliseconds,
-            interval?.TotalMilliseconds, callback, bindOnInstall); scheduled.Add(item); return new Cancel(item);
+            interval?.TotalMilliseconds, callback, bindOnInstall); scheduled.Add(item); return new Cancel(this, item);
     }
     public void Drain()
     {
@@ -46,12 +47,15 @@ public sealed class GuaRuntimeClock
             { if (++callbackCount > CallbackLimit)
               { scheduled.ForEach(candidate => candidate.Cancelled = true); scheduled.Clear();
                 throw new InvalidOperationException("Gua clock execution_limit."); }
-              if (item.Cancelled) continue; scheduled.Remove(item); item.Callback();
+              if (item.Cancelled) continue; scheduled.Remove(item);
+              try { item.Callback?.Invoke(); }
+              catch (Exception error) { ReportCallbackFailure(error); }
               var generation = Status.Generation;
               if (generation != step.Generation)
               { item.Cancelled = true; scheduled.RemoveAll(candidate => candidate.Generation != generation); break; }
               if (item.Interval is { } interval && !item.Cancelled) { item.Due += interval; scheduled.Add(item); } else item.Cancelled = true; }
-            scheduled.RemoveAll(x => x.Cancelled); Tick?.Invoke(TimeSpan.FromMilliseconds(step.DeltaMs));
+            scheduled.RemoveAll(x => x.Cancelled);
+            Tick?.Invoke(new GuaClockDelta(step.DeltaMs));
             step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
         }
     }
@@ -67,8 +71,28 @@ public sealed class GuaRuntimeClock
             item.BindOnInstall = false;
         }
     }
+    private void PurgeInactive(GuaClockStatus status)
+    {
+        scheduled.RemoveAll(item => item.Cancelled || !status.Installed && item.Generation != status.Generation);
+    }
+    private void CancelSchedule(Scheduled item)
+    {
+        item.Cancelled = true;
+        item.Callback = null;
+        scheduled.Remove(item);
+    }
+    private void ReportCallbackFailure(Exception error)
+    {
+        if (CallbackFailed is null) return;
+        foreach (Action<Exception> handler in CallbackFailed.GetInvocationList())
+        {
+            try { handler(error); }
+            catch { }
+        }
+    }
     private static void Check(int result) { if (result != 1) throw new InvalidOperationException($"Gua clock operation failed: {(GuaClockResult)result}."); }
     private sealed class Scheduled(long sequence, ulong generation, double due, double? interval, Action callback, bool bindOnInstall)
-    { public long Sequence { get; } = sequence; public ulong Generation { get; set; } = generation; public double Due { get; set; } = due; public double? Interval { get; } = interval; public Action Callback { get; } = callback; public bool BindOnInstall { get; set; } = bindOnInstall; public bool Cancelled { get; set; } }
-    private sealed class Cancel(Scheduled item) : IDisposable { public void Dispose() => item.Cancelled = true; }
+    { public long Sequence { get; } = sequence; public ulong Generation { get; set; } = generation; public double Due { get; set; } = due; public double? Interval { get; } = interval; public Action? Callback { get; set; } = callback; public bool BindOnInstall { get; set; } = bindOnInstall; public bool Cancelled { get; set; } }
+    private sealed class Cancel(GuaRuntimeClock owner, Scheduled item) : IDisposable
+    { private GuaRuntimeClock? Owner { get; set; } = owner; public void Dispose() { Owner?.CancelSchedule(item); Owner = null; } }
 }

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -47,12 +47,16 @@ public sealed class GuaRuntimeClock
     public IDisposable Schedule(TimeSpan delay, Action callback, TimeSpan? interval = null)
     {
         if (callback is null) throw new ArgumentNullException(nameof(callback));
-        if (delay < TimeSpan.Zero || interval is { } repeat && repeat <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
+        if (delay < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
+        if (interval is { } repeat && repeat <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(interval));
         var status = Status;
         var bindOnInstall = !status.Installed;
-        var item = new Scheduled(++sequence, status.Generation,
-            bindOnInstall ? delay.TotalMilliseconds : status.NowMilliseconds + delay.TotalMilliseconds,
-            interval?.TotalMilliseconds, callback, bindOnInstall); scheduled.Add(item); return new Cancel(this, item);
+        var delayMs = delay.TotalMilliseconds;
+        var intervalMs = interval?.TotalMilliseconds;
+        var due = bindOnInstall ? delayMs : status.NowMilliseconds + delayMs;
+        if (!bindOnInstall) ValidateRepresentableSchedule(status.NowMilliseconds, delayMs, due, intervalMs);
+        var item = new Scheduled(++sequence, status.Generation, due,
+            intervalMs, callback, bindOnInstall); scheduled.Add(item); return new Cancel(this, item);
     }
     public void Drain()
     {
@@ -77,7 +81,17 @@ public sealed class GuaRuntimeClock
               var generation = Status.Generation;
               if (generation != step.Generation)
               { item.Cancelled = true; scheduled.RemoveAll(candidate => candidate.Generation != generation); break; }
-              if (item.Interval is { } interval && !item.Cancelled) { item.Due += interval; scheduled.Add(item); } else item.Cancelled = true; }
+              if (item.Interval is { } interval && !item.Cancelled)
+              {
+                  var nextDue = item.Due + interval;
+                  if (double.IsFinite(nextDue) && nextDue > item.Due) { item.Due = nextDue; scheduled.Add(item); }
+                  else
+                  {
+                      item.Cancelled = true;
+                      ReportCallbackFailure(new InvalidOperationException("Gua clock interval cannot advance its representable deadline."));
+                  }
+              }
+              else item.Cancelled = true; }
             scheduled.RemoveAll(x => x.Cancelled);
             if (Status.Generation != step.Generation)
             {
@@ -98,10 +112,18 @@ public sealed class GuaRuntimeClock
         var status = Status;
         if (!status.Installed) return;
         scheduled.RemoveAll(item => item.BindOnInstall && status.Generation != item.Generation + 1);
-        foreach (var item in scheduled.Where(item => item.BindOnInstall))
+        foreach (var item in scheduled.Where(item => item.BindOnInstall).ToArray())
         {
+            var due = status.NowMilliseconds + item.Due;
+            try { ValidateRepresentableSchedule(status.NowMilliseconds, item.Due, due, item.Interval); }
+            catch (ArgumentOutOfRangeException error)
+            {
+                CancelSchedule(item);
+                ReportCallbackFailure(error);
+                continue;
+            }
             item.Generation = status.Generation;
-            item.Due = status.NowMilliseconds + item.Due;
+            item.Due = due;
             item.BindOnInstall = false;
         }
     }
@@ -122,6 +144,17 @@ public sealed class GuaRuntimeClock
         {
             try { handler(error); }
             catch { }
+        }
+    }
+    private static void ValidateRepresentableSchedule(double now, double delay, double due, double? interval)
+    {
+        if (!double.IsFinite(due) || delay > 0 && due <= now)
+            throw new ArgumentOutOfRangeException(nameof(delay), "The delay cannot advance the current Gua clock timeline.");
+        if (interval is { } repeat)
+        {
+            var nextDue = due + repeat;
+            if (!double.IsFinite(nextDue) || nextDue <= due)
+                throw new ArgumentOutOfRangeException(nameof(interval), "The interval cannot advance its representable Gua clock deadline.");
         }
     }
     private static void Check(int result) { if (result != 1) throw new InvalidOperationException($"Gua clock operation failed: {(GuaClockResult)result}."); }

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -47,6 +47,9 @@ public sealed class GuaRuntimeClock
               { scheduled.ForEach(candidate => candidate.Cancelled = true); scheduled.Clear();
                 throw new InvalidOperationException("Gua clock execution_limit."); }
               if (item.Cancelled) continue; scheduled.Remove(item); item.Callback();
+              var generation = Status.Generation;
+              if (generation != step.Generation)
+              { item.Cancelled = true; scheduled.RemoveAll(candidate => candidate.Generation != generation); break; }
               if (item.Interval is { } interval && !item.Cancelled) { item.Due += interval; scheduled.Add(item); } else item.Cancelled = true; }
             scheduled.RemoveAll(x => x.Cancelled); Tick?.Invoke(TimeSpan.FromMilliseconds(step.DeltaMs));
             step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -39,7 +39,8 @@ public sealed class GuaRuntimeClock
             var now = Status.NowMilliseconds;
             while (scheduled.Where(x => !x.Cancelled && x.Due <= now).OrderBy(x => x.Due).ThenBy(x => x.Sequence).FirstOrDefault() is { } item)
             { if (++callbackCount > 1_000_000) throw new InvalidOperationException("Gua clock execution_limit.");
-              if (item.Cancelled) continue; item.Callback(); if (item.Interval is { } interval) item.Due += interval; else item.Cancelled = true; }
+              if (item.Cancelled) continue; scheduled.Remove(item); item.Callback();
+              if (item.Interval is { } interval && !item.Cancelled) { item.Due += interval; scheduled.Add(item); } else item.Cancelled = true; }
             scheduled.RemoveAll(x => x.Cancelled); Tick?.Invoke(TimeSpan.FromMilliseconds(step.DeltaMs));
             step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
         }

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -24,10 +24,13 @@ public sealed class GuaRuntimeClock
     public void RunFor(TimeSpan duration, TimeSpan? step = null)
     { Check(Native.gua_runtime_clock_run_for(runtime.Handle, duration.TotalMilliseconds,
         step?.TotalMilliseconds ?? Status.DefaultStepMilliseconds)); Drain(); }
-    public void Advance(TimeSpan unscaledDelta)
-    { var status = Status; PurgeInactive(status); if (!status.Installed) { reportedAutomaticExecutionLimitGeneration = null; return; } if (status.PendingMilliseconds > 0) { Drain(); return; }
-      if (status.Paused || unscaledDelta <= TimeSpan.Zero) { reportedAutomaticExecutionLimitGeneration = null; return; }
-      var result = Native.gua_runtime_clock_advance(runtime.Handle, unscaledDelta.TotalMilliseconds);
+    public void Advance(TimeSpan unscaledDelta) => AdvanceMilliseconds(unscaledDelta.TotalMilliseconds);
+    public void AdvanceMilliseconds(double unscaledDeltaMilliseconds)
+    { if (!double.IsFinite(unscaledDeltaMilliseconds) || unscaledDeltaMilliseconds < 0)
+          throw new ArgumentOutOfRangeException(nameof(unscaledDeltaMilliseconds));
+      var status = Status; PurgeInactive(status); if (!status.Installed) { reportedAutomaticExecutionLimitGeneration = null; return; } if (status.PendingMilliseconds > 0) { Drain(); return; }
+      if (status.Paused || unscaledDeltaMilliseconds <= 0) { reportedAutomaticExecutionLimitGeneration = null; return; }
+      var result = Native.gua_runtime_clock_advance(runtime.Handle, unscaledDeltaMilliseconds);
       if (result != (int)GuaClockResult.Ok)
       {
           var latest = Status;

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -10,6 +10,7 @@ public sealed class GuaRuntimeClock
     private readonly List<Scheduled> scheduled = [];
     private long sequence;
     private bool draining;
+    private ulong? reportedAutomaticExecutionLimitGeneration;
     internal GuaRuntimeClock(GuaRuntime runtime) => this.runtime = runtime;
     public event Action<GuaClockDelta>? Tick;
     public event Action<Exception>? CallbackFailed;
@@ -23,15 +24,25 @@ public sealed class GuaRuntimeClock
     public void RunFor(TimeSpan duration, TimeSpan? step = null)
     { Check(Native.gua_runtime_clock_run_for(runtime.Handle, duration.TotalMilliseconds, (step ?? TimeSpan.FromMilliseconds(Status.DefaultStepMilliseconds)).TotalMilliseconds)); Drain(); }
     public void Advance(TimeSpan unscaledDelta)
-    { var status = Status; PurgeInactive(status); if (!status.Installed) return; if (status.PendingMilliseconds > 0) { Drain(); return; }
-      if (status.Paused || unscaledDelta <= TimeSpan.Zero) return;
+    { var status = Status; PurgeInactive(status); if (!status.Installed) { reportedAutomaticExecutionLimitGeneration = null; return; } if (status.PendingMilliseconds > 0) { Drain(); return; }
+      if (status.Paused || unscaledDelta <= TimeSpan.Zero) { reportedAutomaticExecutionLimitGeneration = null; return; }
       var result = Native.gua_runtime_clock_advance(runtime.Handle, unscaledDelta.TotalMilliseconds);
       if (result != (int)GuaClockResult.Ok)
       {
           var latest = Status;
           if ((GuaClockResult)result == GuaClockResult.InvalidState && latest.Installed && latest.Paused) return;
+          if ((GuaClockResult)result == GuaClockResult.ExecutionLimit)
+          {
+              if (reportedAutomaticExecutionLimitGeneration != latest.Generation)
+              {
+                  reportedAutomaticExecutionLimitGeneration = latest.Generation;
+                  ReportCallbackFailure(new InvalidOperationException("Gua clock automatic advance exceeded execution_limit; the host frame will continue without advancing the clock."));
+              }
+              return;
+          }
           Check(result);
       }
+      reportedAutomaticExecutionLimitGeneration = null;
       Drain(); }
     public IDisposable Schedule(TimeSpan delay, Action callback, TimeSpan? interval = null)
     {

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -100,8 +100,11 @@ public sealed class GuaRuntimeClock
             }
             if (Tick is not null)
                 foreach (Action<GuaClockDelta> handler in Tick.GetInvocationList())
+                {
                     try { handler(new GuaClockDelta(step.DeltaMs)); }
                     catch (Exception error) { ReportCallbackFailure(error); }
+                    if (Status.Generation != step.Generation) break;
+                }
             step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
         }
         }

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -9,6 +9,7 @@ public sealed class GuaRuntimeClock
     private readonly GuaRuntime runtime;
     private readonly List<Scheduled> scheduled = [];
     private long sequence;
+    private bool draining;
     internal GuaRuntimeClock(GuaRuntime runtime) => this.runtime = runtime;
     public event Action<GuaClockDelta>? Tick;
     public event Action<Exception>? CallbackFailed;
@@ -44,6 +45,10 @@ public sealed class GuaRuntimeClock
     }
     public void Drain()
     {
+        if (draining) return;
+        draining = true;
+        try
+        {
         BindPendingSchedules();
         var callbackCount = 0;
         var step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
@@ -63,12 +68,19 @@ public sealed class GuaRuntimeClock
               { item.Cancelled = true; scheduled.RemoveAll(candidate => candidate.Generation != generation); break; }
               if (item.Interval is { } interval && !item.Cancelled) { item.Due += interval; scheduled.Add(item); } else item.Cancelled = true; }
             scheduled.RemoveAll(x => x.Cancelled);
+            if (Status.Generation != step.Generation)
+            {
+                step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
+                continue;
+            }
             if (Tick is not null)
                 foreach (Action<GuaClockDelta> handler in Tick.GetInvocationList())
                     try { handler(new GuaClockDelta(step.DeltaMs)); }
                     catch (Exception error) { ReportCallbackFailure(error); }
             step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
         }
+        }
+        finally { draining = false; }
     }
     private void BindPendingSchedules()
     {

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -5,6 +5,7 @@ namespace Gua.Runtime;
 
 public sealed class GuaRuntimeClock
 {
+    private const int CallbackLimit = 1_000_000;
     private readonly GuaRuntime runtime;
     private readonly List<Scheduled> scheduled = [];
     private long sequence;
@@ -42,7 +43,9 @@ public sealed class GuaRuntimeClock
             scheduled.RemoveAll(x => x.Generation != step.Generation);
             var now = Status.NowMilliseconds;
             while (scheduled.Where(x => !x.Cancelled && x.Due <= now).OrderBy(x => x.Due).ThenBy(x => x.Sequence).FirstOrDefault() is { } item)
-            { if (++callbackCount > 1_000_000) throw new InvalidOperationException("Gua clock execution_limit.");
+            { if (++callbackCount > CallbackLimit)
+              { scheduled.ForEach(candidate => candidate.Cancelled = true); scheduled.Clear();
+                throw new InvalidOperationException("Gua clock execution_limit."); }
               if (item.Cancelled) continue; scheduled.Remove(item); item.Callback();
               if (item.Interval is { } interval && !item.Cancelled) { item.Due += interval; scheduled.Add(item); } else item.Cancelled = true; }
             scheduled.RemoveAll(x => x.Cancelled); Tick?.Invoke(TimeSpan.FromMilliseconds(step.DeltaMs));

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -27,10 +27,14 @@ public sealed class GuaRuntimeClock
         if (callback is null) throw new ArgumentNullException(nameof(callback));
         if (delay < TimeSpan.Zero || interval is { } repeat && repeat <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
         var status = Status;
-        var item = new Scheduled(++sequence, status.Generation, status.NowMilliseconds + delay.TotalMilliseconds, interval?.TotalMilliseconds, callback); scheduled.Add(item); return new Cancel(item);
+        var bindOnInstall = !status.Installed;
+        var item = new Scheduled(++sequence, status.Generation,
+            bindOnInstall ? delay.TotalMilliseconds : status.NowMilliseconds + delay.TotalMilliseconds,
+            interval?.TotalMilliseconds, callback, bindOnInstall); scheduled.Add(item); return new Cancel(item);
     }
     public void Drain()
     {
+        BindPendingSchedules();
         var callbackCount = 0;
         var step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
         while (Native.gua_runtime_clock_consume_step(runtime.Handle, ref step) != 0)
@@ -45,8 +49,20 @@ public sealed class GuaRuntimeClock
             step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
         }
     }
+    private void BindPendingSchedules()
+    {
+        var status = Status;
+        if (!status.Installed) return;
+        scheduled.RemoveAll(item => item.BindOnInstall && status.Generation != item.Generation + 1);
+        foreach (var item in scheduled.Where(item => item.BindOnInstall))
+        {
+            item.Generation = status.Generation;
+            item.Due = status.NowMilliseconds + item.Due;
+            item.BindOnInstall = false;
+        }
+    }
     private static void Check(int result) { if (result != 1) throw new InvalidOperationException($"Gua clock operation failed: {(GuaClockResult)result}."); }
-    private sealed class Scheduled(long sequence, ulong generation, double due, double? interval, Action callback)
-    { public long Sequence { get; } = sequence; public ulong Generation { get; } = generation; public double Due { get; set; } = due; public double? Interval { get; } = interval; public Action Callback { get; } = callback; public bool Cancelled { get; set; } }
+    private sealed class Scheduled(long sequence, ulong generation, double due, double? interval, Action callback, bool bindOnInstall)
+    { public long Sequence { get; } = sequence; public ulong Generation { get; set; } = generation; public double Due { get; set; } = due; public double? Interval { get; } = interval; public Action Callback { get; } = callback; public bool BindOnInstall { get; set; } = bindOnInstall; public bool Cancelled { get; set; } }
     private sealed class Cancel(Scheduled item) : IDisposable { public void Dispose() => item.Cancelled = true; }
 }

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -1,0 +1,49 @@
+using System.Runtime.InteropServices;
+using Gua.Core;
+
+namespace Gua.Runtime;
+
+public sealed class GuaRuntimeClock
+{
+    private readonly GuaRuntime runtime;
+    private readonly List<Scheduled> scheduled = [];
+    private long sequence;
+    internal GuaRuntimeClock(GuaRuntime runtime) => this.runtime = runtime;
+    public event Action<TimeSpan>? Tick;
+    public GuaClockStatus Status { get { var value = new Native.ClockStatus { StructSize = (uint)Marshal.SizeOf<Native.ClockStatus>() };
+        if (Native.gua_runtime_clock_get_status(runtime.Handle, ref value) == 0) throw new InvalidOperationException("Failed to inspect Gua clock.");
+        return new(value.Installed != 0, value.Paused != 0, value.NowMs, value.DefaultStepMs, value.PendingMs, value.Generation); } }
+    public void Install(TimeSpan? initialTime = null, TimeSpan? step = null) => Check(Native.gua_runtime_clock_install(runtime.Handle,
+        (initialTime ?? TimeSpan.Zero).TotalMilliseconds, (step ?? TimeSpan.FromSeconds(1.0 / 60.0)).TotalMilliseconds));
+    public void Pause() => Check(Native.gua_runtime_clock_pause(runtime.Handle));
+    public void Resume() => Check(Native.gua_runtime_clock_resume(runtime.Handle));
+    public void RunFor(TimeSpan duration, TimeSpan? step = null)
+    { Check(Native.gua_runtime_clock_run_for(runtime.Handle, duration.TotalMilliseconds, (step ?? TimeSpan.FromMilliseconds(Status.DefaultStepMilliseconds)).TotalMilliseconds)); Drain(); }
+    public void Advance(TimeSpan unscaledDelta)
+    { var status = Status; if (!status.Installed) return; if (status.PendingMilliseconds > 0) { Drain(); return; }
+      if (status.Paused || unscaledDelta <= TimeSpan.Zero) return; Check(Native.gua_runtime_clock_advance(runtime.Handle, unscaledDelta.TotalMilliseconds)); Drain(); }
+    public IDisposable Schedule(TimeSpan delay, Action callback, TimeSpan? interval = null)
+    {
+        if (callback is null) throw new ArgumentNullException(nameof(callback));
+        if (delay < TimeSpan.Zero || interval is { } repeat && repeat <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
+        var item = new Scheduled(++sequence, Status.NowMilliseconds + delay.TotalMilliseconds, interval?.TotalMilliseconds, callback); scheduled.Add(item); return new Cancel(item);
+    }
+    public void Drain()
+    {
+        var callbackCount = 0;
+        var step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
+        while (Native.gua_runtime_clock_consume_step(runtime.Handle, ref step) != 0)
+        {
+            var now = Status.NowMilliseconds;
+            while (scheduled.Where(x => !x.Cancelled && x.Due <= now).OrderBy(x => x.Due).ThenBy(x => x.Sequence).FirstOrDefault() is { } item)
+            { if (++callbackCount > 1_000_000) throw new InvalidOperationException("Gua clock execution_limit.");
+              if (item.Cancelled) continue; item.Callback(); if (item.Interval is { } interval) item.Due += interval; else item.Cancelled = true; }
+            scheduled.RemoveAll(x => x.Cancelled); Tick?.Invoke(TimeSpan.FromMilliseconds(step.DeltaMs));
+            step = new Native.ClockStep { StructSize = (uint)Marshal.SizeOf<Native.ClockStep>() };
+        }
+    }
+    private static void Check(int result) { if (result != 1) throw new InvalidOperationException($"Gua clock operation failed: {(GuaClockResult)result}."); }
+    private sealed class Scheduled(long sequence, double due, double? interval, Action callback)
+    { public long Sequence { get; } = sequence; public double Due { get; set; } = due; public double? Interval { get; } = interval; public Action Callback { get; } = callback; public bool Cancelled { get; set; } }
+    private sealed class Cancel(Scheduled item) : IDisposable { public void Dispose() => item.Cancelled = true; }
+}

--- a/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaRuntimeClock.cs
@@ -18,11 +18,12 @@ public sealed class GuaRuntimeClock
         if (Native.gua_runtime_clock_get_status(runtime.Handle, ref value) == 0) throw new InvalidOperationException("Failed to inspect Gua clock.");
         return new(value.Installed != 0, value.Paused != 0, value.NowMs, value.DefaultStepMs, value.PendingMs, value.Generation); } }
     public void Install(TimeSpan? initialTime = null, TimeSpan? step = null) => Check(Native.gua_runtime_clock_install(runtime.Handle,
-        (initialTime ?? TimeSpan.Zero).TotalMilliseconds, (step ?? TimeSpan.FromSeconds(1.0 / 60.0)).TotalMilliseconds));
+        initialTime?.TotalMilliseconds ?? 0.0, step?.TotalMilliseconds ?? 1000.0 / 60.0));
     public void Pause() => Check(Native.gua_runtime_clock_pause(runtime.Handle));
     public void Resume() => Check(Native.gua_runtime_clock_resume(runtime.Handle));
     public void RunFor(TimeSpan duration, TimeSpan? step = null)
-    { Check(Native.gua_runtime_clock_run_for(runtime.Handle, duration.TotalMilliseconds, (step ?? TimeSpan.FromMilliseconds(Status.DefaultStepMilliseconds)).TotalMilliseconds)); Drain(); }
+    { Check(Native.gua_runtime_clock_run_for(runtime.Handle, duration.TotalMilliseconds,
+        step?.TotalMilliseconds ?? Status.DefaultStepMilliseconds)); Drain(); }
     public void Advance(TimeSpan unscaledDelta)
     { var status = Status; PurgeInactive(status); if (!status.Installed) { reportedAutomaticExecutionLimitGeneration = null; return; } if (status.PendingMilliseconds > 0) { Drain(); return; }
       if (status.Paused || unscaledDelta <= TimeSpan.Zero) { reportedAutomaticExecutionLimitGeneration = null; return; }

--- a/bindings/dotnet/src/Gua.Runtime/Native.cs
+++ b/bindings/dotnet/src/Gua.Runtime/Native.cs
@@ -12,6 +12,8 @@ internal static unsafe class Native
     [StructLayout(LayoutKind.Sequential)] internal struct ActionResult { internal uint StructSize; internal ulong RequestId; internal int Action, Status, ErrorCode; internal nint NodeId, Value; internal int Sensitive; }
     [StructLayout(LayoutKind.Sequential)] internal struct ScreenshotRequest { internal uint StructSize; internal ulong RequestId, SessionEpoch, AfterFrameSequence; }
     [StructLayout(LayoutKind.Sequential)] internal unsafe struct LegacyEvent { internal int Type; internal fixed byte NodeId[128]; }
+    [StructLayout(LayoutKind.Sequential)] internal struct ClockStatus { internal uint StructSize; internal int Installed, Paused; internal double NowMs, DefaultStepMs, PendingMs; internal ulong Generation; }
+    [StructLayout(LayoutKind.Sequential)] internal struct ClockStep { internal uint StructSize; internal double DeltaMs; internal int FinalStep; internal ulong Generation; }
 
 #if !NETSTANDARD2_1
     static Native() => NativeLibrary.SetDllImportResolver(typeof(Native).Assembly, Resolve);
@@ -49,6 +51,13 @@ internal static unsafe class Native
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern void gua_runtime_add_log(nint runtime, int level, [MarshalAs(UnmanagedType.LPUTF8Str)] string message);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern unsafe int gua_runtime_copy_ui_tree_json(nint runtime, byte* output, int size);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern unsafe int gua_runtime_copy_version_json(nint runtime, byte* output, int size);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_clock_install(nint runtime, double initialTimeMs, double stepMs);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_clock_pause(nint runtime);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_clock_run_for(nint runtime, double durationMs, double stepMs);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_clock_advance(nint runtime, double durationMs);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_clock_resume(nint runtime);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_clock_get_status(nint runtime, ref ClockStatus status);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_clock_consume_step(nint runtime, ref ClockStep step);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern void gua_runtime_set_adapter_version(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string adapter, [MarshalAs(UnmanagedType.LPUTF8Str)] string version);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern void gua_runtime_set_godot_plugin_version(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string version);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_enqueue_click(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string id);

--- a/bindings/dotnet/src/Gua.Runtime/Native.cs
+++ b/bindings/dotnet/src/Gua.Runtime/Native.cs
@@ -60,6 +60,7 @@ internal static unsafe class Native
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_clock_consume_step(nint runtime, ref ClockStep step);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern void gua_runtime_set_adapter_version(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string adapter, [MarshalAs(UnmanagedType.LPUTF8Str)] string version);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern void gua_runtime_set_godot_plugin_version(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string version);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern void gua_runtime_set_virtual_clock_enabled(nint runtime, int enabled);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_enqueue_click(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string id);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_consume_click_request(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string id);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_emit_click(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string id);

--- a/bindings/dotnet/src/Gua.Runtime/README.md
+++ b/bindings/dotnet/src/Gua.Runtime/README.md
@@ -7,7 +7,10 @@ WebSocket bridge without duplicating P/Invoke declarations.
 
 `GuaRuntime.Clock` is the adapter-side clock pump. Adapters call
 `Advance(unscaledDelta)` from their always-running update, while game code uses
-`Schedule` and `Tick` for deterministic pause/run-for behavior.
+`Schedule` and `Tick` for deterministic pause/run-for behavior. Installing the
+clock does not intercept `Time.deltaTime`, coroutines, or engine timers; each
+game subsystem that should be controllable must explicitly use this clock as
+its time source.
 
 The native `gua_runtime` library must be deployed for the current platform.
 

--- a/bindings/dotnet/src/Gua.Runtime/README.md
+++ b/bindings/dotnet/src/Gua.Runtime/README.md
@@ -6,15 +6,19 @@ complete screenshot requests, expose adapter versions, and run the Inspector
 WebSocket bridge without duplicating P/Invoke declarations.
 
 `GuaRuntime.Clock` is the adapter-side clock pump. Adapters call
-`Advance(unscaledDelta)` from their always-running update, while game code uses
-`Schedule` and `Tick` for deterministic pause/run-for behavior. Installing the
+`AdvanceMilliseconds(unscaledDeltaMs)` when their engine exposes elapsed time
+as a floating-point value, or `Advance(unscaledDelta)` when a `TimeSpan` is
+already available. Game code uses `Schedule` and `Tick` for deterministic
+pause/run-for behavior. Installing the
 clock does not intercept `Time.deltaTime`, coroutines, or engine timers; each
 game subsystem that should be controllable must explicitly use this clock as
 its time source.
 
 `Tick` receives `GuaClockDelta`, which retains the native double-precision
 millisecond value even below `TimeSpan`'s 100 ns resolution. It exposes
-`TotalMilliseconds`, `TotalSeconds`, and a rounded `TimeSpan` conversion.
+`TotalMilliseconds`, `TotalSeconds`, and an explicitly fallible `TimeSpan`
+projection. Clock status likewise keeps `NowMilliseconds` as the authoritative
+protocol value; `Now` is null when that value exceeds `TimeSpan`'s range.
 Adapter callback failures are reported by `CallbackFailed` after the scheduler
 isolates the failure and continues the remaining due callbacks and tick
 notification.

--- a/bindings/dotnet/src/Gua.Runtime/README.md
+++ b/bindings/dotnet/src/Gua.Runtime/README.md
@@ -12,6 +12,13 @@ clock does not intercept `Time.deltaTime`, coroutines, or engine timers; each
 game subsystem that should be controllable must explicitly use this clock as
 its time source.
 
+`Tick` receives `GuaClockDelta`, which retains the native double-precision
+millisecond value even below `TimeSpan`'s 100 ns resolution. It exposes
+`TotalMilliseconds`, `TotalSeconds`, and a rounded `TimeSpan` conversion.
+Adapter callback failures are reported by `CallbackFailed` after the scheduler
+isolates the failure and continues the remaining due callbacks and tick
+notification.
+
 The native `gua_runtime` library must be deployed for the current platform.
 
 Screenshot adapters should use `TryCompleteScreenshot`. It returns `false`

--- a/bindings/dotnet/src/Gua.Runtime/README.md
+++ b/bindings/dotnet/src/Gua.Runtime/README.md
@@ -5,6 +5,10 @@ ABI. Engine adapters use it to publish semantic frames, consume actions,
 complete screenshot requests, expose adapter versions, and run the Inspector
 WebSocket bridge without duplicating P/Invoke declarations.
 
+`GuaRuntime.Clock` is the adapter-side clock pump. Adapters call
+`Advance(unscaledDelta)` from their always-running update, while game code uses
+`Schedule` and `Tick` for deterministic pause/run-for behavior.
+
 The native `gua_runtime` library must be deployed for the current platform.
 
 Screenshot adapters should use `TryCompleteScreenshot`. It returns `false`

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -7,6 +7,7 @@ namespace Gua.Testing.Godot;
 
 public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncClockContext, IDisposable
 {
+    private static readonly TimeSpan MinimumClockPauseResponseTimeout = TimeSpan.FromSeconds(11);
     private readonly Uri _bridgeUri;
     private readonly TimeSpan _requestTimeout;
     private readonly SemaphoreSlim _requestGate = new(1, 1);
@@ -59,13 +60,13 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
 
     public GuaClockResult PauseClock()
     {
-        Request<RemoteClockStatus>(new { type = "clock_pause" });
+        Request<RemoteClockStatus>(new { type = "clock_pause" }, responseTimeout: ClockPauseResponseTimeout);
         return GuaClockResult.Ok;
     }
 
     public async Task<GuaClockResult> PauseClockAsync(CancellationToken cancellationToken = default)
     {
-        await RequestAsync<RemoteClockStatus>(new { type = "clock_pause" }, cancellationToken).ConfigureAwait(false);
+        await RequestAsync<RemoteClockStatus>(new { type = "clock_pause" }, cancellationToken, responseTimeout: ClockPauseResponseTimeout).ConfigureAwait(false);
         return GuaClockResult.Ok;
     }
 
@@ -423,7 +424,9 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
         return Request<GuaRemoteUiTree>(new { type = "get_ui_tree" });
     }
 
-    private T Request<T>(object command, bool allowNullResult = false)
+    private TimeSpan ClockPauseResponseTimeout => _requestTimeout > MinimumClockPauseResponseTimeout ? _requestTimeout : MinimumClockPauseResponseTimeout;
+
+    private T Request<T>(object command, bool allowNullResult = false, TimeSpan? responseTimeout = null)
     {
         _requestGate.Wait();
         try
@@ -447,7 +450,7 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
             Send(output.ToArray());
             while (true)
             {
-                var responseJson = ReceiveString();
+                var responseJson = ReceiveString(responseTimeout);
                 using var response = JsonDocument.Parse(responseJson);
                 if (!response.RootElement.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id)
                 {
@@ -471,7 +474,7 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
         finally { _requestGate.Release(); }
     }
 
-    private async Task<T> RequestAsync<T>(object command, CancellationToken cancellationToken, bool allowNullResult = false)
+    private async Task<T> RequestAsync<T>(object command, CancellationToken cancellationToken, bool allowNullResult = false, TimeSpan? responseTimeout = null)
     {
         await _requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -487,7 +490,7 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
             }
             while (true)
             {
-                var responseJson = await ReceiveStringAsync(cancellationToken).ConfigureAwait(false);
+                var responseJson = await ReceiveStringAsync(cancellationToken, responseTimeout).ConfigureAwait(false);
                 using var response = JsonDocument.Parse(responseJson);
                 if (!response.RootElement.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
                 if (!response.RootElement.GetProperty("ok").GetBoolean())
@@ -526,10 +529,10 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
         catch { _socket.Dispose(); _socket = null; throw; }
     }
 
-    private async Task<string> ReceiveStringAsync(CancellationToken cancellationToken)
+    private async Task<string> ReceiveStringAsync(CancellationToken cancellationToken, TimeSpan? responseTimeout = null)
     {
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeout.CancelAfter(_requestTimeout);
+        timeout.CancelAfter(responseTimeout ?? _requestTimeout);
         var buffer = new byte[65536];
         using var stream = new MemoryStream();
         while (true)

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -59,14 +59,15 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
     public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
     {
         var clock = Request<RemoteClockStatus>(ClockCommand("clock_run_for", "durationMs", duration.TotalMilliseconds, step));
-        if (clock.CompletionSessionEpoch is not { } completionEpoch || clock.CompletionAfterFrameSequence is not { } completionFrame)
+        if (clock.CompletionSessionEpoch is not { } completionEpoch || clock.CompletionAfterFrameSequence is not { } completionFrame ||
+            clock.OperationSequence is not { } operationSequence)
             throw new NotSupportedException("The connected runtime does not provide correlated clock completion.");
         var deadline = DateTime.UtcNow + _requestTimeout;
         while (DateTime.UtcNow < deadline)
         {
             var context = GetContextStatus();
             if (context.SessionEpoch != completionEpoch) throw new InvalidOperationException("stale_session");
-            if (clock.PendingMs <= 0 && context.FrameSequence > completionFrame) return GuaClockResult.Ok;
+            if (clock.CompletedOperationSequence >= operationSequence && context.FrameSequence > completionFrame) return GuaClockResult.Ok;
             Thread.Sleep(5);
             clock = Request<RemoteClockStatus>(new { type = "get_clock" });
         }
@@ -76,7 +77,8 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
     public async Task<GuaClockResult> RunClockForAsync(TimeSpan duration, TimeSpan? step = null, CancellationToken cancellationToken = default)
     {
         var clock = await RequestAsync<RemoteClockStatus>(ClockCommand("clock_run_for", "durationMs", duration.TotalMilliseconds, step), cancellationToken).ConfigureAwait(false);
-        if (clock.CompletionSessionEpoch is not { } completionEpoch || clock.CompletionAfterFrameSequence is not { } completionFrame)
+        if (clock.CompletionSessionEpoch is not { } completionEpoch || clock.CompletionAfterFrameSequence is not { } completionFrame ||
+            clock.OperationSequence is not { } operationSequence)
             throw new NotSupportedException("The connected runtime does not provide correlated clock completion.");
         var deadline = DateTime.UtcNow + _requestTimeout;
         while (DateTime.UtcNow < deadline)
@@ -84,7 +86,7 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
             cancellationToken.ThrowIfCancellationRequested();
             var status = await RequestAsync<ContextStatusResult>(new { type = "get_context_status" }, cancellationToken).ConfigureAwait(false);
             if (status.SessionEpoch != completionEpoch) throw new InvalidOperationException("stale_session");
-            if (clock.PendingMs <= 0 && status.FrameSequence > completionFrame) return GuaClockResult.Ok;
+            if (clock.CompletedOperationSequence >= operationSequence && status.FrameSequence > completionFrame) return GuaClockResult.Ok;
             await Task.Delay(5, cancellationToken).ConfigureAwait(false);
             clock = await RequestAsync<RemoteClockStatus>(new { type = "get_clock" }, cancellationToken).ConfigureAwait(false);
         }
@@ -607,6 +609,7 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
 
     private sealed record ActionRequestResult(ulong RequestId);
     private sealed record RemoteClockStatus(bool Installed, string State, double NowMs, double DefaultStepMs, double PendingMs, ulong Generation,
+        ulong CompletedOperationSequence = 0, ulong? OperationSequence = null,
         ulong? CompletionSessionEpoch = null, ulong? CompletionAfterFrameSequence = null);
     private sealed record ActionEventResult(
         ulong RequestId, int Action, bool Succeeded, int Error, string NodeId, string Value, bool Sensitive,

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -5,7 +5,7 @@ using Gua.Core;
 
 namespace Gua.Testing.Godot;
 
-public sealed class GuaRemoteContext : IGuaContext, IDisposable
+public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IDisposable
 {
     private readonly Uri _bridgeUri;
     private readonly TimeSpan _requestTimeout;
@@ -41,6 +41,45 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
     {
         return GuaVersion.Parse(RequestRawResult(new { type = "get_version" }));
     }
+
+    public GuaClockStatus GetClockStatus() => ToClockStatus(Request<RemoteClockStatus>(new { type = "get_clock" }));
+
+    public GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null)
+    {
+        Request<RemoteClockStatus>(new { type = "clock_install", initialTimeMs = (initialTime ?? TimeSpan.Zero).TotalMilliseconds, stepMs = step?.TotalMilliseconds });
+        return GuaClockResult.Ok;
+    }
+
+    public GuaClockResult PauseClock()
+    {
+        Request<RemoteClockStatus>(new { type = "clock_pause" });
+        return GuaClockResult.Ok;
+    }
+
+    public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
+    {
+        var clock = Request<RemoteClockStatus>(new { type = "clock_run_for", durationMs = duration.TotalMilliseconds, stepMs = step?.TotalMilliseconds });
+        var before = GetContextStatus();
+        var deadline = DateTime.UtcNow + _requestTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var context = GetContextStatus();
+            if (context.SessionEpoch != before.SessionEpoch) throw new InvalidOperationException("stale_session");
+            if (clock.PendingMs <= 0 && context.FrameSequence > before.FrameSequence) return GuaClockResult.Ok;
+            Thread.Sleep(5);
+            clock = Request<RemoteClockStatus>(new { type = "get_clock" });
+        }
+        throw new TimeoutException("Timed out waiting for Gua clock run_for host completion.");
+    }
+
+    public GuaClockResult ResumeClock()
+    {
+        Request<RemoteClockStatus>(new { type = "clock_resume" });
+        return GuaClockResult.Ok;
+    }
+
+    private static GuaClockStatus ToClockStatus(RemoteClockStatus value) => new(value.Installed,
+        string.Equals(value.State, "paused", StringComparison.Ordinal), value.NowMs, value.DefaultStepMs, value.PendingMs, value.Generation);
 
     public Task<GuaVersion> GetVersionAsync(CancellationToken cancellationToken = default)
     {
@@ -475,6 +514,7 @@ public sealed class GuaRemoteContext : IGuaContext, IDisposable
     };
 
     private sealed record ActionRequestResult(ulong RequestId);
+    private sealed record RemoteClockStatus(bool Installed, string State, double NowMs, double DefaultStepMs, double PendingMs, ulong Generation);
     private sealed record ActionEventResult(
         ulong RequestId, int Action, bool Succeeded, int Error, string NodeId, string Value, bool Sensitive,
         ulong SessionEpoch, ulong FrameSequence, ulong Revision);

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -9,6 +9,7 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
 {
     private readonly Uri _bridgeUri;
     private readonly TimeSpan _requestTimeout;
+    private readonly SemaphoreSlim _requestGate = new(1, 1);
     private ClientWebSocket? _socket;
     private readonly List<GuaActionEvent> _bufferedActionEvents = new();
     private int _nextId = 1;
@@ -424,69 +425,79 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
 
     private T Request<T>(object command, bool allowNullResult = false)
     {
-        EnsureConnected();
-        var id = _nextId++;
-        var payload = JsonSerializer.Serialize(command, command.GetType());
-        using var document = JsonDocument.Parse(payload);
-        using var output = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(output))
+        _requestGate.Wait();
+        try
         {
-            writer.WriteStartObject();
-            writer.WriteNumber("id", id);
-            foreach (var property in document.RootElement.EnumerateObject())
+            EnsureConnected();
+            var id = _nextId++;
+            var payload = JsonSerializer.Serialize(command, command.GetType());
+            using var document = JsonDocument.Parse(payload);
+            using var output = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(output))
             {
-                property.WriteTo(writer);
+                writer.WriteStartObject();
+                writer.WriteNumber("id", id);
+                foreach (var property in document.RootElement.EnumerateObject())
+                {
+                    property.WriteTo(writer);
+                }
+                writer.WriteEndObject();
             }
-            writer.WriteEndObject();
+
+            Send(output.ToArray());
+            while (true)
+            {
+                var responseJson = ReceiveString();
+                using var response = JsonDocument.Parse(responseJson);
+                if (!response.RootElement.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id)
+                {
+                    continue;
+                }
+
+                if (!response.RootElement.GetProperty("ok").GetBoolean())
+                {
+                    throw new InvalidOperationException(response.RootElement.GetProperty("error").GetString());
+                }
+
+                var result = response.RootElement.GetProperty("result").Deserialize<T>(JsonOptions);
+                if (result is null && !allowNullResult)
+                {
+                    throw new InvalidOperationException("Gua bridge returned an empty result.");
+                }
+
+                return result!;
+            }
         }
-
-        Send(output.ToArray());
-        while (true)
-        {
-            var responseJson = ReceiveString();
-            using var response = JsonDocument.Parse(responseJson);
-            if (!response.RootElement.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id)
-            {
-                continue;
-            }
-
-            if (!response.RootElement.GetProperty("ok").GetBoolean())
-            {
-                throw new InvalidOperationException(response.RootElement.GetProperty("error").GetString());
-            }
-
-            var result = response.RootElement.GetProperty("result").Deserialize<T>(JsonOptions);
-            if (result is null && !allowNullResult)
-            {
-                throw new InvalidOperationException("Gua bridge returned an empty result.");
-            }
-
-            return result!;
-        }
+        finally { _requestGate.Release(); }
     }
 
     private async Task<T> RequestAsync<T>(object command, CancellationToken cancellationToken, bool allowNullResult = false)
     {
-        await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false);
-        var id = _nextId++;
-        var payload = BuildRequestPayload(command, id);
-        using (var sendTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+        await _requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            sendTimeout.CancelAfter(_requestTimeout);
-            var socket = _socket ?? throw new InvalidOperationException("Gua bridge WebSocket is not connected.");
-            await socket.SendAsync(new ArraySegment<byte>(payload), WebSocketMessageType.Text, true, sendTimeout.Token).ConfigureAwait(false);
+            await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false);
+            var id = _nextId++;
+            var payload = BuildRequestPayload(command, id);
+            using (var sendTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            {
+                sendTimeout.CancelAfter(_requestTimeout);
+                var socket = _socket ?? throw new InvalidOperationException("Gua bridge WebSocket is not connected.");
+                await socket.SendAsync(new ArraySegment<byte>(payload), WebSocketMessageType.Text, true, sendTimeout.Token).ConfigureAwait(false);
+            }
+            while (true)
+            {
+                var responseJson = await ReceiveStringAsync(cancellationToken).ConfigureAwait(false);
+                using var response = JsonDocument.Parse(responseJson);
+                if (!response.RootElement.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
+                if (!response.RootElement.GetProperty("ok").GetBoolean())
+                    throw new InvalidOperationException(response.RootElement.GetProperty("error").GetString());
+                var result = response.RootElement.GetProperty("result").Deserialize<T>(JsonOptions);
+                if (result is null && !allowNullResult) throw new InvalidOperationException("Gua bridge returned an empty result.");
+                return result!;
+            }
         }
-        while (true)
-        {
-            var responseJson = await ReceiveStringAsync(cancellationToken).ConfigureAwait(false);
-            using var response = JsonDocument.Parse(responseJson);
-            if (!response.RootElement.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
-            if (!response.RootElement.GetProperty("ok").GetBoolean())
-                throw new InvalidOperationException(response.RootElement.GetProperty("error").GetString());
-            var result = response.RootElement.GetProperty("result").Deserialize<T>(JsonOptions);
-            if (result is null && !allowNullResult) throw new InvalidOperationException("Gua bridge returned an empty result.");
-            return result!;
-        }
+        finally { _requestGate.Release(); }
     }
 
     private static byte[] BuildRequestPayload(object command, int id)
@@ -533,39 +544,44 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
 
     private string RequestRawResult(object command, TimeSpan? responseTimeout = null)
     {
-        EnsureConnected();
-        var id = _nextId++;
-        var payload = JsonSerializer.Serialize(command, command.GetType());
-        using var document = JsonDocument.Parse(payload);
-        using var output = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(output))
+        _requestGate.Wait();
+        try
         {
-            writer.WriteStartObject();
-            writer.WriteNumber("id", id);
-            foreach (var property in document.RootElement.EnumerateObject())
+            EnsureConnected();
+            var id = _nextId++;
+            var payload = JsonSerializer.Serialize(command, command.GetType());
+            using var document = JsonDocument.Parse(payload);
+            using var output = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(output))
             {
-                property.WriteTo(writer);
+                writer.WriteStartObject();
+                writer.WriteNumber("id", id);
+                foreach (var property in document.RootElement.EnumerateObject())
+                {
+                    property.WriteTo(writer);
+                }
+                writer.WriteEndObject();
             }
-            writer.WriteEndObject();
+
+            Send(output.ToArray());
+            while (true)
+            {
+                var responseJson = ReceiveString(responseTimeout);
+                using var response = JsonDocument.Parse(responseJson);
+                if (!response.RootElement.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id)
+                {
+                    continue;
+                }
+
+                if (!response.RootElement.GetProperty("ok").GetBoolean())
+                {
+                    throw new InvalidOperationException(response.RootElement.GetProperty("error").GetString());
+                }
+
+                return response.RootElement.GetProperty("result").GetRawText();
+            }
         }
-
-        Send(output.ToArray());
-        while (true)
-        {
-            var responseJson = ReceiveString(responseTimeout);
-            using var response = JsonDocument.Parse(responseJson);
-            if (!response.RootElement.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id)
-            {
-                continue;
-            }
-
-            if (!response.RootElement.GetProperty("ok").GetBoolean())
-            {
-                throw new InvalidOperationException(response.RootElement.GetProperty("error").GetString());
-            }
-
-            return response.RootElement.GetProperty("result").GetRawText();
-        }
+        finally { _requestGate.Release(); }
     }
 
     private void EnsureConnected()

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -5,7 +5,7 @@ using Gua.Core;
 
 namespace Gua.Testing.Godot;
 
-public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IDisposable
+public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncClockContext, IDisposable
 {
     private readonly Uri _bridgeUri;
     private readonly TimeSpan _requestTimeout;
@@ -46,7 +46,7 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IDisposabl
 
     public GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null)
     {
-        Request<RemoteClockStatus>(new { type = "clock_install", initialTimeMs = (initialTime ?? TimeSpan.Zero).TotalMilliseconds, stepMs = step?.TotalMilliseconds });
+        Request<RemoteClockStatus>(ClockCommand("clock_install", "initialTimeMs", (initialTime ?? TimeSpan.Zero).TotalMilliseconds, step));
         return GuaClockResult.Ok;
     }
 
@@ -58,16 +58,35 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IDisposabl
 
     public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
     {
-        var clock = Request<RemoteClockStatus>(new { type = "clock_run_for", durationMs = duration.TotalMilliseconds, stepMs = step?.TotalMilliseconds });
-        var before = GetContextStatus();
+        var clock = Request<RemoteClockStatus>(ClockCommand("clock_run_for", "durationMs", duration.TotalMilliseconds, step));
+        if (clock.CompletionSessionEpoch is not { } completionEpoch || clock.CompletionAfterFrameSequence is not { } completionFrame)
+            throw new NotSupportedException("The connected runtime does not provide correlated clock completion.");
         var deadline = DateTime.UtcNow + _requestTimeout;
         while (DateTime.UtcNow < deadline)
         {
             var context = GetContextStatus();
-            if (context.SessionEpoch != before.SessionEpoch) throw new InvalidOperationException("stale_session");
-            if (clock.PendingMs <= 0 && context.FrameSequence > before.FrameSequence) return GuaClockResult.Ok;
+            if (context.SessionEpoch != completionEpoch) throw new InvalidOperationException("stale_session");
+            if (clock.PendingMs <= 0 && context.FrameSequence > completionFrame) return GuaClockResult.Ok;
             Thread.Sleep(5);
             clock = Request<RemoteClockStatus>(new { type = "get_clock" });
+        }
+        throw new TimeoutException("Timed out waiting for Gua clock run_for host completion.");
+    }
+
+    public async Task<GuaClockResult> RunClockForAsync(TimeSpan duration, TimeSpan? step = null, CancellationToken cancellationToken = default)
+    {
+        var clock = await RequestAsync<RemoteClockStatus>(ClockCommand("clock_run_for", "durationMs", duration.TotalMilliseconds, step), cancellationToken).ConfigureAwait(false);
+        if (clock.CompletionSessionEpoch is not { } completionEpoch || clock.CompletionAfterFrameSequence is not { } completionFrame)
+            throw new NotSupportedException("The connected runtime does not provide correlated clock completion.");
+        var deadline = DateTime.UtcNow + _requestTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var status = await RequestAsync<ContextStatusResult>(new { type = "get_context_status" }, cancellationToken).ConfigureAwait(false);
+            if (status.SessionEpoch != completionEpoch) throw new InvalidOperationException("stale_session");
+            if (clock.PendingMs <= 0 && status.FrameSequence > completionFrame) return GuaClockResult.Ok;
+            await Task.Delay(5, cancellationToken).ConfigureAwait(false);
+            clock = await RequestAsync<RemoteClockStatus>(new { type = "get_clock" }, cancellationToken).ConfigureAwait(false);
         }
         throw new TimeoutException("Timed out waiting for Gua clock run_for host completion.");
     }
@@ -80,6 +99,13 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IDisposabl
 
     private static GuaClockStatus ToClockStatus(RemoteClockStatus value) => new(value.Installed,
         string.Equals(value.State, "paused", StringComparison.Ordinal), value.NowMs, value.DefaultStepMs, value.PendingMs, value.Generation);
+
+    private static Dictionary<string, object> ClockCommand(string type, string valueName, double value, TimeSpan? step)
+    {
+        var command = new Dictionary<string, object> { ["type"] = type, [valueName] = value };
+        if (step.HasValue) command["stepMs"] = step.Value.TotalMilliseconds;
+        return command;
+    }
 
     public Task<GuaVersion> GetVersionAsync(CancellationToken cancellationToken = default)
     {
@@ -419,6 +445,72 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IDisposabl
         }
     }
 
+    private async Task<T> RequestAsync<T>(object command, CancellationToken cancellationToken, bool allowNullResult = false)
+    {
+        await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false);
+        var id = _nextId++;
+        var payload = BuildRequestPayload(command, id);
+        using (var sendTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+        {
+            sendTimeout.CancelAfter(_requestTimeout);
+            var socket = _socket ?? throw new InvalidOperationException("Gua bridge WebSocket is not connected.");
+            await socket.SendAsync(new ArraySegment<byte>(payload), WebSocketMessageType.Text, true, sendTimeout.Token).ConfigureAwait(false);
+        }
+        while (true)
+        {
+            var responseJson = await ReceiveStringAsync(cancellationToken).ConfigureAwait(false);
+            using var response = JsonDocument.Parse(responseJson);
+            if (!response.RootElement.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
+            if (!response.RootElement.GetProperty("ok").GetBoolean())
+                throw new InvalidOperationException(response.RootElement.GetProperty("error").GetString());
+            var result = response.RootElement.GetProperty("result").Deserialize<T>(JsonOptions);
+            if (result is null && !allowNullResult) throw new InvalidOperationException("Gua bridge returned an empty result.");
+            return result!;
+        }
+    }
+
+    private static byte[] BuildRequestPayload(object command, int id)
+    {
+        var payload = JsonSerializer.Serialize(command, command.GetType());
+        using var document = JsonDocument.Parse(payload);
+        using var output = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(output))
+        {
+            writer.WriteStartObject(); writer.WriteNumber("id", id);
+            foreach (var property in document.RootElement.EnumerateObject()) property.WriteTo(writer);
+            writer.WriteEndObject();
+        }
+        return output.ToArray();
+    }
+
+    private async Task EnsureConnectedAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_socket?.State == WebSocketState.Open) return;
+        _socket?.Dispose();
+        _socket = new ClientWebSocket();
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(_requestTimeout);
+        try { await _socket.ConnectAsync(_bridgeUri, timeout.Token).ConfigureAwait(false); }
+        catch { _socket.Dispose(); _socket = null; throw; }
+    }
+
+    private async Task<string> ReceiveStringAsync(CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(_requestTimeout);
+        var buffer = new byte[65536];
+        using var stream = new MemoryStream();
+        while (true)
+        {
+            var socket = _socket ?? throw new InvalidOperationException("Gua bridge WebSocket is not connected.");
+            var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), timeout.Token).ConfigureAwait(false);
+            if (result.MessageType == WebSocketMessageType.Close) throw new InvalidOperationException("Gua bridge WebSocket closed.");
+            stream.Write(buffer, 0, result.Count);
+            if (result.EndOfMessage) return Encoding.UTF8.GetString(stream.ToArray());
+        }
+    }
+
     private string RequestRawResult(object command, TimeSpan? responseTimeout = null)
     {
         EnsureConnected();
@@ -514,7 +606,8 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IDisposabl
     };
 
     private sealed record ActionRequestResult(ulong RequestId);
-    private sealed record RemoteClockStatus(bool Installed, string State, double NowMs, double DefaultStepMs, double PendingMs, ulong Generation);
+    private sealed record RemoteClockStatus(bool Installed, string State, double NowMs, double DefaultStepMs, double PendingMs, ulong Generation,
+        ulong? CompletionSessionEpoch = null, ulong? CompletionAfterFrameSequence = null);
     private sealed record ActionEventResult(
         ulong RequestId, int Action, bool Succeeded, int Error, string NodeId, string Value, bool Sensitive,
         ulong SessionEpoch, ulong FrameSequence, ulong Revision);

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -50,9 +50,21 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
         return GuaClockResult.Ok;
     }
 
+    public async Task<GuaClockResult> InstallClockAsync(TimeSpan? initialTime = null, TimeSpan? step = null, CancellationToken cancellationToken = default)
+    {
+        await RequestAsync<RemoteClockStatus>(ClockCommand("clock_install", "initialTimeMs", (initialTime ?? TimeSpan.Zero).TotalMilliseconds, step), cancellationToken).ConfigureAwait(false);
+        return GuaClockResult.Ok;
+    }
+
     public GuaClockResult PauseClock()
     {
         Request<RemoteClockStatus>(new { type = "clock_pause" });
+        return GuaClockResult.Ok;
+    }
+
+    public async Task<GuaClockResult> PauseClockAsync(CancellationToken cancellationToken = default)
+    {
+        await RequestAsync<RemoteClockStatus>(new { type = "clock_pause" }, cancellationToken).ConfigureAwait(false);
         return GuaClockResult.Ok;
     }
 
@@ -96,6 +108,12 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
     public GuaClockResult ResumeClock()
     {
         Request<RemoteClockStatus>(new { type = "clock_resume" });
+        return GuaClockResult.Ok;
+    }
+
+    public async Task<GuaClockResult> ResumeClockAsync(CancellationToken cancellationToken = default)
+    {
+        await RequestAsync<RemoteClockStatus>(new { type = "clock_resume" }, cancellationToken).ConfigureAwait(false);
         return GuaClockResult.Ok;
     }
 

--- a/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
+++ b/bindings/dotnet/src/Gua.Testing.Godot/GuaRemoteContext.cs
@@ -184,6 +184,7 @@ public sealed class GuaRemoteContext : IGuaContext, IGuaClockContext, IGuaAsyncC
             type = "reset_context",
             expectedSessionEpoch = expectedEpoch,
             flags = (uint)options.Targets,
+            flagsVersion = 1,
             strict = options.Strict,
         });
         return new GuaResetReport(

--- a/bindings/dotnet/src/Gua.Testing/GuaClockControls.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaClockControls.cs
@@ -1,0 +1,30 @@
+using Gua.Core;
+
+namespace Gua.Testing;
+
+public static class GuaClockControls
+{
+    public static GuaClockStatus InstallClock(IGuaContext context, TimeSpan? initialTime = null, TimeSpan? step = null)
+    { var clock = Require(context); Ensure(clock.InstallClock(initialTime, step)); return clock.GetClockStatus(); }
+    public static GuaClockStatus PauseClock(IGuaContext context)
+    { var clock = Require(context); Ensure(clock.PauseClock()); return clock.GetClockStatus(); }
+    public static GuaClockStatus RunClockFor(IGuaContext context, TimeSpan duration, TimeSpan? step = null)
+    { var clock = Require(context); Ensure(clock.RunClockFor(duration, step)); return clock.GetClockStatus(); }
+    public static GuaClockStatus ResumeClock(IGuaContext context)
+    { var clock = Require(context); Ensure(clock.ResumeClock()); return clock.GetClockStatus(); }
+    public static GuaClockStatus GetClockStatus(IGuaContext context) => Require(context).GetClockStatus();
+
+    public static Task<GuaClockStatus> InstallClockAsync(IGuaContext context, TimeSpan? initialTime = null, TimeSpan? step = null, CancellationToken cancellationToken = default)
+    { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(InstallClock(context, initialTime, step)); }
+    public static Task<GuaClockStatus> PauseClockAsync(IGuaContext context, CancellationToken cancellationToken = default)
+    { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(PauseClock(context)); }
+    public static Task<GuaClockStatus> RunClockForAsync(IGuaContext context, TimeSpan duration, TimeSpan? step = null, CancellationToken cancellationToken = default)
+    { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(RunClockFor(context, duration, step)); }
+    public static Task<GuaClockStatus> ResumeClockAsync(IGuaContext context, CancellationToken cancellationToken = default)
+    { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(ResumeClock(context)); }
+
+    private static IGuaClockContext Require(IGuaContext context) => context as IGuaClockContext
+        ?? throw new NotSupportedException("This Gua context does not support virtual_clock_v1.");
+    private static void Ensure(GuaClockResult result)
+    { if (result != GuaClockResult.Ok) throw new InvalidOperationException($"Gua clock operation failed: {result}."); }
+}

--- a/bindings/dotnet/src/Gua.Testing/GuaClockControls.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaClockControls.cs
@@ -14,10 +14,26 @@ public static class GuaClockControls
     { var clock = Require(context); Ensure(clock.ResumeClock()); return clock.GetClockStatus(); }
     public static GuaClockStatus GetClockStatus(IGuaContext context) => Require(context).GetClockStatus();
 
-    public static Task<GuaClockStatus> InstallClockAsync(IGuaContext context, TimeSpan? initialTime = null, TimeSpan? step = null, CancellationToken cancellationToken = default)
-    { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(InstallClock(context, initialTime, step)); }
-    public static Task<GuaClockStatus> PauseClockAsync(IGuaContext context, CancellationToken cancellationToken = default)
-    { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(PauseClock(context)); }
+    public static async Task<GuaClockStatus> InstallClockAsync(IGuaContext context, TimeSpan? initialTime = null, TimeSpan? step = null, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (context is IGuaAsyncClockContext asyncClock)
+        {
+            Ensure(await asyncClock.InstallClockAsync(initialTime, step, cancellationToken).ConfigureAwait(false));
+            return Require(context).GetClockStatus();
+        }
+        return InstallClock(context, initialTime, step);
+    }
+    public static async Task<GuaClockStatus> PauseClockAsync(IGuaContext context, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (context is IGuaAsyncClockContext asyncClock)
+        {
+            Ensure(await asyncClock.PauseClockAsync(cancellationToken).ConfigureAwait(false));
+            return Require(context).GetClockStatus();
+        }
+        return PauseClock(context);
+    }
     public static async Task<GuaClockStatus> RunClockForAsync(IGuaContext context, TimeSpan duration, TimeSpan? step = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -28,8 +44,16 @@ public static class GuaClockControls
         }
         return RunClockFor(context, duration, step);
     }
-    public static Task<GuaClockStatus> ResumeClockAsync(IGuaContext context, CancellationToken cancellationToken = default)
-    { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(ResumeClock(context)); }
+    public static async Task<GuaClockStatus> ResumeClockAsync(IGuaContext context, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (context is IGuaAsyncClockContext asyncClock)
+        {
+            Ensure(await asyncClock.ResumeClockAsync(cancellationToken).ConfigureAwait(false));
+            return Require(context).GetClockStatus();
+        }
+        return ResumeClock(context);
+    }
 
     private static IGuaClockContext Require(IGuaContext context) => context as IGuaClockContext
         ?? throw new NotSupportedException("This Gua context does not support virtual_clock_v1.");

--- a/bindings/dotnet/src/Gua.Testing/GuaClockControls.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaClockControls.cs
@@ -5,14 +5,26 @@ namespace Gua.Testing;
 public static class GuaClockControls
 {
     public static GuaClockStatus InstallClock(IGuaContext context, TimeSpan? initialTime = null, TimeSpan? step = null)
-    { var clock = Require(context); Ensure(clock.InstallClock(initialTime, step)); return clock.GetClockStatus(); }
+    {
+        if (context is GuaContext local) { local.Clock.Install(initialTime, step); return local.Clock.Status; }
+        var clock = Require(context); Ensure(clock.InstallClock(initialTime, step)); return clock.GetClockStatus();
+    }
     public static GuaClockStatus PauseClock(IGuaContext context)
-    { var clock = Require(context); Ensure(clock.PauseClock()); return clock.GetClockStatus(); }
+    {
+        if (context is GuaContext local) { local.Clock.Pause(); return local.Clock.Status; }
+        var clock = Require(context); Ensure(clock.PauseClock()); return clock.GetClockStatus();
+    }
     public static GuaClockStatus RunClockFor(IGuaContext context, TimeSpan duration, TimeSpan? step = null)
-    { var clock = Require(context); Ensure(clock.RunClockFor(duration, step)); return clock.GetClockStatus(); }
+    {
+        if (context is GuaContext local) { local.Clock.RunFor(duration, step); return local.Clock.Status; }
+        var clock = Require(context); Ensure(clock.RunClockFor(duration, step)); return clock.GetClockStatus();
+    }
     public static GuaClockStatus ResumeClock(IGuaContext context)
-    { var clock = Require(context); Ensure(clock.ResumeClock()); return clock.GetClockStatus(); }
-    public static GuaClockStatus GetClockStatus(IGuaContext context) => Require(context).GetClockStatus();
+    {
+        if (context is GuaContext local) { local.Clock.Resume(); return local.Clock.Status; }
+        var clock = Require(context); Ensure(clock.ResumeClock()); return clock.GetClockStatus();
+    }
+    public static GuaClockStatus GetClockStatus(IGuaContext context) => context is GuaContext local ? local.Clock.Status : Require(context).GetClockStatus();
 
     public static async Task<GuaClockStatus> InstallClockAsync(IGuaContext context, TimeSpan? initialTime = null, TimeSpan? step = null, CancellationToken cancellationToken = default)
     {

--- a/bindings/dotnet/src/Gua.Testing/GuaClockControls.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaClockControls.cs
@@ -32,7 +32,7 @@ public static class GuaClockControls
         if (context is IGuaAsyncClockContext asyncClock)
         {
             Ensure(await asyncClock.InstallClockAsync(initialTime, step, cancellationToken).ConfigureAwait(false));
-            return Require(context).GetClockStatus();
+            return asyncClock.GetClockStatus();
         }
         return InstallClock(context, initialTime, step);
     }
@@ -42,7 +42,7 @@ public static class GuaClockControls
         if (context is IGuaAsyncClockContext asyncClock)
         {
             Ensure(await asyncClock.PauseClockAsync(cancellationToken).ConfigureAwait(false));
-            return Require(context).GetClockStatus();
+            return asyncClock.GetClockStatus();
         }
         return PauseClock(context);
     }
@@ -52,7 +52,7 @@ public static class GuaClockControls
         if (context is IGuaAsyncClockContext asyncClock)
         {
             Ensure(await asyncClock.RunClockForAsync(duration, step, cancellationToken).ConfigureAwait(false));
-            return Require(context).GetClockStatus();
+            return asyncClock.GetClockStatus();
         }
         return RunClockFor(context, duration, step);
     }
@@ -62,7 +62,7 @@ public static class GuaClockControls
         if (context is IGuaAsyncClockContext asyncClock)
         {
             Ensure(await asyncClock.ResumeClockAsync(cancellationToken).ConfigureAwait(false));
-            return Require(context).GetClockStatus();
+            return asyncClock.GetClockStatus();
         }
         return ResumeClock(context);
     }

--- a/bindings/dotnet/src/Gua.Testing/GuaClockControls.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaClockControls.cs
@@ -18,8 +18,16 @@ public static class GuaClockControls
     { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(InstallClock(context, initialTime, step)); }
     public static Task<GuaClockStatus> PauseClockAsync(IGuaContext context, CancellationToken cancellationToken = default)
     { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(PauseClock(context)); }
-    public static Task<GuaClockStatus> RunClockForAsync(IGuaContext context, TimeSpan duration, TimeSpan? step = null, CancellationToken cancellationToken = default)
-    { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(RunClockFor(context, duration, step)); }
+    public static async Task<GuaClockStatus> RunClockForAsync(IGuaContext context, TimeSpan duration, TimeSpan? step = null, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (context is IGuaAsyncClockContext asyncClock)
+        {
+            Ensure(await asyncClock.RunClockForAsync(duration, step, cancellationToken).ConfigureAwait(false));
+            return Require(context).GetClockStatus();
+        }
+        return RunClockFor(context, duration, step);
+    }
     public static Task<GuaClockStatus> ResumeClockAsync(IGuaContext context, CancellationToken cancellationToken = default)
     { cancellationToken.ThrowIfCancellationRequested(); return Task.FromResult(ResumeClock(context)); }
 

--- a/bindings/dotnet/src/Gua.Testing/GuaTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaTestHost.cs
@@ -9,7 +9,7 @@ public sealed class GuaTestHost
     public GuaTestHost(GuaContext context)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
-        Clock = new GuaClock(_context);
+        Clock = _context.Clock;
     }
 
     public GuaClock Clock { get; }

--- a/bindings/dotnet/src/Gua.Testing/GuaTestHost.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaTestHost.cs
@@ -9,7 +9,10 @@ public sealed class GuaTestHost
     public GuaTestHost(GuaContext context)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
+        Clock = new GuaClock(_context);
     }
+
+    public GuaClock Clock { get; }
 
     public void Frame(string screen, Action<GuaTestHost> buildUi)
     {

--- a/bindings/dotnet/src/Gua.Testing/GuaTestSession.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaTestSession.cs
@@ -11,7 +11,7 @@ public enum GuaResetMode
     Strict,
 }
 
-public sealed record GuaResetPolicy(GuaResetMode Mode, GuaResetTargets Targets = GuaResetTargets.Default)
+public sealed record GuaResetPolicy(GuaResetMode Mode, GuaResetTargets Targets = GuaResetTargets.SessionDefault)
 {
     public static GuaResetPolicy Disabled { get; } = new(GuaResetMode.Disabled);
     public static GuaResetPolicy NonStrict { get; } = new(GuaResetMode.NonStrict);

--- a/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
@@ -5,7 +5,7 @@ using Gua.Core;
 
 namespace Gua.Testing;
 
-public sealed class GuaWebSocketContext : IGuaContext, IDisposable
+public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IDisposable
 {
     private readonly Uri uri;
     private readonly TimeSpan requestTimeout;
@@ -23,6 +23,21 @@ public sealed class GuaWebSocketContext : IGuaContext, IDisposable
     }
     public string GetUiTreeJson() => Raw(new { type = "get_ui_tree" });
     public GuaRemoteTree GetRemoteTree() => Request<GuaRemoteTree>(new { type = "get_ui_tree" });
+    public GuaClockStatus GetClockStatus() => ToClockStatus(Request<RemoteClockStatus>(new { type = "get_clock" }));
+    public GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null)
+    { Request<RemoteClockStatus>(new { type = "clock_install", initialTimeMs = (initialTime ?? TimeSpan.Zero).TotalMilliseconds, stepMs = step?.TotalMilliseconds }); return GuaClockResult.Ok; }
+    public GuaClockResult PauseClock() { Request<RemoteClockStatus>(new { type = "clock_pause" }); return GuaClockResult.Ok; }
+    public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
+    {
+        var status = Request<RemoteClockStatus>(new { type = "clock_run_for", durationMs = duration.TotalMilliseconds, stepMs = step?.TotalMilliseconds });
+        var deadline = DateTime.UtcNow + requestTimeout;
+        while (status.PendingMs > 0 && DateTime.UtcNow < deadline) { Thread.Sleep(5); status = Request<RemoteClockStatus>(new { type = "get_clock" }); }
+        if (status.PendingMs > 0) throw new TimeoutException("Timed out waiting for Gua clock run_for completion.");
+        return GuaClockResult.Ok;
+    }
+    public GuaClockResult ResumeClock() { Request<RemoteClockStatus>(new { type = "clock_resume" }); return GuaClockResult.Ok; }
+    private static GuaClockStatus ToClockStatus(RemoteClockStatus value) => new(value.Installed,
+        string.Equals(value.State, "paused", StringComparison.Ordinal), value.NowMs, value.DefaultStepMs, value.PendingMs, value.Generation);
     public string GetDiagnosticsJson() => Raw(new { type = "get_diagnostics" });
     public GuaVersion GetVersion() => GuaVersion.Parse(Raw(new { type = "get_version" }));
     public string GetScreenshotJson() => Raw(new { type = "get_screenshot" });
@@ -146,6 +161,7 @@ public sealed class GuaWebSocketContext : IGuaContext, IDisposable
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     private sealed record ActionResult(ulong RequestId);
+    private sealed record RemoteClockStatus(bool Installed, string State, double NowMs, double DefaultStepMs, double PendingMs, ulong Generation);
     private sealed record EventResult(ulong RequestId, int Action, bool Succeeded, int Error, string NodeId, string Value, bool Sensitive, ulong SessionEpoch, ulong FrameSequence, ulong Revision);
     private sealed record Status(ulong SessionEpoch, ulong FrameSequence, ulong Revision, uint NodeCount, uint PendingRequestCount, uint InFlightRequestCount, uint UnconsumedEventCount, uint LogCount, bool HasScreenshot, int FirstPendingAction, string FirstPendingNodeId, int FirstEventAction, string FirstEventNodeId);
     private sealed record ResetResult(int Result, ulong PreviousSessionEpoch, ulong SessionEpoch, uint PendingRequestCount, uint InFlightRequestCount, uint UnconsumedEventCount, uint DiscardedNodeCount, uint DiscardedPendingRequestCount, uint DiscardedInFlightRequestCount, uint DiscardedEventCount, uint DiscardedLogCount, bool DiscardedScreenshot, int FirstPendingAction, string FirstPendingNodeId, int FirstEventAction, string FirstEventNodeId);

--- a/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
@@ -26,7 +26,17 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
     public GuaClockStatus GetClockStatus() => ToClockStatus(Request<RemoteClockStatus>(new { type = "get_clock" }));
     public GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null)
     { Request<RemoteClockStatus>(ClockCommand("clock_install", "initialTimeMs", (initialTime ?? TimeSpan.Zero).TotalMilliseconds, step)); return GuaClockResult.Ok; }
+    public async Task<GuaClockResult> InstallClockAsync(TimeSpan? initialTime = null, TimeSpan? step = null, CancellationToken cancellationToken = default)
+    {
+        await RequestAsync<RemoteClockStatus>(ClockCommand("clock_install", "initialTimeMs", (initialTime ?? TimeSpan.Zero).TotalMilliseconds, step), cancellationToken).ConfigureAwait(false);
+        return GuaClockResult.Ok;
+    }
     public GuaClockResult PauseClock() { Request<RemoteClockStatus>(new { type = "clock_pause" }); return GuaClockResult.Ok; }
+    public async Task<GuaClockResult> PauseClockAsync(CancellationToken cancellationToken = default)
+    {
+        await RequestAsync<RemoteClockStatus>(new { type = "clock_pause" }, cancellationToken).ConfigureAwait(false);
+        return GuaClockResult.Ok;
+    }
     public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
     {
         var status = Request<RemoteClockStatus>(ClockCommand("clock_run_for", "durationMs", duration.TotalMilliseconds, step));
@@ -63,6 +73,11 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
         throw new TimeoutException("Timed out waiting for Gua clock run_for host completion.");
     }
     public GuaClockResult ResumeClock() { Request<RemoteClockStatus>(new { type = "clock_resume" }); return GuaClockResult.Ok; }
+    public async Task<GuaClockResult> ResumeClockAsync(CancellationToken cancellationToken = default)
+    {
+        await RequestAsync<RemoteClockStatus>(new { type = "clock_resume" }, cancellationToken).ConfigureAwait(false);
+        return GuaClockResult.Ok;
+    }
     private static GuaClockStatus ToClockStatus(RemoteClockStatus value) => new(value.Installed,
         string.Equals(value.State, "paused", StringComparison.Ordinal), value.NowMs, value.DefaultStepMs, value.PendingMs, value.Generation);
     private static Dictionary<string, object> ClockCommand(string type, string valueName, double value, TimeSpan? step)

--- a/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
@@ -5,7 +5,7 @@ using Gua.Core;
 
 namespace Gua.Testing;
 
-public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IDisposable
+public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsyncClockContext, IDisposable
 {
     private readonly Uri uri;
     private readonly TimeSpan requestTimeout;
@@ -25,26 +25,46 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IDispos
     public GuaRemoteTree GetRemoteTree() => Request<GuaRemoteTree>(new { type = "get_ui_tree" });
     public GuaClockStatus GetClockStatus() => ToClockStatus(Request<RemoteClockStatus>(new { type = "get_clock" }));
     public GuaClockResult InstallClock(TimeSpan? initialTime = null, TimeSpan? step = null)
-    { Request<RemoteClockStatus>(new { type = "clock_install", initialTimeMs = (initialTime ?? TimeSpan.Zero).TotalMilliseconds, stepMs = step?.TotalMilliseconds }); return GuaClockResult.Ok; }
+    { Request<RemoteClockStatus>(ClockCommand("clock_install", "initialTimeMs", (initialTime ?? TimeSpan.Zero).TotalMilliseconds, step)); return GuaClockResult.Ok; }
     public GuaClockResult PauseClock() { Request<RemoteClockStatus>(new { type = "clock_pause" }); return GuaClockResult.Ok; }
     public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
     {
-        var status = Request<RemoteClockStatus>(new { type = "clock_run_for", durationMs = duration.TotalMilliseconds, stepMs = step?.TotalMilliseconds });
-        var before = GetContextStatus();
+        var status = Request<RemoteClockStatus>(ClockCommand("clock_run_for", "durationMs", duration.TotalMilliseconds, step));
+        if (status.CompletionSessionEpoch is not { } completionEpoch || status.CompletionAfterFrameSequence is not { } completionFrame)
+            throw new NotSupportedException("The connected runtime does not provide correlated clock completion.");
         var deadline = DateTime.UtcNow + requestTimeout;
         while (DateTime.UtcNow < deadline)
         {
             var context = GetContextStatus();
-            if (context.SessionEpoch != before.SessionEpoch) throw new InvalidOperationException("stale_session");
-            if (status.PendingMs <= 0 && context.FrameSequence > before.FrameSequence) return GuaClockResult.Ok;
+            if (context.SessionEpoch != completionEpoch) throw new InvalidOperationException("stale_session");
+            if (status.PendingMs <= 0 && context.FrameSequence > completionFrame) return GuaClockResult.Ok;
             Thread.Sleep(5);
             status = Request<RemoteClockStatus>(new { type = "get_clock" });
+        }
+        throw new TimeoutException("Timed out waiting for Gua clock run_for host completion.");
+    }
+    public async Task<GuaClockResult> RunClockForAsync(TimeSpan duration, TimeSpan? step = null, CancellationToken cancellationToken = default)
+    {
+        var status = await RequestAsync<RemoteClockStatus>(ClockCommand("clock_run_for", "durationMs", duration.TotalMilliseconds, step), cancellationToken).ConfigureAwait(false);
+        if (status.CompletionSessionEpoch is not { } completionEpoch || status.CompletionAfterFrameSequence is not { } completionFrame)
+            throw new NotSupportedException("The connected runtime does not provide correlated clock completion.");
+        var deadline = DateTime.UtcNow + requestTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var context = await RequestAsync<Status>(new { type = "get_context_status" }, cancellationToken).ConfigureAwait(false);
+            if (context.SessionEpoch != completionEpoch) throw new InvalidOperationException("stale_session");
+            if (status.PendingMs <= 0 && context.FrameSequence > completionFrame) return GuaClockResult.Ok;
+            await Task.Delay(5, cancellationToken).ConfigureAwait(false);
+            status = await RequestAsync<RemoteClockStatus>(new { type = "get_clock" }, cancellationToken).ConfigureAwait(false);
         }
         throw new TimeoutException("Timed out waiting for Gua clock run_for host completion.");
     }
     public GuaClockResult ResumeClock() { Request<RemoteClockStatus>(new { type = "clock_resume" }); return GuaClockResult.Ok; }
     private static GuaClockStatus ToClockStatus(RemoteClockStatus value) => new(value.Installed,
         string.Equals(value.State, "paused", StringComparison.Ordinal), value.NowMs, value.DefaultStepMs, value.PendingMs, value.Generation);
+    private static Dictionary<string, object> ClockCommand(string type, string valueName, double value, TimeSpan? step)
+    { var command = new Dictionary<string, object> { ["type"] = type, [valueName] = value }; if (step.HasValue) command["stepMs"] = step.Value.TotalMilliseconds; return command; }
     public string GetDiagnosticsJson() => Raw(new { type = "get_diagnostics" });
     public GuaVersion GetVersion() => GuaVersion.Parse(Raw(new { type = "get_version" }));
     public string GetScreenshotJson() => Raw(new { type = "get_screenshot" });
@@ -141,6 +161,22 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IDispos
             var result = root.GetProperty("result").Deserialize<T>(JsonOptions); if (result == null && !allowNull) throw new InvalidOperationException("Gua bridge returned an empty result."); return result!;
         }
     }
+    private async Task<T> RequestAsync<T>(object command, CancellationToken cancellationToken, bool allowNull = false)
+    {
+        await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false); var id = nextId++; var bytes = Envelope(id, command);
+        using (var sendTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+        {
+            sendTimeout.CancelAfter(requestTimeout);
+            await socket!.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, sendTimeout.Token).ConfigureAwait(false);
+        }
+        while (true)
+        {
+            using var document = JsonDocument.Parse(await ReceiveAsync(cancellationToken).ConfigureAwait(false)); var root = document.RootElement;
+            if (!root.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
+            if (!root.GetProperty("ok").GetBoolean()) throw new InvalidOperationException(root.GetProperty("error").GetString());
+            var result = root.GetProperty("result").Deserialize<T>(JsonOptions); if (result == null && !allowNull) throw new InvalidOperationException("Gua bridge returned an empty result."); return result!;
+        }
+    }
     private string Raw(object command, TimeSpan? responseTimeout = null)
     {
         EnsureConnected(); var id = nextId++; Send(Envelope(id, command));
@@ -158,17 +194,29 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IDispos
         socket?.Dispose(); socket = new ClientWebSocket(); using var cts = new CancellationTokenSource(requestTimeout);
         try { socket.ConnectAsync(uri, cts.Token).GetAwaiter().GetResult(); } catch { socket.Dispose(); socket = null; throw; }
     }
+    private async Task EnsureConnectedAsync(CancellationToken cancellationToken)
+    {
+        if (disposed) throw new ObjectDisposedException(nameof(GuaWebSocketContext)); if (socket?.State == WebSocketState.Open) return;
+        socket?.Dispose(); socket = new ClientWebSocket(); using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken); timeout.CancelAfter(requestTimeout);
+        try { await socket.ConnectAsync(uri, timeout.Token).ConfigureAwait(false); } catch { socket.Dispose(); socket = null; throw; }
+    }
     private void Send(byte[] payload) { using var cts = new CancellationTokenSource(requestTimeout); socket!.SendAsync(new ArraySegment<byte>(payload), WebSocketMessageType.Text, true, cts.Token).GetAwaiter().GetResult(); }
     private string Receive(TimeSpan? timeout = null)
     {
         using var cts = new CancellationTokenSource(timeout ?? requestTimeout); var buffer = new byte[65536]; using var stream = new MemoryStream();
         while (true) { var result = socket!.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token).GetAwaiter().GetResult(); if (result.MessageType == WebSocketMessageType.Close) throw new InvalidOperationException("Gua bridge WebSocket closed."); stream.Write(buffer, 0, result.Count); if (result.EndOfMessage) return Encoding.UTF8.GetString(stream.ToArray()); }
     }
+    private async Task<string> ReceiveAsync(CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken); timeout.CancelAfter(requestTimeout); var buffer = new byte[65536]; using var stream = new MemoryStream();
+        while (true) { var result = await socket!.ReceiveAsync(new ArraySegment<byte>(buffer), timeout.Token).ConfigureAwait(false); if (result.MessageType == WebSocketMessageType.Close) throw new InvalidOperationException("Gua bridge WebSocket closed."); stream.Write(buffer, 0, result.Count); if (result.EndOfMessage) return Encoding.UTF8.GetString(stream.ToArray()); }
+    }
     public void Dispose() { if (disposed) return; disposed = true; socket?.Dispose(); socket = null; }
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     private sealed record ActionResult(ulong RequestId);
-    private sealed record RemoteClockStatus(bool Installed, string State, double NowMs, double DefaultStepMs, double PendingMs, ulong Generation);
+    private sealed record RemoteClockStatus(bool Installed, string State, double NowMs, double DefaultStepMs, double PendingMs, ulong Generation,
+        ulong? CompletionSessionEpoch = null, ulong? CompletionAfterFrameSequence = null);
     private sealed record EventResult(ulong RequestId, int Action, bool Succeeded, int Error, string NodeId, string Value, bool Sensitive, ulong SessionEpoch, ulong FrameSequence, ulong Revision);
     private sealed record Status(ulong SessionEpoch, ulong FrameSequence, ulong Revision, uint NodeCount, uint PendingRequestCount, uint InFlightRequestCount, uint UnconsumedEventCount, uint LogCount, bool HasScreenshot, int FirstPendingAction, string FirstPendingNodeId, int FirstEventAction, string FirstEventNodeId);
     private sealed record ResetResult(int Result, ulong PreviousSessionEpoch, ulong SessionEpoch, uint PendingRequestCount, uint InFlightRequestCount, uint UnconsumedEventCount, uint DiscardedNodeCount, uint DiscardedPendingRequestCount, uint DiscardedInFlightRequestCount, uint DiscardedEventCount, uint DiscardedLogCount, bool DiscardedScreenshot, int FirstPendingAction, string FirstPendingNodeId, int FirstEventAction, string FirstEventNodeId);

--- a/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
@@ -7,6 +7,7 @@ namespace Gua.Testing;
 
 public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsyncClockContext, IDisposable
 {
+    private static readonly TimeSpan MinimumClockPauseResponseTimeout = TimeSpan.FromSeconds(11);
     private readonly Uri uri;
     private readonly TimeSpan requestTimeout;
     private readonly SemaphoreSlim requestGate = new(1, 1);
@@ -32,10 +33,10 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
         await RequestAsync<RemoteClockStatus>(ClockCommand("clock_install", "initialTimeMs", (initialTime ?? TimeSpan.Zero).TotalMilliseconds, step), cancellationToken).ConfigureAwait(false);
         return GuaClockResult.Ok;
     }
-    public GuaClockResult PauseClock() { Request<RemoteClockStatus>(new { type = "clock_pause" }); return GuaClockResult.Ok; }
+    public GuaClockResult PauseClock() { Request<RemoteClockStatus>(new { type = "clock_pause" }, responseTimeout: ClockPauseResponseTimeout); return GuaClockResult.Ok; }
     public async Task<GuaClockResult> PauseClockAsync(CancellationToken cancellationToken = default)
     {
-        await RequestAsync<RemoteClockStatus>(new { type = "clock_pause" }, cancellationToken).ConfigureAwait(false);
+        await RequestAsync<RemoteClockStatus>(new { type = "clock_pause" }, cancellationToken, responseTimeout: ClockPauseResponseTimeout).ConfigureAwait(false);
         return GuaClockResult.Ok;
     }
     public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
@@ -168,7 +169,9 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
     private static GuaActionType? Action(int value) => value == 0 ? null : (GuaActionType)value;
     private GuaRemoteTree Tree() => GetRemoteTree();
 
-    private T Request<T>(object command, bool allowNull = false)
+    private TimeSpan ClockPauseResponseTimeout => requestTimeout > MinimumClockPauseResponseTimeout ? requestTimeout : MinimumClockPauseResponseTimeout;
+
+    private T Request<T>(object command, bool allowNull = false, TimeSpan? responseTimeout = null)
     {
         requestGate.Wait();
         try
@@ -176,7 +179,7 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
             EnsureConnected(); var id = nextId++; var bytes = Envelope(id, command); Send(bytes);
             while (true)
             {
-                using var document = JsonDocument.Parse(Receive()); var root = document.RootElement;
+                using var document = JsonDocument.Parse(Receive(responseTimeout)); var root = document.RootElement;
                 if (!root.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
                 if (!root.GetProperty("ok").GetBoolean()) throw new InvalidOperationException(root.GetProperty("error").GetString());
                 var result = root.GetProperty("result").Deserialize<T>(JsonOptions); if (result == null && !allowNull) throw new InvalidOperationException("Gua bridge returned an empty result."); return result!;
@@ -184,7 +187,7 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
         }
         finally { requestGate.Release(); }
     }
-    private async Task<T> RequestAsync<T>(object command, CancellationToken cancellationToken, bool allowNull = false)
+    private async Task<T> RequestAsync<T>(object command, CancellationToken cancellationToken, bool allowNull = false, TimeSpan? responseTimeout = null)
     {
         await requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -197,7 +200,7 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
             }
             while (true)
             {
-                using var document = JsonDocument.Parse(await ReceiveAsync(cancellationToken).ConfigureAwait(false)); var root = document.RootElement;
+                using var document = JsonDocument.Parse(await ReceiveAsync(cancellationToken, responseTimeout).ConfigureAwait(false)); var root = document.RootElement;
                 if (!root.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
                 if (!root.GetProperty("ok").GetBoolean()) throw new InvalidOperationException(root.GetProperty("error").GetString());
                 var result = root.GetProperty("result").Deserialize<T>(JsonOptions); if (result == null && !allowNull) throw new InvalidOperationException("Gua bridge returned an empty result."); return result!;
@@ -239,9 +242,9 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
         using var cts = new CancellationTokenSource(timeout ?? requestTimeout); var buffer = new byte[65536]; using var stream = new MemoryStream();
         while (true) { var result = socket!.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token).GetAwaiter().GetResult(); if (result.MessageType == WebSocketMessageType.Close) throw new InvalidOperationException("Gua bridge WebSocket closed."); stream.Write(buffer, 0, result.Count); if (result.EndOfMessage) return Encoding.UTF8.GetString(stream.ToArray()); }
     }
-    private async Task<string> ReceiveAsync(CancellationToken cancellationToken)
+    private async Task<string> ReceiveAsync(CancellationToken cancellationToken, TimeSpan? responseTimeout = null)
     {
-        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken); timeout.CancelAfter(requestTimeout); var buffer = new byte[65536]; using var stream = new MemoryStream();
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken); timeout.CancelAfter(responseTimeout ?? requestTimeout); var buffer = new byte[65536]; using var stream = new MemoryStream();
         while (true) { var result = await socket!.ReceiveAsync(new ArraySegment<byte>(buffer), timeout.Token).ConfigureAwait(false); if (result.MessageType == WebSocketMessageType.Close) throw new InvalidOperationException("Gua bridge WebSocket closed."); stream.Write(buffer, 0, result.Count); if (result.EndOfMessage) return Encoding.UTF8.GetString(stream.ToArray()); }
     }
     public void Dispose() { if (disposed) return; disposed = true; socket?.Dispose(); socket = null; }

--- a/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
@@ -30,14 +30,15 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
     public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
     {
         var status = Request<RemoteClockStatus>(ClockCommand("clock_run_for", "durationMs", duration.TotalMilliseconds, step));
-        if (status.CompletionSessionEpoch is not { } completionEpoch || status.CompletionAfterFrameSequence is not { } completionFrame)
+        if (status.CompletionSessionEpoch is not { } completionEpoch || status.CompletionAfterFrameSequence is not { } completionFrame ||
+            status.OperationSequence is not { } operationSequence)
             throw new NotSupportedException("The connected runtime does not provide correlated clock completion.");
         var deadline = DateTime.UtcNow + requestTimeout;
         while (DateTime.UtcNow < deadline)
         {
             var context = GetContextStatus();
             if (context.SessionEpoch != completionEpoch) throw new InvalidOperationException("stale_session");
-            if (status.PendingMs <= 0 && context.FrameSequence > completionFrame) return GuaClockResult.Ok;
+            if (status.CompletedOperationSequence >= operationSequence && context.FrameSequence > completionFrame) return GuaClockResult.Ok;
             Thread.Sleep(5);
             status = Request<RemoteClockStatus>(new { type = "get_clock" });
         }
@@ -46,7 +47,8 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
     public async Task<GuaClockResult> RunClockForAsync(TimeSpan duration, TimeSpan? step = null, CancellationToken cancellationToken = default)
     {
         var status = await RequestAsync<RemoteClockStatus>(ClockCommand("clock_run_for", "durationMs", duration.TotalMilliseconds, step), cancellationToken).ConfigureAwait(false);
-        if (status.CompletionSessionEpoch is not { } completionEpoch || status.CompletionAfterFrameSequence is not { } completionFrame)
+        if (status.CompletionSessionEpoch is not { } completionEpoch || status.CompletionAfterFrameSequence is not { } completionFrame ||
+            status.OperationSequence is not { } operationSequence)
             throw new NotSupportedException("The connected runtime does not provide correlated clock completion.");
         var deadline = DateTime.UtcNow + requestTimeout;
         while (DateTime.UtcNow < deadline)
@@ -54,7 +56,7 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
             cancellationToken.ThrowIfCancellationRequested();
             var context = await RequestAsync<Status>(new { type = "get_context_status" }, cancellationToken).ConfigureAwait(false);
             if (context.SessionEpoch != completionEpoch) throw new InvalidOperationException("stale_session");
-            if (status.PendingMs <= 0 && context.FrameSequence > completionFrame) return GuaClockResult.Ok;
+            if (status.CompletedOperationSequence >= operationSequence && context.FrameSequence > completionFrame) return GuaClockResult.Ok;
             await Task.Delay(5, cancellationToken).ConfigureAwait(false);
             status = await RequestAsync<RemoteClockStatus>(new { type = "get_clock" }, cancellationToken).ConfigureAwait(false);
         }
@@ -216,6 +218,7 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
 
     private sealed record ActionResult(ulong RequestId);
     private sealed record RemoteClockStatus(bool Installed, string State, double NowMs, double DefaultStepMs, double PendingMs, ulong Generation,
+        ulong CompletedOperationSequence = 0, ulong? OperationSequence = null,
         ulong? CompletionSessionEpoch = null, ulong? CompletionAfterFrameSequence = null);
     private sealed record EventResult(ulong RequestId, int Action, bool Succeeded, int Error, string NodeId, string Value, bool Sensitive, ulong SessionEpoch, ulong FrameSequence, ulong Revision);
     private sealed record Status(ulong SessionEpoch, ulong FrameSequence, ulong Revision, uint NodeCount, uint PendingRequestCount, uint InFlightRequestCount, uint UnconsumedEventCount, uint LogCount, bool HasScreenshot, int FirstPendingAction, string FirstPendingNodeId, int FirstEventAction, string FirstEventNodeId);

--- a/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
@@ -161,7 +161,7 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
     public GuaResetReport Reset(GuaResetOptions? options = null)
     {
         options ??= new(); var epoch = options.ExpectedSessionEpoch ?? GetContextStatus().SessionEpoch;
-        var r = Request<ResetResult>(new { type = "reset_context", expectedSessionEpoch = epoch, flags = (uint)options.Targets, strict = options.Strict });
+        var r = Request<ResetResult>(new { type = "reset_context", expectedSessionEpoch = epoch, flags = (uint)options.Targets, flagsVersion = 1, strict = options.Strict });
         return new((GuaResetResult)r.Result, r.PreviousSessionEpoch, r.SessionEpoch, r.PendingRequestCount, r.InFlightRequestCount, r.UnconsumedEventCount,
             r.DiscardedNodeCount, r.DiscardedPendingRequestCount, r.DiscardedInFlightRequestCount, r.DiscardedEventCount, r.DiscardedLogCount, r.DiscardedScreenshot,
             Action(r.FirstPendingAction), r.FirstPendingNodeId, Action(r.FirstEventAction), r.FirstEventNodeId);

--- a/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
@@ -30,10 +30,17 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IDispos
     public GuaClockResult RunClockFor(TimeSpan duration, TimeSpan? step = null)
     {
         var status = Request<RemoteClockStatus>(new { type = "clock_run_for", durationMs = duration.TotalMilliseconds, stepMs = step?.TotalMilliseconds });
+        var before = GetContextStatus();
         var deadline = DateTime.UtcNow + requestTimeout;
-        while (status.PendingMs > 0 && DateTime.UtcNow < deadline) { Thread.Sleep(5); status = Request<RemoteClockStatus>(new { type = "get_clock" }); }
-        if (status.PendingMs > 0) throw new TimeoutException("Timed out waiting for Gua clock run_for completion.");
-        return GuaClockResult.Ok;
+        while (DateTime.UtcNow < deadline)
+        {
+            var context = GetContextStatus();
+            if (context.SessionEpoch != before.SessionEpoch) throw new InvalidOperationException("stale_session");
+            if (status.PendingMs <= 0 && context.FrameSequence > before.FrameSequence) return GuaClockResult.Ok;
+            Thread.Sleep(5);
+            status = Request<RemoteClockStatus>(new { type = "get_clock" });
+        }
+        throw new TimeoutException("Timed out waiting for Gua clock run_for host completion.");
     }
     public GuaClockResult ResumeClock() { Request<RemoteClockStatus>(new { type = "clock_resume" }); return GuaClockResult.Ok; }
     private static GuaClockStatus ToClockStatus(RemoteClockStatus value) => new(value.Installed,

--- a/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
+++ b/bindings/dotnet/src/Gua.Testing/GuaWebSocketContext.cs
@@ -9,6 +9,7 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
 {
     private readonly Uri uri;
     private readonly TimeSpan requestTimeout;
+    private readonly SemaphoreSlim requestGate = new(1, 1);
     private ClientWebSocket? socket;
     private readonly List<GuaActionEvent> bufferedActionEvents = new();
     private int nextId = 1;
@@ -169,35 +170,50 @@ public sealed class GuaWebSocketContext : IGuaContext, IGuaClockContext, IGuaAsy
 
     private T Request<T>(object command, bool allowNull = false)
     {
-        EnsureConnected(); var id = nextId++; var bytes = Envelope(id, command); Send(bytes);
-        while (true)
+        requestGate.Wait();
+        try
         {
-            using var document = JsonDocument.Parse(Receive()); var root = document.RootElement;
-            if (!root.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
-            if (!root.GetProperty("ok").GetBoolean()) throw new InvalidOperationException(root.GetProperty("error").GetString());
-            var result = root.GetProperty("result").Deserialize<T>(JsonOptions); if (result == null && !allowNull) throw new InvalidOperationException("Gua bridge returned an empty result."); return result!;
+            EnsureConnected(); var id = nextId++; var bytes = Envelope(id, command); Send(bytes);
+            while (true)
+            {
+                using var document = JsonDocument.Parse(Receive()); var root = document.RootElement;
+                if (!root.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
+                if (!root.GetProperty("ok").GetBoolean()) throw new InvalidOperationException(root.GetProperty("error").GetString());
+                var result = root.GetProperty("result").Deserialize<T>(JsonOptions); if (result == null && !allowNull) throw new InvalidOperationException("Gua bridge returned an empty result."); return result!;
+            }
         }
+        finally { requestGate.Release(); }
     }
     private async Task<T> RequestAsync<T>(object command, CancellationToken cancellationToken, bool allowNull = false)
     {
-        await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false); var id = nextId++; var bytes = Envelope(id, command);
-        using (var sendTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+        await requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            sendTimeout.CancelAfter(requestTimeout);
-            await socket!.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, sendTimeout.Token).ConfigureAwait(false);
+            await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false); var id = nextId++; var bytes = Envelope(id, command);
+            using (var sendTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            {
+                sendTimeout.CancelAfter(requestTimeout);
+                await socket!.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, sendTimeout.Token).ConfigureAwait(false);
+            }
+            while (true)
+            {
+                using var document = JsonDocument.Parse(await ReceiveAsync(cancellationToken).ConfigureAwait(false)); var root = document.RootElement;
+                if (!root.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
+                if (!root.GetProperty("ok").GetBoolean()) throw new InvalidOperationException(root.GetProperty("error").GetString());
+                var result = root.GetProperty("result").Deserialize<T>(JsonOptions); if (result == null && !allowNull) throw new InvalidOperationException("Gua bridge returned an empty result."); return result!;
+            }
         }
-        while (true)
-        {
-            using var document = JsonDocument.Parse(await ReceiveAsync(cancellationToken).ConfigureAwait(false)); var root = document.RootElement;
-            if (!root.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue;
-            if (!root.GetProperty("ok").GetBoolean()) throw new InvalidOperationException(root.GetProperty("error").GetString());
-            var result = root.GetProperty("result").Deserialize<T>(JsonOptions); if (result == null && !allowNull) throw new InvalidOperationException("Gua bridge returned an empty result."); return result!;
-        }
+        finally { requestGate.Release(); }
     }
     private string Raw(object command, TimeSpan? responseTimeout = null)
     {
-        EnsureConnected(); var id = nextId++; Send(Envelope(id, command));
-        while (true) { using var document = JsonDocument.Parse(Receive(responseTimeout)); var root = document.RootElement; if (!root.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue; if (!root.GetProperty("ok").GetBoolean()) throw new InvalidOperationException(root.GetProperty("error").GetString()); return root.GetProperty("result").GetRawText(); }
+        requestGate.Wait();
+        try
+        {
+            EnsureConnected(); var id = nextId++; Send(Envelope(id, command));
+            while (true) { using var document = JsonDocument.Parse(Receive(responseTimeout)); var root = document.RootElement; if (!root.TryGetProperty("id", out var responseId) || responseId.GetInt32() != id) continue; if (!root.GetProperty("ok").GetBoolean()) throw new InvalidOperationException(root.GetProperty("error").GetString()); return root.GetProperty("result").GetRawText(); }
+        }
+        finally { requestGate.Release(); }
     }
     private static byte[] Envelope(int id, object command)
     {

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -104,7 +104,10 @@ For high-level isolation, construct `GuaTestSession` with lifecycle options.
 `GuaTestSessionOptions.Strict` enables strict startup and teardown reset.
 Policies can also be selected independently with `GuaResetPolicy.Disabled`,
 `NonStrict`, or `Strict`; their default targets are nodes, requests, events,
-and retained history. Logs and screenshots remain preserved unless selected.
+retained history, and clock state. Logs and screenshots remain preserved unless
+selected. The published `GuaResetTargets.Default` (15) and `All` (63) values are
+retained for binary compatibility; new default behavior uses `SessionDefault`,
+and `AllWithClock` selects every target.
 
 ```csharp
 using var session = new GuaTestSession(context, new GuaTestSessionOptions

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -6,6 +6,9 @@ Contexts implementing `IGuaClockContext` can use
 `GuaClockControls.InstallClock`, `PauseClock`, `RunClockFor`, and `ResumeClock`
 with matching async methods. The clock advances explicitly connected GuaClock
 work; it is not a wall-clock sleep or an engine-global pause.
+For a local `GuaContext`, the controls use `context.Clock`; `RunClockFor`
+returns only after its queued steps, schedules, and Tick notifications are
+drained. Remote contexts retain their adapter-correlated completion behavior.
 
 `Gua.Testing` adds locator, assertion, wait, and test-host helpers on top of
 `Gua.Core`.

--- a/bindings/dotnet/src/Gua.Testing/README.md
+++ b/bindings/dotnet/src/Gua.Testing/README.md
@@ -1,5 +1,12 @@
 # Gua.Testing
 
+## Virtual clock
+
+Contexts implementing `IGuaClockContext` can use
+`GuaClockControls.InstallClock`, `PauseClock`, `RunClockFor`, and `ResumeClock`
+with matching async methods. The clock advances explicitly connected GuaClock
+work; it is not a wall-clock sleep or an engine-global pause.
+
 `Gua.Testing` adds locator, assertion, wait, and test-host helpers on top of
 `Gua.Core`.
 

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -61,29 +61,38 @@ public sealed class SelectorParityTests
         clock.Install(step: TimeSpan.FromMilliseconds(10));
         clock.Pause();
         var callbacks = 0;
+        var coreTicks = new List<double>();
+        clock.Tick += tick => coreTicks.Add(tick.TotalMilliseconds);
         clock.Schedule(TimeSpan.FromMilliseconds(10), () =>
         {
             callbacks++;
-            clock.RunFor(TimeSpan.FromMilliseconds(10));
+            clock.RunFor(TimeSpan.FromMilliseconds(5));
         });
         clock.RunFor(TimeSpan.FromMilliseconds(10));
         Assert.Multiple(() =>
         {
             Assert.That(callbacks, Is.EqualTo(1));
-            Assert.That(clock.Status.NowMilliseconds, Is.EqualTo(20));
+            Assert.That(clock.Status.NowMilliseconds, Is.EqualTo(15));
+            Assert.That(coreTicks, Is.EqualTo(new[] { 10.0, 5.0 }));
         });
 
         using var runtime = new GuaRuntime();
         runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
         runtime.Clock.Pause();
         var runtimeCallbacks = 0;
+        var runtimeTicks = new List<double>();
+        runtime.Clock.Tick += tick => runtimeTicks.Add(tick.TotalMilliseconds);
         runtime.Clock.Schedule(TimeSpan.FromMilliseconds(10), () =>
         {
             runtimeCallbacks++;
-            runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10));
+            runtime.Clock.RunFor(TimeSpan.FromMilliseconds(5));
         });
         runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10));
-        Assert.That(runtimeCallbacks, Is.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(runtimeCallbacks, Is.EqualTo(1));
+            Assert.That(runtimeTicks, Is.EqualTo(new[] { 10.0, 5.0 }));
+        });
     }
 
     [Test]
@@ -94,6 +103,8 @@ public sealed class SelectorParityTests
         clock.Install(step: TimeSpan.FromMilliseconds(10));
         clock.Pause();
         var callbacks = 0;
+        var coreTicks = 0;
+        clock.Tick += _ => coreTicks++;
         clock.Schedule(TimeSpan.FromMilliseconds(1), () =>
         {
             callbacks++;
@@ -102,6 +113,7 @@ public sealed class SelectorParityTests
 
         clock.RunFor(TimeSpan.FromMilliseconds(10), TimeSpan.FromMilliseconds(10));
         Assert.That(callbacks, Is.EqualTo(1));
+        Assert.That(coreTicks, Is.Zero, "A reset callback must suppress the stale generation's tick.");
         clock.Install(step: TimeSpan.FromMilliseconds(10));
         clock.Pause();
         clock.RunFor(TimeSpan.FromMilliseconds(10));
@@ -118,6 +130,8 @@ public sealed class SelectorParityTests
             runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
             runtime.Clock.Pause();
             var runtimeCallbacks = 0;
+            var runtimeTicks = 0;
+            runtime.Clock.Tick += _ => runtimeTicks++;
             runtime.Clock.Schedule(TimeSpan.FromMilliseconds(1), () =>
             {
                 runtimeCallbacks++;
@@ -126,6 +140,7 @@ public sealed class SelectorParityTests
 
             runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10), TimeSpan.FromMilliseconds(10));
             Assert.That(runtimeCallbacks, Is.EqualTo(1));
+            Assert.That(runtimeTicks, Is.Zero, "A remote reset callback must suppress the stale generation's tick.");
             runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
             runtime.Clock.Pause();
             runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10));
@@ -588,6 +603,44 @@ public sealed class SelectorParityTests
                 "Asynchronous pause must observe cancellation while the consumed running step awaits its host frame.");
             Native.gua_runtime_begin_frame(runtime, "fixture"); Native.gua_runtime_end_frame(runtime);
             await Task.Delay(30);
+        }
+        finally
+        {
+            Native.gua_runtime_stop_inspector_bridge(runtime);
+            Native.gua_runtime_destroy(runtime);
+        }
+    }
+
+    [Test]
+    public async Task StoppingBridgeCancelsAnInFlightRemotePauseWait()
+    {
+        var port = ReservePort();
+        var runtime = Native.gua_runtime_create();
+        Assert.That(runtime, Is.Not.EqualTo(nint.Zero));
+        try
+        {
+            Native.gua_runtime_set_virtual_clock_enabled(runtime, 1);
+            Native.gua_runtime_begin_frame(runtime, "fixture"); Native.gua_runtime_end_frame(runtime);
+            Assert.That(Native.gua_runtime_clock_install(runtime, 0, 10), Is.EqualTo(1));
+            Assert.That(Native.gua_runtime_clock_advance(runtime, 10), Is.EqualTo(1));
+            Assert.That(Native.gua_runtime_start_inspector_bridge(runtime, port), Is.EqualTo(1));
+            using var remote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(12));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+
+            var pause = Task.Run(() =>
+            {
+                try { remote.PauseClock(); }
+                catch (Exception) { }
+            });
+            await Task.Delay(50);
+            Assert.That(pause.IsCompleted, Is.False, "The fixture must enter the in-flight pause wait before shutdown.");
+
+            var stopwatch = Stopwatch.StartNew();
+            Native.gua_runtime_stop_inspector_bridge(runtime);
+            stopwatch.Stop();
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)),
+                "Bridge shutdown must cancel the pause handler instead of waiting for its 10-second deadline.");
+            await pause.WaitAsync(TimeSpan.FromSeconds(2));
         }
         finally
         {

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -576,7 +576,9 @@ public sealed class SelectorParityTests
                 "{\"id\":7,\"type\":\"clock_run_for\",\"durationMs\":25x}", 7);
             var invalidSuffixAfterWhitespace = await SendRawCommandAsync(socket,
                 "{\"id\":8,\"type\":\"clock_run_for\",\"durationMs\":25 x}", 8);
-            var statusAfterError = await SendRawCommandAsync(socket, "{\"id\":9,\"type\":\"get_clock\"}");
+            var nestedDuration = await SendRawCommandAsync(socket,
+                "{\"id\":9,\"type\":\"clock_run_for\",\"meta\":{\"durationMs\":25}}");
+            var statusAfterError = await SendRawCommandAsync(socket, "{\"id\":10,\"type\":\"get_clock\"}");
             Assert.Multiple(() =>
             {
                 Assert.That(missing.GetProperty("ok").GetBoolean(), Is.False);
@@ -591,6 +593,7 @@ public sealed class SelectorParityTests
                 Assert.That(missingInteger.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
                 Assert.That(invalidSuffix.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
                 Assert.That(invalidSuffixAfterWhitespace.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
+                Assert.That(nestedDuration.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
                 Assert.That(statusAfterError.GetProperty("ok").GetBoolean(), Is.True,
                     "An out-of-range number must not close the WebSocket connection.");
                 Assert.That(statusAfterError.GetProperty("result").GetProperty("nowMs").GetDouble(), Is.Zero,

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -286,7 +286,9 @@ public sealed class SelectorParityTests
         try
         {
             using var remote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            using var secondRemote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
             remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            secondRemote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
             Assert.That(remote.GetVersion().Capabilities, Does.Contain("virtual_clock_v1"));
             GuaClockControls.InstallClock(remote, step: TimeSpan.FromMilliseconds(10));
             GuaClockControls.PauseClock(remote);
@@ -297,17 +299,26 @@ public sealed class SelectorParityTests
             await Task.Delay(50);
             Assert.That(runFor.IsCompleted, Is.False, "Core pendingMs=0 must not complete run_for before the adapter publishes its frame.");
 
+            var secondRunFor = Task.Run(() => GuaClockControls.RunClockFor(secondRemote, TimeSpan.FromMilliseconds(100)));
+            Assert.That(SpinWait.SpinUntil(() => runtime.Clock.Status.PendingMilliseconds > 0, TimeSpan.FromSeconds(2)), Is.True);
             runtime.BeginFrame("fixture");
             runtime.EndFrame();
             var status = await runFor.WaitAsync(TimeSpan.FromSeconds(2));
             Assert.That(status.NowMilliseconds, Is.EqualTo(25));
+            Assert.That(secondRunFor.IsCompleted, Is.False,
+                "Run A must complete from its own operation sequence without waiting for run B, while run B remains pending.");
+
+            runtime.Clock.Advance(TimeSpan.Zero);
+            runtime.BeginFrame("fixture"); runtime.EndFrame();
+            var secondStatus = await secondRunFor.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.That(secondStatus.NowMilliseconds, Is.EqualTo(125));
 
             var fastRunFor = Task.Run(() => GuaClockControls.RunClockFor(remote, TimeSpan.FromMilliseconds(5)));
             Assert.That(SpinWait.SpinUntil(() => runtime.Clock.Status.PendingMilliseconds > 0, TimeSpan.FromSeconds(2)), Is.True);
             runtime.Clock.Advance(TimeSpan.Zero);
             runtime.BeginFrame("fixture"); runtime.EndFrame();
             var fastStatus = await fastRunFor.WaitAsync(TimeSpan.FromSeconds(2));
-            Assert.That(fastStatus.NowMilliseconds, Is.EqualTo(30),
+            Assert.That(fastStatus.NowMilliseconds, Is.EqualTo(130),
                 "The correlated completion frame may be published before the client receives clock_run_for's response.");
         }
         finally
@@ -368,6 +379,18 @@ public sealed class SelectorParityTests
             Assert.That(pause.IsCompleted, Is.False, "Pause must wait for host frame publication, not only core step consumption.");
             Native.gua_runtime_begin_frame(runtime, "fixture"); Native.gua_runtime_end_frame(runtime);
             Assert.That(await pause.WaitAsync(TimeSpan.FromSeconds(2)), Is.EqualTo(GuaClockResult.Ok));
+
+            Assert.That(Native.gua_runtime_clock_resume(runtime), Is.EqualTo(1));
+            Assert.That(Native.gua_runtime_clock_advance(runtime, 10), Is.EqualTo(1));
+            step = new NativeClockStep { StructSize = (uint)Marshal.SizeOf<NativeClockStep>() };
+            Assert.That(Native.gua_runtime_clock_consume_step(runtime, ref step), Is.EqualTo(1));
+
+            var latePause = Task.Run(remote.PauseClock);
+            await Task.Delay(30);
+            Assert.That(latePause.IsCompleted, Is.False,
+                "Pause must wait when the running step was consumed but its host frame is not published yet.");
+            Native.gua_runtime_begin_frame(runtime, "fixture"); Native.gua_runtime_end_frame(runtime);
+            Assert.That(await latePause.WaitAsync(TimeSpan.FromSeconds(2)), Is.EqualTo(GuaClockResult.Ok));
         }
         finally
         {
@@ -396,6 +419,9 @@ public sealed class SelectorParityTests
                 "{\"id\":2,\"type\":\"clock_run_for\",\"durationMs\":\"10\"}");
             var invalidInitialTime = await SendRawCommandAsync(socket,
                 "{\"id\":3,\"type\":\"clock_install\",\"initialTimeMs\":\"0\"}");
+            var outOfRange = await SendRawCommandAsync(socket,
+                "{\"id\":4,\"type\":\"clock_run_for\",\"durationMs\":1e999}");
+            var statusAfterError = await SendRawCommandAsync(socket, "{\"id\":5,\"type\":\"get_clock\"}");
             Assert.Multiple(() =>
             {
                 Assert.That(missing.GetProperty("ok").GetBoolean(), Is.False);
@@ -404,6 +430,10 @@ public sealed class SelectorParityTests
                 Assert.That(nonnumeric.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
                 Assert.That(invalidInitialTime.GetProperty("ok").GetBoolean(), Is.False);
                 Assert.That(invalidInitialTime.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
+                Assert.That(outOfRange.GetProperty("ok").GetBoolean(), Is.False);
+                Assert.That(outOfRange.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
+                Assert.That(statusAfterError.GetProperty("ok").GetBoolean(), Is.True,
+                    "An out-of-range number must not close the WebSocket connection.");
             });
         }
         finally
@@ -569,6 +599,8 @@ public sealed class SelectorParityTests
         internal static extern int gua_runtime_clock_install(nint runtime, double initialTimeMs, double stepMs);
         [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int gua_runtime_clock_advance(nint runtime, double durationMs);
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int gua_runtime_clock_resume(nint runtime);
         [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int gua_runtime_clock_consume_step(nint runtime, ref NativeClockStep step);
     }

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -17,6 +17,30 @@ namespace Gua.Selector.Tests;
 public sealed class SelectorParityTests
 {
     [Test]
+    public void LocalClockControlsDrainTheContextsOwnedClock()
+    {
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+        var callbacks = 0;
+        var ticks = new List<double>();
+        clock.Schedule(TimeSpan.FromMilliseconds(20), () => callbacks++);
+        clock.Tick += delta => ticks.Add(delta.TotalMilliseconds);
+
+        GuaClockControls.InstallClock(context, step: TimeSpan.FromMilliseconds(10));
+        GuaClockControls.PauseClock(context);
+        var status = GuaClockControls.RunClockFor(context, TimeSpan.FromMilliseconds(25));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.NowMilliseconds, Is.EqualTo(25));
+            Assert.That(status.PendingMilliseconds, Is.Zero);
+            Assert.That(callbacks, Is.EqualTo(1));
+            Assert.That(ticks, Is.EqualTo(new[] { 10.0, 10.0, 5.0 }));
+            Assert.That(context.Clock, Is.SameAs(clock));
+        });
+    }
+
+    [Test]
     public void SchedulesCreatedBeforeInstallationBindToTheFirstClockGeneration()
     {
         using var context = new GuaContext();

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -38,6 +38,16 @@ public sealed class SelectorParityTests
             Assert.That(ticks, Is.EqualTo(new[] { 10.0, 10.0, 5.0 }));
             Assert.That(context.Clock, Is.SameAs(clock));
         });
+
+        Assert.That(context.Reset().Result, Is.EqualTo(GuaResetResult.Succeeded));
+        var resetStatus = GuaClockControls.GetClockStatus(context);
+        Assert.Multiple(() =>
+        {
+            Assert.That(resetStatus.Installed, Is.False);
+            Assert.That(resetStatus.NowMilliseconds, Is.Zero);
+            Assert.That(resetStatus.PendingMilliseconds, Is.Zero);
+            Assert.That(resetStatus.DefaultStepMilliseconds, Is.EqualTo(1000.0 / 60.0));
+        });
     }
 
     [Test]

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -385,12 +385,14 @@ public sealed class SelectorParityTests
             step = new NativeClockStep { StructSize = (uint)Marshal.SizeOf<NativeClockStep>() };
             Assert.That(Native.gua_runtime_clock_consume_step(runtime, ref step), Is.EqualTo(1));
 
-            var latePause = Task.Run(remote.PauseClock);
-            await Task.Delay(30);
-            Assert.That(latePause.IsCompleted, Is.False,
-                "Pause must wait when the running step was consumed but its host frame is not published yet.");
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+            var stopwatch = Stopwatch.StartNew();
+            var latePause = GuaClockControls.PauseClockAsync(remote, cancellationToken: cancellation.Token);
+            Assert.That(async () => await latePause, Throws.InstanceOf<OperationCanceledException>());
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(1)),
+                "Asynchronous pause must observe cancellation while the consumed running step awaits its host frame.");
             Native.gua_runtime_begin_frame(runtime, "fixture"); Native.gua_runtime_end_frame(runtime);
-            Assert.That(await latePause.WaitAsync(TimeSpan.FromSeconds(2)), Is.EqualTo(GuaClockResult.Ok));
+            await Task.Delay(30);
         }
         finally
         {

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -17,6 +17,43 @@ namespace Gua.Selector.Tests;
 public sealed class SelectorParityTests
 {
     [Test]
+    public void SchedulesCreatedBeforeInstallationBindToTheFirstClockGeneration()
+    {
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+        var coreCallbackCount = 0;
+        clock.Schedule(TimeSpan.FromMilliseconds(20), () => coreCallbackCount++);
+        clock.Install(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(10));
+        clock.Pause();
+        clock.RunFor(TimeSpan.FromMilliseconds(25));
+
+        using var runtime = new GuaRuntime();
+        var runtimeCallbackCount = 0;
+        runtime.Clock.Schedule(TimeSpan.FromMilliseconds(20), () => runtimeCallbackCount++);
+        runtime.Clock.Install(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(10));
+        runtime.Clock.Pause();
+        runtime.Clock.RunFor(TimeSpan.FromMilliseconds(25));
+
+        using var resetContext = new GuaContext();
+        var resetClock = new GuaClock(resetContext);
+        var staleCallbackCount = 0;
+        resetClock.Schedule(TimeSpan.FromMilliseconds(20), () => staleCallbackCount++);
+        Assert.That(resetContext.Reset().Result, Is.EqualTo(GuaResetResult.Succeeded));
+        resetClock.Install(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(10));
+        resetClock.Pause();
+        resetClock.RunFor(TimeSpan.FromMilliseconds(25));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(coreCallbackCount, Is.EqualTo(1));
+            Assert.That(clock.Status.NowMilliseconds, Is.EqualTo(125));
+            Assert.That(runtimeCallbackCount, Is.EqualTo(1));
+            Assert.That(runtime.Clock.Status.NowMilliseconds, Is.EqualTo(125));
+            Assert.That(staleCallbackCount, Is.Zero);
+        });
+    }
+
+    [Test]
     public void ClockCallbacksCanRunNestedAdvancesWithoutReenteringTheSameSchedule()
     {
         using var context = new GuaContext();

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -87,6 +87,57 @@ public sealed class SelectorParityTests
     }
 
     [Test]
+    public void ClockResetInsideRepeatingCallbackDropsTheStaleGeneration()
+    {
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+        clock.Install(step: TimeSpan.FromMilliseconds(10));
+        clock.Pause();
+        var callbacks = 0;
+        clock.Schedule(TimeSpan.FromMilliseconds(1), () =>
+        {
+            callbacks++;
+            context.Reset();
+        }, TimeSpan.FromMilliseconds(1));
+
+        clock.RunFor(TimeSpan.FromMilliseconds(10), TimeSpan.FromMilliseconds(10));
+        Assert.That(callbacks, Is.EqualTo(1));
+        clock.Install(step: TimeSpan.FromMilliseconds(10));
+        clock.Pause();
+        clock.RunFor(TimeSpan.FromMilliseconds(10));
+        Assert.That(callbacks, Is.EqualTo(1));
+
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.BeginFrame("fixture"); runtime.EndFrame();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var remote = new GuaWebSocketContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
+            runtime.Clock.Pause();
+            var runtimeCallbacks = 0;
+            runtime.Clock.Schedule(TimeSpan.FromMilliseconds(1), () =>
+            {
+                runtimeCallbacks++;
+                remote.Reset();
+            }, TimeSpan.FromMilliseconds(1));
+
+            runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10), TimeSpan.FromMilliseconds(10));
+            Assert.That(runtimeCallbacks, Is.EqualTo(1));
+            runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
+            runtime.Clock.Pause();
+            runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10));
+            Assert.That(runtimeCallbacks, Is.EqualTo(1));
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
+        }
+    }
+
+    [Test]
     public void ClockExecutionLimitRetiresRemainingSchedules()
     {
         using var context = new GuaContext();

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -15,6 +15,39 @@ namespace Gua.Selector.Tests;
 public sealed class SelectorParityTests
 {
     [Test]
+    public void ClockCallbacksCanRunNestedAdvancesWithoutReenteringTheSameSchedule()
+    {
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+        clock.Install(step: TimeSpan.FromMilliseconds(10));
+        clock.Pause();
+        var callbacks = 0;
+        clock.Schedule(TimeSpan.FromMilliseconds(10), () =>
+        {
+            callbacks++;
+            clock.RunFor(TimeSpan.FromMilliseconds(10));
+        });
+        clock.RunFor(TimeSpan.FromMilliseconds(10));
+        Assert.Multiple(() =>
+        {
+            Assert.That(callbacks, Is.EqualTo(1));
+            Assert.That(clock.Status.NowMilliseconds, Is.EqualTo(20));
+        });
+
+        using var runtime = new GuaRuntime();
+        runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
+        runtime.Clock.Pause();
+        var runtimeCallbacks = 0;
+        runtime.Clock.Schedule(TimeSpan.FromMilliseconds(10), () =>
+        {
+            runtimeCallbacks++;
+            runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10));
+        });
+        runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10));
+        Assert.That(runtimeCallbacks, Is.EqualTo(1));
+    }
+
+    [Test]
     public void RemoteTreeDeserializesProtocolBoundsAndNestedState()
     {
         const string json = """
@@ -262,10 +295,78 @@ public sealed class SelectorParityTests
             runtime.EndFrame();
             var status = await runFor.WaitAsync(TimeSpan.FromSeconds(2));
             Assert.That(status.NowMilliseconds, Is.EqualTo(25));
+
+            var fastRunFor = Task.Run(() => GuaClockControls.RunClockFor(remote, TimeSpan.FromMilliseconds(5)));
+            Assert.That(SpinWait.SpinUntil(() => runtime.Clock.Status.PendingMilliseconds > 0, TimeSpan.FromSeconds(2)), Is.True);
+            runtime.Clock.Advance(TimeSpan.Zero);
+            runtime.BeginFrame("fixture"); runtime.EndFrame();
+            var fastStatus = await fastRunFor.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.That(fastStatus.NowMilliseconds, Is.EqualTo(30),
+                "The correlated completion frame may be published before the client receives clock_run_for's response.");
         }
         finally
         {
             runtime.StopInspectorBridge();
+        }
+    }
+
+    [Test]
+    public async Task RemoteRunForRejectsExplicitZeroStepsAndHonorsCancellation()
+    {
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.EnableVirtualClockAdapter();
+        runtime.BeginFrame("fixture"); runtime.EndFrame();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var remote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            Assert.That(() => remote.InstallClock(step: TimeSpan.Zero), Throws.InvalidOperationException);
+            remote.InstallClock(step: TimeSpan.FromMilliseconds(10));
+            remote.PauseClock();
+            Assert.That(() => remote.RunClockFor(TimeSpan.FromMilliseconds(10), TimeSpan.Zero), Throws.InvalidOperationException);
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+            var stopwatch = Stopwatch.StartNew();
+            Assert.That(async () =>
+                await GuaClockControls.RunClockForAsync(remote, TimeSpan.FromMilliseconds(25), cancellationToken: cancellation.Token),
+                Throws.InstanceOf<OperationCanceledException>());
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(1)));
+        }
+        finally { runtime.StopInspectorBridge(); }
+    }
+
+    [Test]
+    public async Task RemotePauseWaitsForAnInFlightRunningStepAndItsHostFrame()
+    {
+        var port = ReservePort();
+        var runtime = Native.gua_runtime_create();
+        Assert.That(runtime, Is.Not.EqualTo(nint.Zero));
+        try
+        {
+            Native.gua_runtime_set_virtual_clock_enabled(runtime, 1);
+            Native.gua_runtime_begin_frame(runtime, "fixture"); Native.gua_runtime_end_frame(runtime);
+            Assert.That(Native.gua_runtime_clock_install(runtime, 0, 10), Is.EqualTo(1));
+            Assert.That(Native.gua_runtime_clock_advance(runtime, 10), Is.EqualTo(1));
+            Assert.That(Native.gua_runtime_start_inspector_bridge(runtime, port), Is.EqualTo(1));
+            using var remote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+
+            var pause = Task.Run(remote.PauseClock);
+            await Task.Delay(30);
+            Assert.That(pause.IsCompleted, Is.False);
+            var step = new NativeClockStep { StructSize = (uint)Marshal.SizeOf<NativeClockStep>() };
+            Assert.That(Native.gua_runtime_clock_consume_step(runtime, ref step), Is.EqualTo(1));
+            await Task.Delay(30);
+            Assert.That(pause.IsCompleted, Is.False, "Pause must wait for host frame publication, not only core step consumption.");
+            Native.gua_runtime_begin_frame(runtime, "fixture"); Native.gua_runtime_end_frame(runtime);
+            Assert.That(await pause.WaitAsync(TimeSpan.FromSeconds(2)), Is.EqualTo(GuaClockResult.Ok));
+        }
+        finally
+        {
+            Native.gua_runtime_stop_inspector_bridge(runtime);
+            Native.gua_runtime_destroy(runtime);
         }
     }
 
@@ -397,5 +498,22 @@ public sealed class SelectorParityTests
         internal static extern int gua_runtime_start_inspector_bridge(nint runtime, int port);
         [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void gua_runtime_stop_inspector_bridge(nint runtime);
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void gua_runtime_set_virtual_clock_enabled(nint runtime, int enabled);
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int gua_runtime_clock_install(nint runtime, double initialTimeMs, double stepMs);
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int gua_runtime_clock_advance(nint runtime, double durationMs);
+        [DllImport("gua_runtime", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int gua_runtime_clock_consume_step(nint runtime, ref NativeClockStep step);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeClockStep
+    {
+        public uint StructSize;
+        public double DeltaMs;
+        public int FinalStep;
+        public ulong Generation;
     }
 }

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -165,6 +165,83 @@ public sealed class SelectorParityTests
     }
 
     [Test]
+    public void RuntimeClockIsolatesCallbackFailuresAndPurgesInactiveSchedules()
+    {
+        using var runtime = new GuaRuntime();
+        runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
+        runtime.Clock.Pause();
+        var callbacks = new List<string>();
+        Exception? callbackFailure = null;
+        runtime.Clock.CallbackFailed += error => callbackFailure = error;
+        runtime.Clock.Schedule(TimeSpan.FromMilliseconds(10), () => throw new InvalidOperationException("boom"));
+        runtime.Clock.Schedule(TimeSpan.FromMilliseconds(10), () => callbacks.Add("second"));
+        runtime.Clock.Tick += _ => callbacks.Add("tick");
+
+        Assert.That(() => runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10)), Throws.Nothing);
+        Assert.Multiple(() =>
+        {
+            Assert.That(callbackFailure, Is.TypeOf<InvalidOperationException>());
+            Assert.That(callbacks, Is.EqualTo(new[] { "second", "tick" }));
+            Assert.That(ScheduledCount(runtime.Clock), Is.Zero);
+        });
+
+        var cancelled = runtime.Clock.Schedule(TimeSpan.FromSeconds(1), () => callbacks.Add("cancelled"));
+        Assert.That(ScheduledCount(runtime.Clock), Is.EqualTo(1));
+        cancelled.Dispose();
+        Assert.That(ScheduledCount(runtime.Clock), Is.Zero,
+            "Disposal must release the callback without waiting for another clock step.");
+
+        var port = ReservePort();
+        runtime.BeginFrame("fixture"); runtime.EndFrame();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var remote = new GuaWebSocketContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            runtime.Clock.Schedule(TimeSpan.FromSeconds(1), () => callbacks.Add("stale"));
+            remote.Reset();
+            runtime.Clock.Advance(TimeSpan.Zero);
+            Assert.That(ScheduledCount(runtime.Clock), Is.Zero,
+                "An uninstalled clock must purge schedules from the reset generation.");
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
+        }
+    }
+
+    [Test]
+    public async Task RuntimeClockPublishesSubTimeSpanTickPrecision()
+    {
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.EnableVirtualClockAdapter();
+        runtime.BeginFrame("fixture"); runtime.EndFrame();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            var preciseTicks = new List<double>();
+            runtime.Clock.Tick += tick => preciseTicks.Add(tick.TotalMilliseconds);
+            using var socket = new ClientWebSocket();
+            await socket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}"), CancellationToken.None);
+            await SendRawCommandAsync(socket,
+                "{\"id\":1,\"type\":\"clock_install\",\"initialTimeMs\":0,\"stepMs\":0.00001}");
+            await SendRawCommandAsync(socket, "{\"id\":2,\"type\":\"clock_pause\"}");
+            await SendRawCommandAsync(socket,
+                "{\"id\":3,\"type\":\"clock_run_for\",\"durationMs\":0.00002,\"stepMs\":0.00001}");
+
+            runtime.Clock.Drain();
+
+            Assert.That(preciseTicks, Is.EqualTo(new[] { 0.00001, 0.00001 }));
+            Assert.That(runtime.Clock.Status.NowMilliseconds, Is.EqualTo(0.00002).Within(1e-12));
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
+        }
+    }
+
+    [Test]
     public void RemoteTreeDeserializesProtocolBoundsAndNestedState()
     {
         const string json = """
@@ -710,6 +787,14 @@ public sealed class SelectorParityTests
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
         listener.Stop();
         return port;
+    }
+
+    private static int ScheduledCount(object clock)
+    {
+        var field = clock.GetType().GetField("scheduled", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Clock scheduler storage was not found.");
+        return ((System.Collections.ICollection)(field.GetValue(clock)
+            ?? throw new InvalidOperationException("Clock scheduler storage was null."))).Count;
     }
 
     private static async Task<JsonElement> SendRawCommandAsync(ClientWebSocket socket, string json, int? expectedResponseId = null)

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -612,6 +612,39 @@ public sealed class SelectorParityTests
     }
 
     [Test]
+    public async Task SharedRemotePauseUsesTheBridgeResponseDeadline()
+    {
+        var port = ReservePort();
+        var runtime = Native.gua_runtime_create();
+        Assert.That(runtime, Is.Not.EqualTo(nint.Zero));
+        try
+        {
+            Native.gua_runtime_set_virtual_clock_enabled(runtime, 1);
+            Native.gua_runtime_begin_frame(runtime, "fixture"); Native.gua_runtime_end_frame(runtime);
+            Assert.That(Native.gua_runtime_clock_install(runtime, 0, 10), Is.EqualTo(1));
+            Assert.That(Native.gua_runtime_clock_advance(runtime, 10), Is.EqualTo(1));
+            Assert.That(Native.gua_runtime_start_inspector_bridge(runtime, port), Is.EqualTo(1));
+            using var remote = new GuaWebSocketContext($"ws://127.0.0.1:{port}", TimeSpan.FromMilliseconds(500));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+
+            var pause = Task.Run(remote.PauseClock);
+            await Task.Delay(600);
+            Assert.That(pause.IsCompleted, Is.False,
+                "Pause must use the bridge's response deadline instead of the shorter general request timeout.");
+
+            var step = new NativeClockStep { StructSize = (uint)Marshal.SizeOf<NativeClockStep>() };
+            Assert.That(Native.gua_runtime_clock_consume_step(runtime, ref step), Is.EqualTo(1));
+            Native.gua_runtime_begin_frame(runtime, "fixture"); Native.gua_runtime_end_frame(runtime);
+            Assert.That(await pause.WaitAsync(TimeSpan.FromSeconds(2)), Is.EqualTo(GuaClockResult.Ok));
+        }
+        finally
+        {
+            Native.gua_runtime_stop_inspector_bridge(runtime);
+            Native.gua_runtime_destroy(runtime);
+        }
+    }
+
+    [Test]
     public async Task StoppingBridgeCancelsAnInFlightRemotePauseWait()
     {
         var port = ReservePort();

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -1148,6 +1148,58 @@ public sealed class SelectorParityTests
         }
     }
 
+    [Test]
+    public async Task RuntimeRunForUsesTheExactInstalledDefaultStepWhenOmitted()
+    {
+        const double installedStepMs = 0.123456789;
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.EnableVirtualClockAdapter();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var socket = new ClientWebSocket();
+            await socket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}"), CancellationToken.None);
+            var install = await SendRawCommandAsync(socket,
+                $"{{\"id\":1,\"type\":\"clock_install\",\"initialTimeMs\":0,\"stepMs\":{installedStepMs:R}}}");
+            var pause = await SendRawCommandAsync(socket, "{\"id\":2,\"type\":\"clock_pause\"}");
+            Assert.That(install.GetProperty("ok").GetBoolean(), Is.True);
+            Assert.That(pause.GetProperty("ok").GetBoolean(), Is.True);
+
+            var ticks = new List<double>();
+            runtime.Clock.Tick += delta => ticks.Add(delta.TotalMilliseconds);
+            runtime.Clock.RunFor(TimeSpan.FromMilliseconds(0.3));
+
+            Assert.That(ticks, Is.Not.Empty);
+            Assert.That(ticks[0], Is.EqualTo(installedStepMs),
+                "An omitted step must pass the installed double directly instead of round-tripping through TimeSpan.");
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
+        }
+    }
+
+    [Test]
+    public async Task AsyncClockControlsRequireOnlyTheAsyncStatusContract()
+    {
+        var context = new AsyncOnlyClockContext();
+        Assert.That(context, Is.Not.InstanceOf<IGuaClockContext>());
+
+        var installed = await GuaClockControls.InstallClockAsync(context, step: TimeSpan.FromMilliseconds(10));
+        var paused = await GuaClockControls.PauseClockAsync(context);
+        var advanced = await GuaClockControls.RunClockForAsync(context, TimeSpan.FromMilliseconds(25));
+        var resumed = await GuaClockControls.ResumeClockAsync(context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(installed.Installed, Is.True);
+            Assert.That(paused.Paused, Is.True);
+            Assert.That(advanced.NowMilliseconds, Is.EqualTo(25));
+            Assert.That(resumed.Paused, Is.False);
+        });
+    }
+
     private static int ScheduledCount(object clock)
     {
         var field = clock.GetType().GetField("scheduled", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
@@ -1181,6 +1233,51 @@ public sealed class SelectorParityTests
             if (document.RootElement.TryGetProperty("id", out var id) && id.GetInt32() == expectedId.Value)
                 return document.RootElement.Clone();
         }
+    }
+
+    private sealed class AsyncOnlyClockContext : IGuaContext, IGuaAsyncClockContext
+    {
+        private GuaClockStatus status = new(false, false, 0, 1000.0 / 60.0, 0, 0);
+
+        public GuaClockStatus GetClockStatus() => status;
+        public Task<GuaClockResult> InstallClockAsync(TimeSpan? initialTime = null, TimeSpan? step = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            status = new(true, false, initialTime?.TotalMilliseconds ?? 0.0,
+                step?.TotalMilliseconds ?? 1000.0 / 60.0, 0, status.Generation + 1);
+            return Task.FromResult(GuaClockResult.Ok);
+        }
+        public Task<GuaClockResult> PauseClockAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            status = status with { Paused = true };
+            return Task.FromResult(GuaClockResult.Ok);
+        }
+        public Task<GuaClockResult> RunClockForAsync(TimeSpan duration, TimeSpan? step = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            status = status with { NowMilliseconds = status.NowMilliseconds + duration.TotalMilliseconds };
+            return Task.FromResult(GuaClockResult.Ok);
+        }
+        public Task<GuaClockResult> ResumeClockAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            status = status with { Paused = false };
+            return Task.FromResult(GuaClockResult.Ok);
+        }
+
+        public string GetUiTreeJson() => "{}";
+        public GuaNodeState GetNodeState(string id) => throw new NotSupportedException();
+        public string FindNodeById(string id) => throw new NotSupportedException();
+        public string FindNodeByRole(string role, string? name = null) => throw new NotSupportedException();
+        public string FindNodeByText(string text) => throw new NotSupportedException();
+        public bool EnqueueClick(string id) => throw new NotSupportedException();
+        public GuaActionError EnqueueAction(GuaActionRequest request, out ulong requestId) => throw new NotSupportedException();
+        public bool TryPollActionEvent(out GuaActionEvent e) => throw new NotSupportedException();
+        public bool TryPollActionEvent(ulong requestId, out GuaActionEvent e) => throw new NotSupportedException();
+        public bool TryPollEvent(out GuaEvent e) => throw new NotSupportedException();
     }
 
     private static class Native

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -222,6 +222,61 @@ public sealed class SelectorParityTests
     }
 
     [Test]
+    public void TickResetStopsRemainingSubscribersFromReceivingTheStaleStep()
+    {
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+        clock.Install(step: TimeSpan.FromMilliseconds(10));
+        clock.Pause();
+        var coreResetTicks = 0;
+        var coreStaleTicks = 0;
+        clock.Tick += _ =>
+        {
+            coreResetTicks++;
+            context.Reset();
+        };
+        clock.Tick += _ => coreStaleTicks++;
+
+        clock.RunFor(TimeSpan.FromMilliseconds(10));
+        Assert.Multiple(() =>
+        {
+            Assert.That(coreResetTicks, Is.EqualTo(1));
+            Assert.That(coreStaleTicks, Is.Zero);
+        });
+
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.BeginFrame("fixture"); runtime.EndFrame();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var remote = new GuaWebSocketContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
+            runtime.Clock.Pause();
+            var runtimeResetTicks = 0;
+            var runtimeStaleTicks = 0;
+            runtime.Clock.Tick += _ =>
+            {
+                runtimeResetTicks++;
+                remote.Reset();
+            };
+            runtime.Clock.Tick += _ => runtimeStaleTicks++;
+
+            runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10));
+            Assert.Multiple(() =>
+            {
+                Assert.That(runtimeResetTicks, Is.EqualTo(1));
+                Assert.That(runtimeStaleTicks, Is.Zero);
+            });
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
+        }
+    }
+
+    [Test]
     public void ClockExecutionLimitRetiresRemainingSchedules()
     {
         using var context = new GuaContext();

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -439,6 +439,36 @@ public sealed class SelectorParityTests
     }
 
     [Test]
+    public async Task RemoteContextsSerializeConcurrentAsyncWebSocketRequests()
+    {
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.EnableVirtualClockAdapter();
+        runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
+        runtime.Clock.Pause();
+        runtime.BeginFrame("fixture"); runtime.EndFrame();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var godotRemote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            godotRemote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            var godotRequests = Enumerable.Range(0, 8).Select(_ => godotRemote.PauseClockAsync()).ToArray();
+            Assert.That(await Task.WhenAll(godotRequests).WaitAsync(TimeSpan.FromSeconds(2)),
+                Is.All.EqualTo(GuaClockResult.Ok));
+
+            using var sharedRemote = new GuaWebSocketContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            sharedRemote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            var sharedRequests = Enumerable.Range(0, 8).Select(_ => sharedRemote.PauseClockAsync()).ToArray();
+            Assert.That(await Task.WhenAll(sharedRequests).WaitAsync(TimeSpan.FromSeconds(2)),
+                Is.All.EqualTo(GuaClockResult.Ok));
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
+        }
+    }
+
+    [Test]
     public async Task RemoteClockRejectsMissingDurationAndNonnumericFields()
     {
         var port = ReservePort();

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -1032,6 +1032,50 @@ public sealed class SelectorParityTests
         }
     }
 
+    [Test]
+    public async Task RuntimeClockRejectsSchedulesThatCannotAdvanceRepresentableDeadlines()
+    {
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.EnableVirtualClockAdapter();
+        var callbacks = 0;
+        var failures = new List<Exception>();
+        runtime.Clock.CallbackFailed += failures.Add;
+        runtime.Clock.Schedule(TimeSpan.Zero, () => callbacks++, TimeSpan.FromMilliseconds(1));
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var socket = new ClientWebSocket();
+            await socket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}"), CancellationToken.None);
+            var install = await SendRawCommandAsync(socket,
+                "{\"id\":1,\"type\":\"clock_install\",\"initialTimeMs\":1e16,\"stepMs\":2}");
+            Assert.That(install.GetProperty("ok").GetBoolean(), Is.True);
+
+            var intervalError = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                runtime.Clock.Schedule(TimeSpan.Zero, () => callbacks++, TimeSpan.FromMilliseconds(1)));
+            Assert.That(intervalError!.ParamName, Is.EqualTo("interval"));
+            var delayError = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                runtime.Clock.Schedule(TimeSpan.FromMilliseconds(1), () => callbacks++));
+            Assert.That(delayError!.ParamName, Is.EqualTo("delay"));
+
+            using var valid = runtime.Clock.Schedule(TimeSpan.Zero, () => callbacks++, TimeSpan.FromMilliseconds(2));
+            valid.Dispose();
+            Assert.That(() => runtime.Clock.Advance(TimeSpan.FromMilliseconds(2)), Throws.Nothing);
+            Assert.Multiple(() =>
+            {
+                Assert.That(callbacks, Is.Zero);
+                Assert.That(ScheduledCount(runtime.Clock), Is.Zero,
+                    "A pre-install interval that cannot advance the installed timeline must be retired.");
+                Assert.That(failures, Has.Count.EqualTo(1));
+                Assert.That(failures[0], Is.TypeOf<ArgumentOutOfRangeException>());
+            });
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
+        }
+    }
+
     private static int ScheduledCount(object clock)
     {
         var field = clock.GetType().GetField("scheduled", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Sockets;
+using System.Net.WebSockets;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 using System.Diagnostics;
 using Gua.Core;
@@ -375,6 +377,42 @@ public sealed class SelectorParityTests
     }
 
     [Test]
+    public async Task RemoteClockRejectsMissingDurationAndNonnumericFields()
+    {
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.EnableVirtualClockAdapter();
+        runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
+        runtime.Clock.Pause();
+        runtime.BeginFrame("fixture");
+        runtime.EndFrame();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var socket = new ClientWebSocket();
+            await socket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}"), CancellationToken.None);
+            var missing = await SendRawCommandAsync(socket, "{\"id\":1,\"type\":\"clock_run_for\"}");
+            var nonnumeric = await SendRawCommandAsync(socket,
+                "{\"id\":2,\"type\":\"clock_run_for\",\"durationMs\":\"10\"}");
+            var invalidInitialTime = await SendRawCommandAsync(socket,
+                "{\"id\":3,\"type\":\"clock_install\",\"initialTimeMs\":\"0\"}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(missing.GetProperty("ok").GetBoolean(), Is.False);
+                Assert.That(missing.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
+                Assert.That(nonnumeric.GetProperty("ok").GetBoolean(), Is.False);
+                Assert.That(nonnumeric.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
+                Assert.That(invalidInitialTime.GetProperty("ok").GetBoolean(), Is.False);
+                Assert.That(invalidInitialTime.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
+            });
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
+        }
+    }
+
+    [Test]
     public void RemoteResetRejectsStaleEpochAndKeepsTheConnection()
     {
         var port = ReservePort();
@@ -478,6 +516,29 @@ public sealed class SelectorParityTests
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
         listener.Stop();
         return port;
+    }
+
+    private static async Task<JsonElement> SendRawCommandAsync(ClientWebSocket socket, string json)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var requestDocument = JsonDocument.Parse(json);
+        var expectedId = requestDocument.RootElement.GetProperty("id").GetInt32();
+        var request = Encoding.UTF8.GetBytes(json);
+        await socket.SendAsync(new ArraySegment<byte>(request), WebSocketMessageType.Text, true, timeout.Token);
+        var buffer = new byte[4096];
+        while (true)
+        {
+            using var response = new MemoryStream();
+            WebSocketReceiveResult received;
+            do
+            {
+                received = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), timeout.Token);
+                response.Write(buffer, 0, received.Count);
+            } while (!received.EndOfMessage);
+            using var document = JsonDocument.Parse(response.ToArray());
+            if (document.RootElement.TryGetProperty("id", out var id) && id.GetInt32() == expectedId)
+                return document.RootElement.Clone();
+        }
     }
 
     private static class Native

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -236,6 +236,10 @@ public sealed class SelectorParityTests
                 Assert.That(localVersion.Capabilities, Does.Contain("virtual_clock_v1"));
             });
             Assert.That(remoteVersion.Capabilities, Does.Contain("version_v1"));
+            Assert.That(() => remote.GetClockStatus(),
+                Throws.InvalidOperationException.With.Message.Contains("unsupported"));
+            Assert.That(() => remote.InstallClock(),
+                Throws.InvalidOperationException.With.Message.Contains("unsupported"));
 
             using var sharedRemote = new GuaWebSocketContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
             sharedRemote.WaitUntilAvailable(TimeSpan.FromSeconds(2));

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -199,7 +199,8 @@ public sealed class SelectorParityTests
                 Assert.That(remoteVersion.ProtocolSchemaVersion, Is.EqualTo(localVersion.ProtocolSchemaVersion));
                 Assert.That(remoteVersion.AbiVersion, Is.EqualTo(localVersion.AbiVersion));
                 Assert.That(remoteVersion.BuildId, Is.EqualTo(localVersion.BuildId));
-                Assert.That(remoteVersion.Capabilities, Is.EqualTo(localVersion.Capabilities));
+                Assert.That(remoteVersion.Capabilities, Does.Not.Contain("virtual_clock_v1"));
+                Assert.That(localVersion.Capabilities, Does.Contain("virtual_clock_v1"));
             });
             Assert.That(remoteVersion.Capabilities, Does.Contain("version_v1"));
 
@@ -231,6 +232,40 @@ public sealed class SelectorParityTests
         {
             Native.gua_runtime_stop_inspector_bridge(runtime);
             Native.gua_runtime_destroy(runtime);
+        }
+    }
+
+    [Test]
+    public async Task GodotRemoteClockWaitsForTheHostFrameAfterCoreStepsAreConsumed()
+    {
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.EnableVirtualClockAdapter();
+        runtime.BeginFrame("fixture");
+        runtime.EndFrame();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var remote = new GuaRemoteContext($"ws://127.0.0.1:{port}", TimeSpan.FromSeconds(2));
+            remote.WaitUntilAvailable(TimeSpan.FromSeconds(2));
+            Assert.That(remote.GetVersion().Capabilities, Does.Contain("virtual_clock_v1"));
+            GuaClockControls.InstallClock(remote, step: TimeSpan.FromMilliseconds(10));
+            GuaClockControls.PauseClock(remote);
+
+            var runFor = Task.Run(() => GuaClockControls.RunClockFor(remote, TimeSpan.FromMilliseconds(25)));
+            Assert.That(SpinWait.SpinUntil(() => runtime.Clock.Status.PendingMilliseconds > 0, TimeSpan.FromSeconds(2)), Is.True);
+            runtime.Clock.Advance(TimeSpan.Zero);
+            await Task.Delay(50);
+            Assert.That(runFor.IsCompleted, Is.False, "Core pendingMs=0 must not complete run_for before the adapter publishes its frame.");
+
+            runtime.BeginFrame("fixture");
+            runtime.EndFrame();
+            var status = await runFor.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.That(status.NowMilliseconds, Is.EqualTo(25));
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
         }
     }
 

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -65,6 +65,18 @@ public sealed class SelectorParityTests
         Assert.That(clock.Status.Generation, Is.EqualTo(explicitGeneration));
     }
 
+    [Test]
+    public void ContextRejectsASecondManagedClock()
+    {
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+
+        Assert.That(context.Clock, Is.SameAs(clock));
+        Assert.That(() => new GuaClock(context),
+            Throws.InvalidOperationException.With.Message.Contains("only one GuaClock"));
+        Assert.That(context.Clock, Is.SameAs(clock));
+    }
+
     private static WeakReference ScheduleCapturedCallback(GuaClock clock)
     {
         var captured = new object();
@@ -962,11 +974,57 @@ public sealed class SelectorParityTests
             Assert.That(currentExplicit.GetProperty("ok").GetBoolean(), Is.True);
             Assert.That(afterCurrentExplicit.GetProperty("result").GetProperty("installed").GetBoolean(), Is.True);
 
+            var fractionalVersion = await SendRawCommandAsync(socket,
+                "{\"id\":5,\"type\":\"reset_context\",\"expectedSessionEpoch\":3,\"flags\":15,\"flagsVersion\":1.5}");
+            var afterFractionalVersion = await SendRawCommandAsync(socket, "{\"id\":6,\"type\":\"get_clock\"}");
+            Assert.That(fractionalVersion.GetProperty("ok").GetBoolean(), Is.False);
+            Assert.That(afterFractionalVersion.GetProperty("result").GetProperty("installed").GetBoolean(), Is.True,
+                "A structurally invalid flagsVersion must not partially reset the session.");
+
             var legacyAll = await SendRawCommandAsync(socket,
-                "{\"id\":5,\"type\":\"reset_context\",\"expectedSessionEpoch\":3,\"flags\":63}");
-            var afterLegacyAll = await SendRawCommandAsync(socket, "{\"id\":6,\"type\":\"get_clock\"}");
+                "{\"id\":7,\"type\":\"reset_context\",\"expectedSessionEpoch\":3,\"flags\":63}");
+            var afterLegacyAll = await SendRawCommandAsync(socket, "{\"id\":8,\"type\":\"get_clock\"}");
             Assert.That(legacyAll.GetProperty("ok").GetBoolean(), Is.True);
             Assert.That(afterLegacyAll.GetProperty("result").GetProperty("installed").GetBoolean(), Is.False);
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
+        }
+    }
+
+    [Test]
+    public async Task AutomaticClockExecutionLimitDoesNotStopHostFrames()
+    {
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.EnableVirtualClockAdapter();
+        runtime.BeginFrame("before-limit"); runtime.EndFrame();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var socket = new ClientWebSocket();
+            await socket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}"), CancellationToken.None);
+            var install = await SendRawCommandAsync(socket,
+                "{\"id\":1,\"type\":\"clock_install\",\"initialTimeMs\":0,\"stepMs\":1e-9}");
+            Assert.That(install.GetProperty("ok").GetBoolean(), Is.True);
+
+            var failures = new List<Exception>();
+            runtime.Clock.CallbackFailed += failures.Add;
+            Assert.That(() => runtime.Clock.Advance(TimeSpan.FromMilliseconds(16)), Throws.Nothing);
+            Assert.That(() =>
+            {
+                runtime.BeginFrame("after-limit");
+                runtime.EndFrame();
+            }, Throws.Nothing);
+            Assert.That(runtime.GetUiTreeJson(), Does.Contain("after-limit"));
+            Assert.That(runtime.Clock.Status.NowMilliseconds, Is.Zero);
+            Assert.That(failures, Has.Count.EqualTo(1));
+            Assert.That(failures[0].Message, Does.Contain("execution_limit"));
+
+            Assert.That(() => runtime.Clock.Advance(TimeSpan.FromMilliseconds(16)), Throws.Nothing);
+            Assert.That(failures, Has.Count.EqualTo(1),
+                "The same invalid running-clock configuration should be diagnosed once without flooding every host frame.");
         }
         finally
         {

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -171,16 +171,19 @@ public sealed class SelectorParityTests
         runtime.Clock.Install(step: TimeSpan.FromMilliseconds(10));
         runtime.Clock.Pause();
         var callbacks = new List<string>();
-        Exception? callbackFailure = null;
-        runtime.Clock.CallbackFailed += error => callbackFailure = error;
+        var callbackFailures = new List<Exception>();
+        runtime.Clock.CallbackFailed += error => callbackFailures.Add(error);
         runtime.Clock.Schedule(TimeSpan.FromMilliseconds(10), () => throw new InvalidOperationException("boom"));
         runtime.Clock.Schedule(TimeSpan.FromMilliseconds(10), () => callbacks.Add("second"));
+        runtime.Clock.Tick += _ => throw new ApplicationException("tick-boom");
         runtime.Clock.Tick += _ => callbacks.Add("tick");
 
         Assert.That(() => runtime.Clock.RunFor(TimeSpan.FromMilliseconds(10)), Throws.Nothing);
         Assert.Multiple(() =>
         {
-            Assert.That(callbackFailure, Is.TypeOf<InvalidOperationException>());
+            Assert.That(callbackFailures, Has.Count.EqualTo(2));
+            Assert.That(callbackFailures[0], Is.TypeOf<InvalidOperationException>());
+            Assert.That(callbackFailures[1], Is.TypeOf<ApplicationException>());
             Assert.That(callbacks, Is.EqualTo(new[] { "second", "tick" }));
             Assert.That(ScheduledCount(runtime.Clock), Is.Zero);
         });

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -39,7 +39,11 @@ public sealed class SelectorParityTests
             Assert.That(context.Clock, Is.SameAs(clock));
         });
 
+        var captured = ScheduleCapturedCallback(clock);
         Assert.That(context.Reset().Result, Is.EqualTo(GuaResetResult.Succeeded));
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
         var resetStatus = GuaClockControls.GetClockStatus(context);
         Assert.Multiple(() =>
         {
@@ -47,7 +51,26 @@ public sealed class SelectorParityTests
             Assert.That(resetStatus.NowMilliseconds, Is.Zero);
             Assert.That(resetStatus.PendingMilliseconds, Is.Zero);
             Assert.That(resetStatus.DefaultStepMilliseconds, Is.EqualTo(1000.0 / 60.0));
+            Assert.That(captured.IsAlive, Is.False, "Clock reset must release stale callback closures immediately.");
+            Assert.That((uint)GuaResetTargets.Default, Is.EqualTo(15));
+            Assert.That((uint)GuaResetTargets.SessionDefault, Is.EqualTo(79));
+            Assert.That((uint)GuaResetTargets.All, Is.EqualTo(63));
+            Assert.That((uint)GuaResetTargets.AllWithClock, Is.EqualTo(127));
         });
+
+        clock.Install(step: TimeSpan.FromMilliseconds(10));
+        var explicitGeneration = clock.Status.Generation;
+        Assert.That(context.Reset(new GuaResetOptions(GuaResetTargets.Default)).Result, Is.EqualTo(GuaResetResult.Succeeded));
+        Assert.That(clock.Status.Installed, Is.True);
+        Assert.That(clock.Status.Generation, Is.EqualTo(explicitGeneration));
+    }
+
+    private static WeakReference ScheduleCapturedCallback(GuaClock clock)
+    {
+        var captured = new object();
+        var reference = new WeakReference(captured);
+        clock.Schedule(TimeSpan.FromHours(1), () => GC.KeepAlive(captured));
+        return reference;
     }
 
     [Test]
@@ -910,6 +933,45 @@ public sealed class SelectorParityTests
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
         listener.Stop();
         return port;
+    }
+
+    [Test]
+    public async Task RemoteResetDistinguishesLegacyAggregateMasksFromCurrentExplicitMasks()
+    {
+        var port = ReservePort();
+        using var runtime = new GuaRuntime();
+        runtime.EnableVirtualClockAdapter();
+        runtime.Clock.Install(step: TimeSpan.FromMilliseconds(250));
+        runtime.BeginFrame("fixture"); runtime.EndFrame();
+        Assert.That(runtime.StartInspectorBridge(port), Is.True);
+        try
+        {
+            using var socket = new ClientWebSocket();
+            await socket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}"), CancellationToken.None);
+
+            var legacyDefault = await SendRawCommandAsync(socket,
+                "{\"id\":1,\"type\":\"reset_context\",\"expectedSessionEpoch\":1,\"flags\":15}");
+            var afterLegacyDefault = await SendRawCommandAsync(socket, "{\"id\":2,\"type\":\"get_clock\"}");
+            Assert.That(legacyDefault.GetProperty("ok").GetBoolean(), Is.True);
+            Assert.That(afterLegacyDefault.GetProperty("result").GetProperty("installed").GetBoolean(), Is.False);
+
+            runtime.Clock.Install(step: TimeSpan.FromMilliseconds(250));
+            var currentExplicit = await SendRawCommandAsync(socket,
+                "{\"id\":3,\"type\":\"reset_context\",\"expectedSessionEpoch\":2,\"flags\":15,\"flagsVersion\":1}");
+            var afterCurrentExplicit = await SendRawCommandAsync(socket, "{\"id\":4,\"type\":\"get_clock\"}");
+            Assert.That(currentExplicit.GetProperty("ok").GetBoolean(), Is.True);
+            Assert.That(afterCurrentExplicit.GetProperty("result").GetProperty("installed").GetBoolean(), Is.True);
+
+            var legacyAll = await SendRawCommandAsync(socket,
+                "{\"id\":5,\"type\":\"reset_context\",\"expectedSessionEpoch\":3,\"flags\":63}");
+            var afterLegacyAll = await SendRawCommandAsync(socket, "{\"id\":6,\"type\":\"get_clock\"}");
+            Assert.That(legacyAll.GetProperty("ok").GetBoolean(), Is.True);
+            Assert.That(afterLegacyAll.GetProperty("result").GetProperty("installed").GetBoolean(), Is.False);
+        }
+        finally
+        {
+            runtime.StopInspectorBridge();
+        }
     }
 
     private static int ScheduledCount(object clock)

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -87,6 +87,33 @@ public sealed class SelectorParityTests
     }
 
     [Test]
+    public void ClockExecutionLimitRetiresRemainingSchedules()
+    {
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+        clock.Install(step: TimeSpan.FromMilliseconds(101));
+        clock.Pause();
+        var callbacks = 0;
+        clock.Schedule(TimeSpan.Zero, () => callbacks++, TimeSpan.FromTicks(1));
+        Assert.That(() => clock.RunFor(TimeSpan.FromMilliseconds(101)),
+            Throws.InvalidOperationException.With.Message.Contains("execution_limit"));
+        Assert.That(callbacks, Is.EqualTo(1_000_000));
+        Assert.That(() => clock.RunFor(TimeSpan.FromMilliseconds(1)), Throws.Nothing);
+        Assert.That(callbacks, Is.EqualTo(1_000_000));
+
+        using var runtime = new GuaRuntime();
+        runtime.Clock.Install(step: TimeSpan.FromMilliseconds(101));
+        runtime.Clock.Pause();
+        var runtimeCallbacks = 0;
+        runtime.Clock.Schedule(TimeSpan.Zero, () => runtimeCallbacks++, TimeSpan.FromTicks(1));
+        Assert.That(() => runtime.Clock.RunFor(TimeSpan.FromMilliseconds(101)),
+            Throws.InvalidOperationException.With.Message.Contains("execution_limit"));
+        Assert.That(runtimeCallbacks, Is.EqualTo(1_000_000));
+        Assert.That(() => runtime.Clock.RunFor(TimeSpan.FromMilliseconds(1)), Throws.Nothing);
+        Assert.That(runtimeCallbacks, Is.EqualTo(1_000_000));
+    }
+
+    [Test]
     public void RemoteTreeDeserializesProtocolBoundsAndNestedState()
     {
         const string json = """
@@ -490,7 +517,15 @@ public sealed class SelectorParityTests
                 "{\"id\":3,\"type\":\"clock_install\",\"initialTimeMs\":\"0\"}");
             var outOfRange = await SendRawCommandAsync(socket,
                 "{\"id\":4,\"type\":\"clock_run_for\",\"durationMs\":1e999}");
-            var statusAfterError = await SendRawCommandAsync(socket, "{\"id\":5,\"type\":\"get_clock\"}");
+            var leadingPlus = await SendRawCommandAsync(socket,
+                "{\"id\":5,\"type\":\"clock_run_for\",\"durationMs\":+25}", 5);
+            var missingInteger = await SendRawCommandAsync(socket,
+                "{\"id\":6,\"type\":\"clock_run_for\",\"durationMs\":.5}", 6);
+            var invalidSuffix = await SendRawCommandAsync(socket,
+                "{\"id\":7,\"type\":\"clock_run_for\",\"durationMs\":25x}", 7);
+            var invalidSuffixAfterWhitespace = await SendRawCommandAsync(socket,
+                "{\"id\":8,\"type\":\"clock_run_for\",\"durationMs\":25 x}", 8);
+            var statusAfterError = await SendRawCommandAsync(socket, "{\"id\":9,\"type\":\"get_clock\"}");
             Assert.Multiple(() =>
             {
                 Assert.That(missing.GetProperty("ok").GetBoolean(), Is.False);
@@ -501,8 +536,14 @@ public sealed class SelectorParityTests
                 Assert.That(invalidInitialTime.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
                 Assert.That(outOfRange.GetProperty("ok").GetBoolean(), Is.False);
                 Assert.That(outOfRange.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
+                Assert.That(leadingPlus.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
+                Assert.That(missingInteger.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
+                Assert.That(invalidSuffix.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
+                Assert.That(invalidSuffixAfterWhitespace.GetProperty("error").GetString(), Is.EqualTo("invalid_duration"));
                 Assert.That(statusAfterError.GetProperty("ok").GetBoolean(), Is.True,
                     "An out-of-range number must not close the WebSocket connection.");
+                Assert.That(statusAfterError.GetProperty("result").GetProperty("nowMs").GetDouble(), Is.Zero,
+                    "Invalid JSON number spellings must not mutate the clock timeline.");
             });
         }
         finally
@@ -617,11 +658,15 @@ public sealed class SelectorParityTests
         return port;
     }
 
-    private static async Task<JsonElement> SendRawCommandAsync(ClientWebSocket socket, string json)
+    private static async Task<JsonElement> SendRawCommandAsync(ClientWebSocket socket, string json, int? expectedResponseId = null)
     {
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-        using var requestDocument = JsonDocument.Parse(json);
-        var expectedId = requestDocument.RootElement.GetProperty("id").GetInt32();
+        var expectedId = expectedResponseId;
+        if (!expectedId.HasValue)
+        {
+            using var requestDocument = JsonDocument.Parse(json);
+            expectedId = requestDocument.RootElement.GetProperty("id").GetInt32();
+        }
         var request = Encoding.UTF8.GetBytes(json);
         await socket.SendAsync(new ArraySegment<byte>(request), WebSocketMessageType.Text, true, timeout.Token);
         var buffer = new byte[4096];
@@ -635,7 +680,7 @@ public sealed class SelectorParityTests
                 response.Write(buffer, 0, received.Count);
             } while (!received.EndOfMessage);
             using var document = JsonDocument.Parse(response.ToArray());
-            if (document.RootElement.TryGetProperty("id", out var id) && id.GetInt32() == expectedId)
+            if (document.RootElement.TryGetProperty("id", out var id) && id.GetInt32() == expectedId.Value)
                 return document.RootElement.Clone();
         }
     }

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -66,6 +66,23 @@ public sealed class SelectorParityTests
     }
 
     [Test]
+    public void NativeClockStepsPreserveFractionalDeltasAsDoubles()
+    {
+        Assert.That(typeof(GuaClockStep).GetProperty(nameof(GuaClockStep.Delta))!.PropertyType,
+            Is.EqualTo(typeof(GuaClockDelta)),
+            "Native deltas must not pass through runtime-dependent TimeSpan.FromMilliseconds rounding.");
+
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+        var fractionalStep = TimeSpan.FromTicks(166_667);
+        clock.Install(step: fractionalStep);
+        clock.Pause();
+        Assert.That(context.RunClockFor(fractionalStep, fractionalStep), Is.EqualTo(GuaClockResult.Ok));
+        Assert.That(context.TryConsumeClockStep(out var step), Is.True);
+        Assert.That(step.Delta.TotalMilliseconds, Is.EqualTo(fractionalStep.TotalMilliseconds));
+    }
+
+    [Test]
     public void ContextRejectsASecondManagedClock()
     {
         using var context = new GuaContext();

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -1181,6 +1181,44 @@ public sealed class SelectorParityTests
     }
 
     [Test]
+    public void ClockTimeSpanProjectionsAreExplicitlyFallibleOutsideTheManagedRange()
+    {
+        var status = new GuaClockStatus(true, false, 1e16, 10, 0, 1);
+        var delta = new GuaClockDelta(1e16);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.NowMilliseconds, Is.EqualTo(1e16));
+            Assert.That(status.Now, Is.Null);
+            Assert.That(status.TryGetNow(out _), Is.False);
+            Assert.That(delta.TimeSpan, Is.Null);
+            Assert.That(delta.TryGetTimeSpan(out _), Is.False);
+        });
+
+        var bounded = new GuaClockStatus(true, false, 16.6667, 10, 0, 1);
+        Assert.That(bounded.TryGetNow(out var boundedNow), Is.True);
+        Assert.That(boundedNow.TotalMilliseconds, Is.EqualTo(16.6667).Within(0.0001));
+    }
+
+    [Test]
+    public void RuntimeClockAdvancesFromDoubleMillisecondsWithoutTimeSpanRounding()
+    {
+        const double elapsedMilliseconds = 16.666666;
+        using var runtime = new GuaRuntime();
+        runtime.Clock.Install(step: TimeSpan.FromMilliseconds(100));
+        var ticks = new List<double>();
+        runtime.Clock.Tick += delta => ticks.Add(delta.TotalMilliseconds);
+
+        runtime.Clock.AdvanceMilliseconds(elapsedMilliseconds);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(runtime.Clock.Status.NowMilliseconds, Is.EqualTo(elapsedMilliseconds));
+            Assert.That(ticks, Is.EqualTo(new[] { elapsedMilliseconds }));
+        });
+    }
+
+    [Test]
     public async Task AsyncClockControlsRequireOnlyTheAsyncStatusContract()
     {
         var context = new AsyncOnlyClockContext();

--- a/bindings/dotnet/tests/Gua.Visual.Tests/ClockTests.cs
+++ b/bindings/dotnet/tests/Gua.Visual.Tests/ClockTests.cs
@@ -33,4 +33,22 @@ public sealed class ClockTests
         Assert.That(clock.Status.Paused, Is.True);
         Assert.That(clock.Status, Is.TypeOf<GuaClockStatus>());
     }
+
+    [Test]
+    public void ResetGenerationDiscardsSchedulesFromThePreviousSession()
+    {
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+        var fired = false;
+        clock.Install(step: TimeSpan.FromMilliseconds(10));
+        clock.Schedule(TimeSpan.FromMilliseconds(20), () => fired = true);
+
+        var report = context.Reset();
+        Assert.That(report.Result, Is.EqualTo(GuaResetResult.Succeeded));
+        clock.Install(step: TimeSpan.FromMilliseconds(10));
+        clock.Pause();
+        clock.RunFor(TimeSpan.FromMilliseconds(25));
+
+        Assert.That(fired, Is.False);
+    }
 }

--- a/bindings/dotnet/tests/Gua.Visual.Tests/ClockTests.cs
+++ b/bindings/dotnet/tests/Gua.Visual.Tests/ClockTests.cs
@@ -1,0 +1,36 @@
+using Gua.Core;
+using NUnit.Framework;
+
+namespace Gua.Visual.Tests;
+
+public sealed class ClockTests
+{
+    [Test]
+    public void RunForExecutesSchedulesAndTicksWithoutWallTime()
+    {
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+        var fired = new List<string>();
+        var ticks = new List<double>();
+        clock.Install(step: TimeSpan.FromMilliseconds(10));
+        clock.Schedule(TimeSpan.FromMilliseconds(20), () => fired.Add("first"));
+        clock.Schedule(TimeSpan.FromMilliseconds(20), () => fired.Add("second"));
+        clock.Tick += delta => ticks.Add(delta.TotalMilliseconds);
+        clock.Pause();
+        clock.RunFor(TimeSpan.FromMilliseconds(25));
+        Assert.That(fired, Is.EqualTo(new[] { "first", "second" }));
+        Assert.That(ticks, Is.EqualTo(new[] { 10, 10, 5 }));
+        Assert.That(clock.Status.NowMilliseconds, Is.EqualTo(25));
+        Assert.That(clock.Status.Paused, Is.True);
+    }
+
+    [Test]
+    public void NativeEngineTimersAreNotClaimedByClock()
+    {
+        using var context = new GuaContext();
+        var clock = new GuaClock(context);
+        clock.Install(); clock.Pause();
+        Assert.That(clock.Status.Paused, Is.True);
+        Assert.That(clock.Status, Is.TypeOf<GuaClockStatus>());
+    }
+}

--- a/bindings/unity/Runtime/GuaUnityRuntime.cs
+++ b/bindings/unity/Runtime/GuaUnityRuntime.cs
@@ -76,7 +76,7 @@ public sealed class GuaUnityRuntime : MonoBehaviour
         if (runtime == null) return;
         try
         {
-            runtime.Clock.Advance(TimeSpan.FromSeconds(Time.unscaledDeltaTime));
+            runtime.Clock.AdvanceMilliseconds((double)Time.unscaledDeltaTime * 1000.0);
             targets.Clear();
             ids.Clear();
             clickTargetIds.Clear();

--- a/bindings/unity/Runtime/GuaUnityRuntime.cs
+++ b/bindings/unity/Runtime/GuaUnityRuntime.cs
@@ -62,6 +62,13 @@ public sealed class GuaUnityRuntime : MonoBehaviour
 
     public static void RunFrame() { if (activeRuntime != null && activeRuntime.enabled) activeRuntime.Tick(); }
 
+    /// <summary>
+    /// Gets the clock that game logic must explicitly use to participate in
+    /// Gua pause and run-for operations.
+    /// </summary>
+    public static GuaRuntimeClock Clock => activeRuntime?.runtime?.Clock
+        ?? throw new InvalidOperationException("The Gua Unity runtime has not started yet.");
+
     private void Tick()
     {
         if (runtime == null) return;

--- a/bindings/unity/Runtime/GuaUnityRuntime.cs
+++ b/bindings/unity/Runtime/GuaUnityRuntime.cs
@@ -47,6 +47,7 @@ public sealed class GuaUnityRuntime : MonoBehaviour
         {
             runtime = new GuaRuntime();
             runtime.SetAdapterVersion("unity", GuaVersion.Parse(runtime.GetVersionJson()).RuntimeVersion);
+            runtime.EnableVirtualClockAdapter();
             var configured = Environment.GetEnvironmentVariable("GUA_BRIDGE_PORT");
             var port = int.TryParse(configured, NumberStyles.None, CultureInfo.InvariantCulture, out var value) ? value : 8765;
             if (!runtime.StartInspectorBridge(port)) throw new InvalidOperationException($"Failed to start Gua Inspector bridge on port {port}.");

--- a/bindings/unity/Runtime/GuaUnityRuntime.cs
+++ b/bindings/unity/Runtime/GuaUnityRuntime.cs
@@ -67,6 +67,7 @@ public sealed class GuaUnityRuntime : MonoBehaviour
         if (runtime == null) return;
         try
         {
+            runtime.Clock.Advance(TimeSpan.FromSeconds(Time.unscaledDeltaTime));
             targets.Clear();
             ids.Clear();
             clickTargetIds.Clear();

--- a/bindings/unity/Runtime/GuaUnityRuntime.cs
+++ b/bindings/unity/Runtime/GuaUnityRuntime.cs
@@ -18,7 +18,7 @@ using Toggle = UnityEngine.UI.Toggle;
 namespace Gua.Unity
 {
 
-[DefaultExecutionOrder(32000)]
+[DefaultExecutionOrder(-32000)]
 public sealed class GuaUnityRuntime : MonoBehaviour
 {
     private readonly Dictionary<string, Target> targets = new(StringComparer.Ordinal);
@@ -46,6 +46,7 @@ public sealed class GuaUnityRuntime : MonoBehaviour
         try
         {
             runtime = new GuaRuntime();
+            runtime.Clock.CallbackFailed += error => Debug.LogError("Gua clock callback failed: " + error);
             runtime.SetAdapterVersion("unity", GuaVersion.Parse(runtime.GetVersionJson()).RuntimeVersion);
             runtime.EnableVirtualClockAdapter();
             var configured = Environment.GetEnvironmentVariable("GUA_BRIDGE_PORT");

--- a/bindings/unity/Samples~/Runtime UI Fixture/README.md
+++ b/bindings/unity/Samples~/Runtime UI Fixture/README.md
@@ -4,5 +4,14 @@ Import this sample from Package Manager and open `GuaRuntimeUiSample.unity`.
 The scene creates UI Toolkit, uGUI, and TextMeshPro controls at runtime. Gua
 starts automatically; no semantic node registration is required.
 
+## Virtual clock integration
+
+Gua can pause only game logic that explicitly uses GuaClock as its time source.
+Use `GuaUnityRuntime.Clock.Schedule(...)` or subscribe to
+`GuaUnityRuntime.Clock.Tick` in the target game subsystem. Calling
+`clock_install` from a test, MCP, or Inspector activates that shared clock; it
+does not rewrite existing `Time.deltaTime`, `WaitForSeconds`, coroutines,
+physics, animation, or audio behavior.
+
 The package targets Windows x64, Unity 6000.0 or newer, and the Mono scripting
 backend. Import TextMeshPro Essential Resources before building a Player.

--- a/bindings/unity/Samples~/Runtime UI Fixture/README.md
+++ b/bindings/unity/Samples~/Runtime UI Fixture/README.md
@@ -13,5 +13,8 @@ Use `GuaUnityRuntime.Clock.Schedule(...)` or subscribe to
 does not rewrite existing `Time.deltaTime`, `WaitForSeconds`, coroutines,
 physics, animation, or audio behavior.
 
+The `Tick` callback receives a `GuaClockDelta`; use `TotalMilliseconds` or
+`TotalSeconds` to retain steps below the 100 ns resolution of `TimeSpan`.
+
 The package targets Windows x64, Unity 6000.0 or newer, and the Mono scripting
 backend. Import TextMeshPro Essential Resources before building a Player.

--- a/examples/dotnet-godot/README.md
+++ b/examples/dotnet-godot/README.md
@@ -36,3 +36,10 @@ the Gua adapter to the root Godot `Control`; the adapter collects standard
 labels and buttons into the semantic UI tree, publishes snapshots, observes
 button clicks, and dispatches Inspector `click_node` requests through the normal
 Godot button signal.
+
+Game logic that explicitly participates in virtual-time control can use
+`GuaGodotRuntime.Clock.Schedule(...)` or its double-precision `Tick` event. The
+sample pumps that clock from Godot's monotonic
+microsecond counter, so changing `Engine.TimeScale` does not freeze or scale the
+running Gua clock. Godot timers and other engine-native time sources remain
+outside GuaClock control.

--- a/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
+++ b/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
@@ -20,6 +20,7 @@ public sealed class GuaGodotRuntime : IDisposable
             ProjectSettings.GlobalizePath("res://addons/gua/bin"));
         _runtime = new GuaRuntime();
         _runtime.SetGodotPluginVersion("0.1.0");
+        _runtime.EnableVirtualClockAdapter();
     }
 
     public bool InspectorBridgeRunning
@@ -103,6 +104,12 @@ public sealed class GuaGodotRuntime : IDisposable
         EndFrame();
         DispatchClickRequests();
         ScheduleScreenshotCapture();
+    }
+
+    public void AdvanceClock(TimeSpan unscaledDelta)
+    {
+        ThrowIfDisposed();
+        _runtime!.Clock.Advance(unscaledDelta);
     }
 
     public bool EnqueueClick(string id)

--- a/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
+++ b/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
@@ -12,6 +12,8 @@ public sealed class GuaGodotRuntime : IDisposable
     private readonly HashSet<ulong> _connectedButtons = new();
     private readonly HashSet<string> _suppressedButtonSignals = new(StringComparer.Ordinal);
     private bool _screenshotCaptureRunning;
+    private ulong _lastClockTicksUsec;
+    private bool _clockPumpEnabled;
 
     public GuaGodotRuntime()
     {
@@ -20,7 +22,6 @@ public sealed class GuaGodotRuntime : IDisposable
             ProjectSettings.GlobalizePath("res://addons/gua/bin"));
         _runtime = new GuaRuntime();
         _runtime.SetGodotPluginVersion("0.1.0");
-        _runtime.EnableVirtualClockAdapter();
     }
 
     public bool InspectorBridgeRunning
@@ -88,6 +89,12 @@ public sealed class GuaGodotRuntime : IDisposable
     {
         ThrowIfDisposed();
         _attachedRoot = root ?? throw new ArgumentNullException(nameof(root));
+        _lastClockTicksUsec = Time.GetTicksUsec();
+        if (!_clockPumpEnabled)
+        {
+            _runtime!.EnableVirtualClockAdapter();
+            _clockPumpEnabled = true;
+        }
     }
 
     public void SyncAttachedTree(string screen)
@@ -98,6 +105,7 @@ public sealed class GuaGodotRuntime : IDisposable
             throw new InvalidOperationException("Gua Godot runtime is not attached to a root Control.");
         }
 
+        PumpClock();
         BeginFrame(screen);
         _buttonsById.Clear();
         CollectControl(_attachedRoot, _attachedRoot);
@@ -120,6 +128,14 @@ public sealed class GuaGodotRuntime : IDisposable
     {
         ThrowIfDisposed();
         Clock.Advance(unscaledDelta);
+        _lastClockTicksUsec = Time.GetTicksUsec();
+    }
+
+    public void AdvanceClockMilliseconds(double unscaledDeltaMilliseconds)
+    {
+        ThrowIfDisposed();
+        Clock.AdvanceMilliseconds(unscaledDeltaMilliseconds);
+        _lastClockTicksUsec = Time.GetTicksUsec();
     }
 
     public bool EnqueueClick(string id)
@@ -177,6 +193,14 @@ public sealed class GuaGodotRuntime : IDisposable
         {
             throw new ObjectDisposedException(nameof(GuaGodotRuntime));
         }
+    }
+
+    private void PumpClock()
+    {
+        var ticksUsec = Time.GetTicksUsec();
+        var elapsedUsec = ticksUsec >= _lastClockTicksUsec ? ticksUsec - _lastClockTicksUsec : 0;
+        _lastClockTicksUsec = ticksUsec;
+        Clock.AdvanceMilliseconds(elapsedUsec / 1000.0);
     }
 
     private void CollectControl(Control root, Control control)

--- a/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
+++ b/examples/dotnet-godot/addons/gua/GuaGodotRuntime.cs
@@ -106,10 +106,20 @@ public sealed class GuaGodotRuntime : IDisposable
         ScheduleScreenshotCapture();
     }
 
+    /// <summary>Clock used by game logic that participates in Gua virtual-time control.</summary>
+    public GuaRuntimeClock Clock
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _runtime!.Clock;
+        }
+    }
+
     public void AdvanceClock(TimeSpan unscaledDelta)
     {
         ThrowIfDisposed();
-        _runtime!.Clock.Advance(unscaledDelta);
+        Clock.Advance(unscaledDelta);
     }
 
     public bool EnqueueClick(string id)

--- a/examples/dotnet-godot/addons/gua/README.md
+++ b/examples/dotnet-godot/addons/gua/README.md
@@ -27,6 +27,10 @@ public override void _Process(double delta)
 }
 ```
 
+`SyncAttachedTree` also pumps the Gua clock from Godot's monotonic, unscaled
+elapsed time before publishing the semantic frame. The virtual-clock capability
+is enabled only after `Attach` installs this normal frame pump.
+
 The addon is a runtime adapter. `plugin.cfg` and `plugin.gd` exist only so the
 directory follows Godot addon packaging conventions.
 

--- a/examples/dotnet-godot/scripts/Main.cs
+++ b/examples/dotnet-godot/scripts/Main.cs
@@ -10,6 +10,7 @@ public partial class Main : Control
     private Button? _settingsButton;
     private Label? _loadingLabel;
     private bool _loading;
+    private ulong _lastClockTicksUsec;
 
     [Export]
     public bool StartInspectorBridgeOnReady { get; set; } = true;
@@ -23,6 +24,7 @@ public partial class Main : Control
         BuildUi();
         _gua.Attach(this);
         _gua.SyncAttachedTree(CurrentScreen);
+        _lastClockTicksUsec = Time.GetTicksUsec();
 
         if (StartInspectorBridgeOnReady)
         {
@@ -31,9 +33,12 @@ public partial class Main : Control
 
     }
 
-    public override void _Process(double delta)
+    public override void _Process(double _delta)
     {
-        _gua.AdvanceClock(TimeSpan.FromSeconds(delta));
+        var ticksUsec = Time.GetTicksUsec();
+        var elapsedUsec = ticksUsec >= _lastClockTicksUsec ? ticksUsec - _lastClockTicksUsec : 0;
+        _lastClockTicksUsec = ticksUsec;
+        _gua.AdvanceClock(TimeSpan.FromMilliseconds(elapsedUsec / 1000.0));
         _gua.SyncAttachedTree(CurrentScreen);
     }
 

--- a/examples/dotnet-godot/scripts/Main.cs
+++ b/examples/dotnet-godot/scripts/Main.cs
@@ -33,6 +33,7 @@ public partial class Main : Control
 
     public override void _Process(double delta)
     {
+        _gua.AdvanceClock(TimeSpan.FromSeconds(delta));
         _gua.SyncAttachedTree(CurrentScreen);
     }
 

--- a/examples/dotnet-godot/scripts/Main.cs
+++ b/examples/dotnet-godot/scripts/Main.cs
@@ -10,7 +10,6 @@ public partial class Main : Control
     private Button? _settingsButton;
     private Label? _loadingLabel;
     private bool _loading;
-    private ulong _lastClockTicksUsec;
 
     [Export]
     public bool StartInspectorBridgeOnReady { get; set; } = true;
@@ -24,7 +23,6 @@ public partial class Main : Control
         BuildUi();
         _gua.Attach(this);
         _gua.SyncAttachedTree(CurrentScreen);
-        _lastClockTicksUsec = Time.GetTicksUsec();
 
         if (StartInspectorBridgeOnReady)
         {
@@ -35,10 +33,6 @@ public partial class Main : Control
 
     public override void _Process(double _delta)
     {
-        var ticksUsec = Time.GetTicksUsec();
-        var elapsedUsec = ticksUsec >= _lastClockTicksUsec ? ticksUsec - _lastClockTicksUsec : 0;
-        _lastClockTicksUsec = ticksUsec;
-        _gua.AdvanceClock(TimeSpan.FromMilliseconds(elapsedUsec / 1000.0));
         _gua.SyncAttachedTree(CurrentScreen);
     }
 

--- a/examples/godot-gdscript/README.md
+++ b/examples/godot-gdscript/README.md
@@ -55,6 +55,22 @@ const GuaAutoAdapterScript := preload("res://addons/gua/gua_auto_adapter.gd")
 var ui := GuaAutoAdapterScript.new()
 ```
 
+## Virtual clock integration
+
+Only game logic that uses the adapter's clock can be paused or advanced by Gua.
+Replace the native `Timer` or per-frame time source in each target subsystem
+with `ui.clock_schedule(...)` or the `ui.clock_tick` signal:
+
+```gdscript
+# Game-side integration. This callback now follows GuaClock time.
+ui.clock_schedule(2000.0, _show_message)
+ui.clock_tick.connect(_update_countdown)
+```
+
+Calling `clock_install` from a test, MCP, or Inspector activates the shared
+virtual clock. It does not automatically attach GuaClock to existing `Timer`,
+`SceneTreeTimer`, animation, physics, or audio logic.
+
 The adapter resolves the native `GuaContext` class through `ClassDB` when it is
 first used. If the GDExtension is not loaded, or if the vendored DLL is stale and
 does not expose a required method such as `consume_click_request`, the adapter

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -264,7 +264,7 @@ func _bind_pending_clock_schedules(status: Dictionary) -> void:
 	var generation := int(status.get("generation", 0))
 	var now_ms := float(status.get("now_ms", 0.0))
 	for item: Dictionary in clock_schedules:
-		if bool(item.get("bind_on_install", false)):
+		if bool(item.get("bind_on_install", false)) and generation == int(item.get("generation", 0)) + 1:
 			item.generation = generation
 			item.due_ms = now_ms + float(item.get("due_ms", 0.0))
 			item.bind_on_install = false

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -248,8 +248,8 @@ func _drain_clock_schedules(now_ms: float, generation: int) -> void:
 		if float(item.interval_ms) > 0.0 and not active_clock_schedule_cancelled:
 			item.due_ms = float(item.due_ms) + float(item.interval_ms)
 			clock_schedules.append(item)
-			clock_schedules.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
-				return float(a.due_ms) < float(b.due_ms) or (float(a.due_ms) == float(b.due_ms) and int(a.id) < int(b.id)))
+		clock_schedules.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+			return float(a.due_ms) < float(b.due_ms) or (float(a.due_ms) == float(b.due_ms) and int(a.id) < int(b.id)))
 		active_clock_schedule_id = 0
 		active_clock_schedule_cancelled = false
 

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -227,7 +227,7 @@ func clock_install(initial_time_ms: float = 0.0, step_ms: float = 1000.0 / 60.0)
 func clock_pause() -> Dictionary:
 	return context.clock_pause() if _ensure_context() else {}
 
-func clock_run_for(duration_ms: float, step_ms: float = 0.0) -> Dictionary:
+func clock_run_for(duration_ms: float, step_ms = null) -> Dictionary:
 	return context.clock_run_for(duration_ms, step_ms) if _ensure_context() else {}
 
 func clock_resume() -> Dictionary:

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -77,7 +77,7 @@ func update(screen: String) -> void:
 		var step: Dictionary = context.consume_clock_step()
 		if step.is_empty():
 			break
-		_drain_clock_schedules(float(context.get_clock().get("now_ms", 0.0)))
+		_drain_clock_schedules(float(context.get_clock().get("now_ms", 0.0)), int(step.get("generation", 0)))
 		clock_tick.emit(float(step.get("delta_ms", 0.0)) / 1000.0)
 
 	if root == null:
@@ -221,7 +221,8 @@ func clock_schedule(delay_ms: float, callback: Callable, interval_ms: float = 0.
 		return 0
 	var schedule_id := next_clock_schedule_id
 	next_clock_schedule_id += 1
-	clock_schedules.append({"id": schedule_id, "due_ms": float(get_clock().get("now_ms", 0.0)) + delay_ms, "interval_ms": interval_ms, "callback": callback})
+	var status := get_clock()
+	clock_schedules.append({"id": schedule_id, "generation": int(status.get("generation", 0)), "due_ms": float(status.get("now_ms", 0.0)) + delay_ms, "interval_ms": interval_ms, "callback": callback})
 	return schedule_id
 
 func clock_cancel(schedule_id: int) -> void:
@@ -229,7 +230,8 @@ func clock_cancel(schedule_id: int) -> void:
 	if active_clock_schedule_id == schedule_id:
 		active_clock_schedule_cancelled = true
 
-func _drain_clock_schedules(now_ms: float) -> void:
+func _drain_clock_schedules(now_ms: float, generation: int) -> void:
+	clock_schedules = clock_schedules.filter(func(item: Dictionary) -> bool: return int(item.get("generation", 0)) == generation)
 	clock_schedules.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
 		return float(a.due_ms) < float(b.due_ms) or (float(a.due_ms) == float(b.due_ms) and int(a.id) < int(b.id)))
 	var callbacks := 0

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -38,6 +38,7 @@ const REQUIRED_CONTEXT_METHODS := [
 	"get_clock",
 	"consume_clock_step",
 	"consume_clock_steps",
+	"enable_virtual_clock_adapter",
 	"start_inspector_bridge",
 	"inspector_bridge_url",
 ]
@@ -310,6 +311,8 @@ func _ensure_context() -> bool:
 			% [CONTEXT_CLASS, missing_methods[0], REBUILD_COMMAND]
 		)
 		return false
+
+	context.enable_virtual_clock_adapter()
 
 	return true
 

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -56,6 +56,7 @@ var gdextension_resource: Resource
 var unavailable := false
 var screenshot_capture_scheduled := false
 var last_clock_ticks_ms := Time.get_ticks_msec()
+var observed_clock_generation := -1
 var clock_schedules: Array[Dictionary] = []
 var next_clock_schedule_id := 1
 var active_clock_schedule_id := 0
@@ -68,6 +69,7 @@ var clock_execution_limit_reached := false
 
 func attach(root_control: Control) -> void:
 	root = root_control
+	last_clock_ticks_ms = Time.get_ticks_msec()
 	_ensure_context()
 
 
@@ -77,7 +79,12 @@ func update(screen: String) -> void:
 	var ticks_ms := Time.get_ticks_msec()
 	var clock_status: Dictionary = context.get_clock()
 	_bind_pending_clock_schedules(clock_status)
-	if clock_status.get("installed", false) and clock_status.get("state", "running") == "running":
+	var clock_installed := bool(clock_status.get("installed", false))
+	var clock_generation := int(clock_status.get("generation", -1))
+	if clock_installed and observed_clock_generation != clock_generation:
+		last_clock_ticks_ms = ticks_ms
+	observed_clock_generation = clock_generation if clock_installed else -1
+	if clock_installed and clock_status.get("state", "running") == "running":
 		context.clock_advance(maxi(0, ticks_ms - last_clock_ticks_ms))
 	last_clock_ticks_ms = ticks_ms
 	while true:
@@ -227,7 +234,13 @@ func get_context_status() -> Dictionary:
 
 
 func clock_install(initial_time_ms: float = 0.0, step_ms: float = 1000.0 / 60.0) -> Dictionary:
-	return context.clock_install(initial_time_ms, step_ms) if _ensure_context() else {}
+	if not _ensure_context():
+		return {}
+	var result: Dictionary = context.clock_install(initial_time_ms, step_ms)
+	if int(result.get("result", 0)) == 1:
+		last_clock_ticks_ms = Time.get_ticks_msec()
+		observed_clock_generation = int(result.get("generation", context.get_clock().get("generation", -1)))
+	return result
 
 func clock_pause() -> Dictionary:
 	return context.clock_pause() if _ensure_context() else {}
@@ -322,6 +335,8 @@ func reset_context(options: Dictionary = {}) -> Dictionary:
 		controls_by_id.clear()
 		suppressed_clicks.clear()
 		if (int(resolved.get("flags", RESET_DEFAULT_FLAGS)) & RESET_CLOCK_FLAG) != 0:
+			last_clock_ticks_ms = Time.get_ticks_msec()
+			observed_clock_generation = -1
 			clock_schedules.clear()
 			active_clock_schedule_id = 0
 			active_clock_schedule_cancelled = false
@@ -404,10 +419,10 @@ func _collect_control(control: Control, parent_id: String) -> void:
 	}
 	if not parent_id.is_empty():
 		descriptor["parent_id"] = parent_id
-	var text := _control_text(control)
+	var text: Variant = _control_text(control)
 	if text != null:
 		descriptor["text"] = text
-	var value := _control_value(control)
+	var value: Variant = _control_value(control)
 	if value != null:
 		descriptor["value"] = value
 	if control is CheckBox:

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -7,6 +7,7 @@ const META_ID := "gua_id"
 const META_SENSITIVE := "gua_sensitive"
 const RESET_CLOCK_FLAG := 1 << 6
 const RESET_DEFAULT_FLAGS := 79
+const CLOCK_CALLBACK_LIMIT := 1000000
 const CONTEXT_CLASS := "GuaContext"
 const GDEXTENSION_RESOURCE := "res://addons/gua/gua.gdextension"
 const REBUILD_COMMAND := "cmake --build --preset windows-msvc-debug --target gua-godot"
@@ -59,6 +60,10 @@ var clock_schedules: Array[Dictionary] = []
 var next_clock_schedule_id := 1
 var active_clock_schedule_id := 0
 var active_clock_schedule_cancelled := false
+var clock_run_active := false
+var clock_run_callbacks_remaining := CLOCK_CALLBACK_LIMIT
+var clock_run_generation := -1
+var clock_execution_limit_reached := false
 
 
 func attach(root_control: Control) -> void:
@@ -71,6 +76,7 @@ func update(screen: String) -> void:
 		return
 	var ticks_ms := Time.get_ticks_msec()
 	var clock_status: Dictionary = context.get_clock()
+	_bind_pending_clock_schedules(clock_status)
 	if clock_status.get("installed", false) and clock_status.get("state", "running") == "running":
 		context.clock_advance(maxi(0, ticks_ms - last_clock_ticks_ms))
 	last_clock_ticks_ms = ticks_ms
@@ -78,8 +84,21 @@ func update(screen: String) -> void:
 		var step: Dictionary = context.consume_clock_step()
 		if step.is_empty():
 			break
-		_drain_clock_schedules(float(context.get_clock().get("now_ms", 0.0)), int(step.get("generation", 0)))
+		var step_generation := int(step.get("generation", 0))
+		if not clock_run_active or clock_run_generation != step_generation:
+			clock_run_active = true
+			clock_run_callbacks_remaining = CLOCK_CALLBACK_LIMIT
+			clock_run_generation = step_generation
+		clock_run_callbacks_remaining -= _drain_clock_schedules(
+			float(context.get_clock().get("now_ms", 0.0)), step_generation, clock_run_callbacks_remaining)
+		if clock_execution_limit_reached:
+			push_error("Gua clock execution_limit")
+			clock_execution_limit_reached = false
 		clock_tick.emit(float(step.get("delta_ms", 0.0)) / 1000.0)
+		if bool(step.get("final", false)):
+			clock_run_active = false
+			clock_run_callbacks_remaining = CLOCK_CALLBACK_LIMIT
+			clock_run_generation = -1
 
 	if root == null:
 		push_error("GuaAutoAdapter.update called before attach.")
@@ -223,7 +242,15 @@ func clock_schedule(delay_ms: float, callback: Callable, interval_ms: float = 0.
 	var schedule_id := next_clock_schedule_id
 	next_clock_schedule_id += 1
 	var status := get_clock()
-	clock_schedules.append({"id": schedule_id, "generation": int(status.get("generation", 0)), "due_ms": float(status.get("now_ms", 0.0)) + delay_ms, "interval_ms": interval_ms, "callback": callback})
+	var bind_on_install := not bool(status.get("installed", false))
+	clock_schedules.append({
+		"id": schedule_id,
+		"generation": int(status.get("generation", 0)),
+		"due_ms": delay_ms if bind_on_install else float(status.get("now_ms", 0.0)) + delay_ms,
+		"bind_on_install": bind_on_install,
+		"interval_ms": interval_ms,
+		"callback": callback,
+	})
 	return schedule_id
 
 func clock_cancel(schedule_id: int) -> void:
@@ -231,16 +258,30 @@ func clock_cancel(schedule_id: int) -> void:
 	if active_clock_schedule_id == schedule_id:
 		active_clock_schedule_cancelled = true
 
-func _drain_clock_schedules(now_ms: float, generation: int) -> void:
+func _bind_pending_clock_schedules(status: Dictionary) -> void:
+	if not bool(status.get("installed", false)):
+		return
+	var generation := int(status.get("generation", 0))
+	var now_ms := float(status.get("now_ms", 0.0))
+	for item: Dictionary in clock_schedules:
+		if bool(item.get("bind_on_install", false)):
+			item.generation = generation
+			item.due_ms = now_ms + float(item.get("due_ms", 0.0))
+			item.bind_on_install = false
+
+func _drain_clock_schedules(now_ms: float, generation: int, callback_budget: int) -> int:
 	clock_schedules = clock_schedules.filter(func(item: Dictionary) -> bool: return int(item.get("generation", 0)) == generation)
 	clock_schedules.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
 		return float(a.due_ms) < float(b.due_ms) or (float(a.due_ms) == float(b.due_ms) and int(a.id) < int(b.id)))
 	var callbacks := 0
 	while not clock_schedules.is_empty() and float(clock_schedules[0].due_ms) <= now_ms:
+		if callbacks >= callback_budget:
+			clock_execution_limit_reached = true
+			clock_schedules.clear()
+			active_clock_schedule_id = 0
+			active_clock_schedule_cancelled = false
+			return callbacks
 		callbacks += 1
-		if callbacks > 1000000:
-			push_error("Gua clock execution_limit")
-			return
 		var item: Dictionary = clock_schedules.pop_front()
 		active_clock_schedule_id = int(item.id)
 		active_clock_schedule_cancelled = false
@@ -252,6 +293,7 @@ func _drain_clock_schedules(now_ms: float, generation: int) -> void:
 			return float(a.due_ms) < float(b.due_ms) or (float(a.due_ms) == float(b.due_ms) and int(a.id) < int(b.id)))
 		active_clock_schedule_id = 0
 		active_clock_schedule_cancelled = false
+	return callbacks
 
 
 func reset_context(options: Dictionary = {}) -> Dictionary:
@@ -271,6 +313,10 @@ func reset_context(options: Dictionary = {}) -> Dictionary:
 			clock_schedules.clear()
 			active_clock_schedule_id = 0
 			active_clock_schedule_cancelled = false
+			clock_run_active = false
+			clock_run_callbacks_remaining = CLOCK_CALLBACK_LIMIT
+			clock_run_generation = -1
+			clock_execution_limit_reached = false
 	return report
 
 

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -1,6 +1,8 @@
 class_name GuaAutoAdapter
 extends RefCounted
 
+signal clock_tick(delta: float)
+
 const META_ID := "gua_id"
 const META_SENSITIVE := "gua_sensitive"
 const CONTEXT_CLASS := "GuaContext"
@@ -26,6 +28,13 @@ const REQUIRED_CONTEXT_METHODS := [
 	"poll_event_v2",
 	"get_context_status",
 	"reset_context",
+	"clock_install",
+	"clock_pause",
+	"clock_run_for",
+	"clock_resume",
+	"clock_advance",
+	"get_clock",
+	"consume_clock_steps",
 	"start_inspector_bridge",
 	"inspector_bridge_url",
 ]
@@ -41,6 +50,9 @@ var suppressed_clicks: Dictionary = {}
 var gdextension_resource: Resource
 var unavailable := false
 var screenshot_capture_scheduled := false
+var last_clock_ticks_ms := Time.get_ticks_msec()
+var clock_schedules: Array[Dictionary] = []
+var next_clock_schedule_id := 1
 
 
 func attach(root_control: Control) -> void:
@@ -51,6 +63,14 @@ func attach(root_control: Control) -> void:
 func update(screen: String) -> void:
 	if not _ensure_context():
 		return
+	var ticks_ms := Time.get_ticks_msec()
+	var clock_status: Dictionary = context.get_clock()
+	if clock_status.get("installed", false) and clock_status.get("state", "running") == "running":
+		context.clock_advance(maxi(0, ticks_ms - last_clock_ticks_ms))
+	last_clock_ticks_ms = ticks_ms
+	for step in context.consume_clock_steps():
+		_drain_clock_schedules(float(context.get_clock().get("now_ms", 0.0)))
+		clock_tick.emit(float(step.get("delta_ms", 0.0)) / 1000.0)
 
 	if root == null:
 		push_error("GuaAutoAdapter.update called before attach.")
@@ -171,6 +191,50 @@ func get_context_status() -> Dictionary:
 	if not _ensure_context():
 		return {}
 	return context.get_context_status()
+
+
+func clock_install(initial_time_ms: float = 0.0, step_ms: float = 1000.0 / 60.0) -> Dictionary:
+	return context.clock_install(initial_time_ms, step_ms) if _ensure_context() else {}
+
+func clock_pause() -> Dictionary:
+	return context.clock_pause() if _ensure_context() else {}
+
+func clock_run_for(duration_ms: float, step_ms: float = 0.0) -> Dictionary:
+	return context.clock_run_for(duration_ms, step_ms) if _ensure_context() else {}
+
+func clock_resume() -> Dictionary:
+	return context.clock_resume() if _ensure_context() else {}
+
+func get_clock() -> Dictionary:
+	return context.get_clock() if _ensure_context() else {}
+
+func clock_schedule(delay_ms: float, callback: Callable, interval_ms: float = 0.0) -> int:
+	if delay_ms < 0.0 or interval_ms < 0.0 or not callback.is_valid():
+		return 0
+	var schedule_id := next_clock_schedule_id
+	next_clock_schedule_id += 1
+	clock_schedules.append({"id": schedule_id, "due_ms": float(get_clock().get("now_ms", 0.0)) + delay_ms, "interval_ms": interval_ms, "callback": callback})
+	return schedule_id
+
+func clock_cancel(schedule_id: int) -> void:
+	clock_schedules = clock_schedules.filter(func(item: Dictionary) -> bool: return int(item.id) != schedule_id)
+
+func _drain_clock_schedules(now_ms: float) -> void:
+	clock_schedules.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		return float(a.due_ms) < float(b.due_ms) or (float(a.due_ms) == float(b.due_ms) and int(a.id) < int(b.id)))
+	var callbacks := 0
+	while not clock_schedules.is_empty() and float(clock_schedules[0].due_ms) <= now_ms:
+		callbacks += 1
+		if callbacks > 1000000:
+			push_error("Gua clock execution_limit")
+			return
+		var item: Dictionary = clock_schedules.pop_front()
+		(item.callback as Callable).call()
+		if float(item.interval_ms) > 0.0:
+			item.due_ms = float(item.due_ms) + float(item.interval_ms)
+			clock_schedules.append(item)
+			clock_schedules.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+				return float(a.due_ms) < float(b.due_ms) or (float(a.due_ms) == float(b.due_ms) and int(a.id) < int(b.id)))
 
 
 func reset_context(options: Dictionary = {}) -> Dictionary:

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -278,6 +278,9 @@ func clock_cancel(schedule_id: int) -> void:
 
 func _bind_pending_clock_schedules(status: Dictionary) -> void:
 	if not bool(status.get("installed", false)):
+		var generation := int(status.get("generation", 0))
+		clock_schedules = clock_schedules.filter(func(item: Dictionary) -> bool:
+			return int(item.get("generation", -1)) == generation)
 		return
 	var generation := int(status.get("generation", 0))
 	var now_ms := float(status.get("now_ms", 0.0))

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -94,6 +94,11 @@ func update(screen: String) -> void:
 		if clock_execution_limit_reached:
 			push_error("Gua clock execution_limit")
 			clock_execution_limit_reached = false
+		if int(context.get_clock().get("generation", -1)) != step_generation:
+			clock_run_active = false
+			clock_run_callbacks_remaining = CLOCK_CALLBACK_LIMIT
+			clock_run_generation = -1
+			continue
 		clock_tick.emit(float(step.get("delta_ms", 0.0)) / 1000.0)
 		if bool(step.get("final", false)):
 			clock_run_active = false

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -106,7 +106,7 @@ func update(screen: String) -> void:
 			clock_run_callbacks_remaining = CLOCK_CALLBACK_LIMIT
 			clock_run_generation = -1
 			continue
-		clock_tick.emit(float(step.get("delta_ms", 0.0)) / 1000.0)
+		_dispatch_clock_tick(float(step.get("delta_ms", 0.0)) / 1000.0, step_generation)
 		if bool(step.get("final", false)):
 			clock_run_active = false
 			clock_run_callbacks_remaining = CLOCK_CALLBACK_LIMIT
@@ -126,6 +126,28 @@ func update(screen: String) -> void:
 	_dispatch_click_requests()
 	_dispatch_action_requests()
 	_schedule_screenshot_capture()
+
+
+func _dispatch_clock_tick(delta_seconds: float, step_generation: int) -> void:
+	for connection in get_signal_connection_list(&"clock_tick"):
+		if int(context.get_clock().get("generation", -1)) != step_generation:
+			return
+		var callback: Callable = connection.get("callable", Callable())
+		if not callback.is_valid() or not clock_tick.is_connected(callback):
+			continue
+		var flags := int(connection.get("flags", 0))
+		if flags & CONNECT_ONE_SHOT:
+			clock_tick.disconnect(callback)
+		if flags & CONNECT_DEFERRED:
+			Callable(self, "_dispatch_deferred_clock_tick").bind(
+				callback, delta_seconds, step_generation).call_deferred()
+		else:
+			callback.call(delta_seconds)
+
+
+func _dispatch_deferred_clock_tick(callback: Callable, delta_seconds: float, step_generation: int) -> void:
+	if int(context.get_clock().get("generation", -1)) == step_generation and callback.is_valid():
+		callback.call(delta_seconds)
 
 
 func capture_viewport_screenshot(image_override: Image = null) -> Dictionary:

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -5,6 +5,8 @@ signal clock_tick(delta: float)
 
 const META_ID := "gua_id"
 const META_SENSITIVE := "gua_sensitive"
+const RESET_CLOCK_FLAG := 1 << 6
+const RESET_DEFAULT_FLAGS := 79
 const CONTEXT_CLASS := "GuaContext"
 const GDEXTENSION_RESOURCE := "res://addons/gua/gua.gdextension"
 const REBUILD_COMMAND := "cmake --build --preset windows-msvc-debug --target gua-godot"
@@ -34,6 +36,7 @@ const REQUIRED_CONTEXT_METHODS := [
 	"clock_resume",
 	"clock_advance",
 	"get_clock",
+	"consume_clock_step",
 	"consume_clock_steps",
 	"start_inspector_bridge",
 	"inspector_bridge_url",
@@ -53,6 +56,8 @@ var screenshot_capture_scheduled := false
 var last_clock_ticks_ms := Time.get_ticks_msec()
 var clock_schedules: Array[Dictionary] = []
 var next_clock_schedule_id := 1
+var active_clock_schedule_id := 0
+var active_clock_schedule_cancelled := false
 
 
 func attach(root_control: Control) -> void:
@@ -68,7 +73,10 @@ func update(screen: String) -> void:
 	if clock_status.get("installed", false) and clock_status.get("state", "running") == "running":
 		context.clock_advance(maxi(0, ticks_ms - last_clock_ticks_ms))
 	last_clock_ticks_ms = ticks_ms
-	for step in context.consume_clock_steps():
+	while true:
+		var step: Dictionary = context.consume_clock_step()
+		if step.is_empty():
+			break
 		_drain_clock_schedules(float(context.get_clock().get("now_ms", 0.0)))
 		clock_tick.emit(float(step.get("delta_ms", 0.0)) / 1000.0)
 
@@ -218,6 +226,8 @@ func clock_schedule(delay_ms: float, callback: Callable, interval_ms: float = 0.
 
 func clock_cancel(schedule_id: int) -> void:
 	clock_schedules = clock_schedules.filter(func(item: Dictionary) -> bool: return int(item.id) != schedule_id)
+	if active_clock_schedule_id == schedule_id:
+		active_clock_schedule_cancelled = true
 
 func _drain_clock_schedules(now_ms: float) -> void:
 	clock_schedules.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
@@ -229,12 +239,16 @@ func _drain_clock_schedules(now_ms: float) -> void:
 			push_error("Gua clock execution_limit")
 			return
 		var item: Dictionary = clock_schedules.pop_front()
+		active_clock_schedule_id = int(item.id)
+		active_clock_schedule_cancelled = false
 		(item.callback as Callable).call()
-		if float(item.interval_ms) > 0.0:
+		if float(item.interval_ms) > 0.0 and not active_clock_schedule_cancelled:
 			item.due_ms = float(item.due_ms) + float(item.interval_ms)
 			clock_schedules.append(item)
 			clock_schedules.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
 				return float(a.due_ms) < float(b.due_ms) or (float(a.due_ms) == float(b.due_ms) and int(a.id) < int(b.id)))
+		active_clock_schedule_id = 0
+		active_clock_schedule_cancelled = false
 
 
 func reset_context(options: Dictionary = {}) -> Dictionary:
@@ -250,6 +264,10 @@ func reset_context(options: Dictionary = {}) -> Dictionary:
 		list_items_by_id.clear()
 		controls_by_id.clear()
 		suppressed_clicks.clear()
+		if (int(resolved.get("flags", RESET_DEFAULT_FLAGS)) & RESET_CLOCK_FLAG) != 0:
+			clock_schedules.clear()
+			active_clock_schedule_id = 0
+			active_clock_schedule_cancelled = false
 	return report
 
 

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -255,16 +255,20 @@ func get_clock() -> Dictionary:
 	return context.get_clock() if _ensure_context() else {}
 
 func clock_schedule(delay_ms: float, callback: Callable, interval_ms: float = 0.0) -> int:
-	if delay_ms < 0.0 or interval_ms < 0.0 or not callback.is_valid():
+	if not is_finite(delay_ms) or not is_finite(interval_ms) or delay_ms < 0.0 or interval_ms < 0.0 or not callback.is_valid():
+		return 0
+	var status := get_clock()
+	var bind_on_install := not bool(status.get("installed", false))
+	var now_ms := float(status.get("now_ms", 0.0))
+	var due_ms := delay_ms if bind_on_install else now_ms + delay_ms
+	if not bind_on_install and not _clock_schedule_deadline_is_representable(now_ms, delay_ms, due_ms, interval_ms):
 		return 0
 	var schedule_id := next_clock_schedule_id
 	next_clock_schedule_id += 1
-	var status := get_clock()
-	var bind_on_install := not bool(status.get("installed", false))
 	clock_schedules.append({
 		"id": schedule_id,
 		"generation": int(status.get("generation", 0)),
-		"due_ms": delay_ms if bind_on_install else float(status.get("now_ms", 0.0)) + delay_ms,
+		"due_ms": due_ms,
 		"bind_on_install": bind_on_install,
 		"interval_ms": interval_ms,
 		"callback": callback,
@@ -284,11 +288,19 @@ func _bind_pending_clock_schedules(status: Dictionary) -> void:
 		return
 	var generation := int(status.get("generation", 0))
 	var now_ms := float(status.get("now_ms", 0.0))
+	var retained_schedules: Array[Dictionary] = []
 	for item: Dictionary in clock_schedules:
 		if bool(item.get("bind_on_install", false)) and generation == int(item.get("generation", 0)) + 1:
+			var delay_ms := float(item.get("due_ms", 0.0))
+			var due_ms := now_ms + delay_ms
+			if not _clock_schedule_deadline_is_representable(
+				now_ms, delay_ms, due_ms, float(item.get("interval_ms", 0.0))):
+				continue
 			item.generation = generation
-			item.due_ms = now_ms + float(item.get("due_ms", 0.0))
+			item.due_ms = due_ms
 			item.bind_on_install = false
+		retained_schedules.append(item)
+	clock_schedules = retained_schedules
 
 func _drain_clock_schedules(now_ms: float, generation: int, callback_budget: int) -> int:
 	clock_schedules = clock_schedules.filter(func(item: Dictionary) -> bool: return int(item.get("generation", 0)) == generation)
@@ -315,13 +327,27 @@ func _drain_clock_schedules(now_ms: float, generation: int, callback_budget: int
 			active_clock_schedule_cancelled = false
 			return callbacks
 		if float(item.interval_ms) > 0.0 and not active_clock_schedule_cancelled:
-			item.due_ms = float(item.due_ms) + float(item.interval_ms)
-			clock_schedules.append(item)
+			var previous_due_ms := float(item.due_ms)
+			var next_due_ms := previous_due_ms + float(item.interval_ms)
+			if is_finite(next_due_ms) and next_due_ms > previous_due_ms:
+				item.due_ms = next_due_ms
+				clock_schedules.append(item)
 		clock_schedules.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
 			return float(a.due_ms) < float(b.due_ms) or (float(a.due_ms) == float(b.due_ms) and int(a.id) < int(b.id)))
 		active_clock_schedule_id = 0
 		active_clock_schedule_cancelled = false
 	return callbacks
+
+
+func _clock_schedule_deadline_is_representable(
+	now_ms: float, delay_ms: float, due_ms: float, interval_ms: float) -> bool:
+	if not is_finite(due_ms) or (delay_ms > 0.0 and due_ms <= now_ms):
+		return false
+	if interval_ms > 0.0:
+		var next_due_ms := due_ms + interval_ms
+		if not is_finite(next_due_ms) or next_due_ms <= due_ms:
+			return false
+	return true
 
 
 func reset_context(options: Dictionary = {}) -> Dictionary:

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -286,6 +286,13 @@ func _drain_clock_schedules(now_ms: float, generation: int, callback_budget: int
 		active_clock_schedule_id = int(item.id)
 		active_clock_schedule_cancelled = false
 		(item.callback as Callable).call()
+		var current_generation := int(context.get_clock().get("generation", -1))
+		if current_generation != generation:
+			clock_schedules = clock_schedules.filter(func(candidate: Dictionary) -> bool:
+				return int(candidate.get("generation", -1)) == current_generation)
+			active_clock_schedule_id = 0
+			active_clock_schedule_cancelled = false
+			return callbacks
 		if float(item.interval_ms) > 0.0 and not active_clock_schedule_cancelled:
 			item.due_ms = float(item.due_ms) + float(item.interval_ms)
 			clock_schedules.append(item)

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -330,7 +330,12 @@ func _run() -> void:
 
 	var preinstall_schedule_count := [0]
 	ui.clock_schedule(20.0, func(): preinstall_schedule_count[0] += 1)
-	ui.clock_install(0.0, 10.0)
+	ui.last_clock_ticks_ms = 0
+	var install_started_ticks := Time.get_ticks_msec()
+	var installed_clock := ui.clock_install(0.0, 10.0)
+	if installed_clock.get("result", 0) != 1 or ui.last_clock_ticks_ms < install_started_ticks:
+		_fail("Gua Godot clock retained elapsed time from before installation: %s" % [installed_clock])
+		return
 	ui.clock_pause()
 	var rejected_zero_step := ui.clock_run_for(10.0, 0.0)
 	if rejected_zero_step.get("result", 0) != -1 or rejected_zero_step.get("error", "") != "invalid_duration" or float(ui.get_clock().get("now_ms", -1.0)) != 0.0:

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -368,6 +368,21 @@ func _run() -> void:
 		_fail("Gua clock rescheduled a running interval after it cancelled itself: %d" % interval_count[0])
 		return
 
+	var reset_interval_count := [0]
+	ui.clock_schedule(1.0, func():
+		reset_interval_count[0] += 1
+		ui.reset_context()
+	, 1.0)
+	ui.clock_run_for(10.0, 10.0)
+	ui.update("title")
+	ui.clock_install(0.0, 10.0)
+	ui.clock_pause()
+	ui.clock_run_for(10.0, 10.0)
+	ui.update("title")
+	if reset_interval_count[0] != 1:
+		_fail("Gua clock rescheduled an interval from a reset generation: %d" % reset_interval_count[0])
+		return
+
 	var limited_interval_count := [0]
 	ui.clock_schedule(1.0, func(): limited_interval_count[0] += 1, 1.0)
 	var limit_status := ui.get_clock()

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -328,6 +328,8 @@ func _run() -> void:
 		_fail("Gua smoke leaked a sensitive value in the semantic UI tree.")
 		return
 
+	var preinstall_schedule_count := [0]
+	ui.clock_schedule(20.0, func(): preinstall_schedule_count[0] += 1)
 	ui.clock_install(0.0, 10.0)
 	ui.clock_pause()
 	var clock_order: Array[String] = []
@@ -337,6 +339,9 @@ func _run() -> void:
 	ui.update("title")
 	if clock_order != ["tick:10", "schedule:20", "tick:20", "tick:25"]:
 		_fail("Gua clock did not process schedules and ticks at each step boundary: %s" % [clock_order])
+		return
+	if preinstall_schedule_count[0] != 1:
+		_fail("Gua dropped a game schedule that was registered before clock installation.")
 		return
 	var nested_schedule_order: Array[String] = []
 	var later_schedule_id := ui.clock_schedule(20.0, func(): nested_schedule_order.append("later"))
@@ -362,6 +367,16 @@ func _run() -> void:
 	if interval_count[0] != 1:
 		_fail("Gua clock rescheduled a running interval after it cancelled itself: %d" % interval_count[0])
 		return
+
+	var limited_interval_count := [0]
+	ui.clock_schedule(1.0, func(): limited_interval_count[0] += 1, 1.0)
+	var limit_status := ui.get_clock()
+	var limited_callbacks := ui._drain_clock_schedules(
+		float(limit_status.get("now_ms", 0.0)) + 4.0, int(limit_status.get("generation", 0)), 2)
+	if limited_callbacks != 2 or limited_interval_count[0] != 2 or not ui.clock_schedules.is_empty() or not ui.clock_execution_limit_reached:
+		_fail("Gua clock callback budget did not cancel remaining interval work across the run.")
+		return
+	ui.clock_execution_limit_reached = false
 
 	var stale_schedule_count := [0]
 	ui.clock_schedule(100.0, func(): stale_schedule_count[0] += 1)

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -396,6 +396,17 @@ func _run() -> void:
 		_fail("Gua clock rescheduled an interval from a reset generation: %d" % reset_interval_count[0])
 		return
 
+	var stale_tick_subscriber_count := [0]
+	ui.clock_tick.connect(func(_delta: float): ui.reset_context(), CONNECT_ONE_SHOT)
+	ui.clock_tick.connect(func(_delta: float): stale_tick_subscriber_count[0] += 1, CONNECT_ONE_SHOT)
+	ui.clock_run_for(10.0, 10.0)
+	ui.update("title")
+	if stale_tick_subscriber_count[0] != 0:
+		_fail("Gua invoked a later clock_tick subscriber after an earlier subscriber reset the context.")
+		return
+	ui.clock_install(0.0, 10.0)
+	ui.clock_pause()
+
 	var limited_interval_count := [0]
 	ui.clock_schedule(1.0, func(): limited_interval_count[0] += 1, 1.0)
 	var limit_status := ui.get_clock()

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -319,6 +319,29 @@ func _run() -> void:
 		_fail("Gua smoke leaked a sensitive value in the semantic UI tree.")
 		return
 
+	ui.clock_install(0.0, 10.0)
+	ui.clock_pause()
+	var clock_order: Array[String] = []
+	ui.clock_tick.connect(func(_delta: float): clock_order.append("tick:%d" % int(ui.get_clock().get("now_ms", -1.0))))
+	ui.clock_schedule(20.0, func(): clock_order.append("schedule:%d" % int(ui.get_clock().get("now_ms", -1.0))))
+	ui.clock_run_for(25.0)
+	ui.update("title")
+	if clock_order != ["tick:10", "schedule:20", "tick:20", "tick:25"]:
+		_fail("Gua clock did not process schedules and ticks at each step boundary: %s" % [clock_order])
+		return
+
+	var interval_count := [0]
+	var interval_id := [0]
+	interval_id[0] = ui.clock_schedule(10.0, func():
+		interval_count[0] += 1
+		ui.clock_cancel(interval_id[0])
+	, 10.0)
+	ui.clock_run_for(30.0)
+	ui.update("title")
+	if interval_count[0] != 1:
+		_fail("Gua clock rescheduled a running interval after it cancelled itself: %d" % interval_count[0])
+		return
+
 	var leaked := ui.enqueue_action({"action": "focus", "node_id": "start"})
 	if leaked.get("request_id", 0) == 0:
 		_fail("Gua smoke could not create a pending request for reset validation.")

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -332,6 +332,10 @@ func _run() -> void:
 	ui.clock_schedule(20.0, func(): preinstall_schedule_count[0] += 1)
 	ui.clock_install(0.0, 10.0)
 	ui.clock_pause()
+	var rejected_zero_step := ui.clock_run_for(10.0, 0.0)
+	if rejected_zero_step.get("result", 0) != -1 or rejected_zero_step.get("error", "") != "invalid_duration" or float(ui.get_clock().get("now_ms", -1.0)) != 0.0:
+		_fail("Gua Godot clock accepted an explicitly supplied zero step: %s" % rejected_zero_step)
+		return
 	var clock_order: Array[String] = []
 	ui.clock_tick.connect(func(_delta: float): clock_order.append("tick:%d" % int(ui.get_clock().get("now_ms", -1.0))))
 	ui.clock_schedule(20.0, func(): clock_order.append("schedule:%d" % int(ui.get_clock().get("now_ms", -1.0))))

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -342,6 +342,27 @@ func _run() -> void:
 		_fail("Gua clock rescheduled a running interval after it cancelled itself: %d" % interval_count[0])
 		return
 
+	var stale_schedule_count := [0]
+	ui.clock_schedule(100.0, func(): stale_schedule_count[0] += 1)
+	var clock_reset: Dictionary = ui.context.reset_context({
+		"expected_session_epoch": ui.get_context_status().get("session_epoch", 0),
+		"flags": ui.RESET_CLOCK_FLAG,
+	})
+	if clock_reset.get("result", 0) != 1:
+		_fail("Gua direct clock reset failed: %s" % clock_reset)
+		return
+	var reinstalled_clock := ui.clock_install(0.0, 10.0)
+	ui.clock_pause()
+	ui.clock_run_for(100.0)
+	ui.update("title")
+	if stale_schedule_count[0] != 0:
+		_fail("Gua invoked a schedule from a stale clock generation.")
+		return
+	var rejected_install := ui.clock_install(0.0, 10.0)
+	if reinstalled_clock.get("result", 0) != 1 or rejected_install.get("result", 0) != -3 or rejected_install.get("error", "") != "invalid_state":
+		_fail("Gua Godot clock controls did not surface native operation results: %s / %s" % [reinstalled_clock, rejected_install])
+		return
+
 	var leaked := ui.enqueue_action({"action": "focus", "node_id": "start"})
 	if leaked.get("request_id", 0) == 0:
 		_fail("Gua smoke could not create a pending request for reset validation.")

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -415,6 +415,10 @@ func _run() -> void:
 	if clock_reset.get("result", 0) != 1:
 		_fail("Gua direct clock reset failed: %s" % clock_reset)
 		return
+	ui.update("title")
+	if not ui.clock_schedules.is_empty():
+		_fail("Gua retained schedules after observing a remote clock reset.")
+		return
 	var reinstalled_clock := ui.clock_install(0.0, 10.0)
 	ui.clock_pause()
 	ui.clock_run_for(100.0)

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -116,6 +116,12 @@ func _run() -> void:
 	screen.add_child(scroll)
 
 	await process_frame
+	var extension := load("res://addons/gua/gua.gdextension")
+	var bare_context: Object = ClassDB.instantiate("GuaContext")
+	if extension == null or bare_context == null or bare_context.get_version_json().contains("virtual_clock_v1"):
+		_fail("A bare Godot GuaContext advertised the virtual clock without an adapter pump.")
+		return
+	bare_context = null
 
 	var ui := GuaAutoAdapterScript.new()
 	adapter = ui
@@ -126,6 +132,9 @@ func _run() -> void:
 
 	ui.attach(screen)
 	ui.update("title")
+	if not ui.context.get_version_json().contains("virtual_clock_v1"):
+		_fail("GuaAutoAdapter did not enable its pumped virtual-clock capability.")
+		return
 	await process_frame
 	var smoke_image := Image.create(2, 2, false, Image.FORMAT_RGBA8)
 	smoke_image.fill(Color(0.2, 0.4, 0.6, 1.0))

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -431,6 +431,41 @@ func _run() -> void:
 		_fail("Gua Godot clock controls did not surface native operation results: %s / %s" % [reinstalled_clock, rejected_install])
 		return
 
+	var precision_reset := ui.reset_context({
+		"expected_session_epoch": ui.get_context_status().get("session_epoch", 0),
+		"flags": ui.RESET_CLOCK_FLAG,
+	})
+	var invalid_preinstall_interval_count := [0]
+	var pending_precision_schedule := ui.clock_schedule(
+		0.0, func(): invalid_preinstall_interval_count[0] += 1, 1.0)
+	var precision_install := ui.clock_install(1e16, 2.0)
+	ui.clock_pause()
+	ui.update("title")
+	if precision_reset.get("result", 0) != 1 or pending_precision_schedule == 0 or precision_install.get("result", 0) != 1 \
+			or invalid_preinstall_interval_count[0] != 0 or not ui.clock_schedules.is_empty():
+		_fail("Gua retained a pre-install interval that cannot advance the installed timeline.")
+		return
+	if ui.clock_schedule(0.0, func(): invalid_preinstall_interval_count[0] += 1, 1.0) != 0:
+		_fail("Gua accepted an interval that cannot advance its representable deadline.")
+		return
+	var precision_status := ui.get_clock()
+	var precision_generation := int(precision_status.get("generation", 0))
+	var precision_now_ms := float(precision_status.get("now_ms", 0.0))
+	ui.clock_schedules.append({
+		"id": ui.next_clock_schedule_id,
+		"generation": precision_generation,
+		"due_ms": precision_now_ms,
+		"bind_on_install": false,
+		"interval_ms": 1.0,
+		"callback": func(): invalid_preinstall_interval_count[0] += 1,
+	})
+	ui.next_clock_schedule_id += 1
+	var precision_callbacks := ui._drain_clock_schedules(precision_now_ms, precision_generation, 10)
+	if precision_callbacks != 1 or invalid_preinstall_interval_count[0] != 1 \
+			or not ui.clock_schedules.is_empty() or ui.clock_execution_limit_reached:
+		_fail("Gua reinserted a repeating schedule whose deadline did not advance.")
+		return
+
 	var leaked := ui.enqueue_action({"action": "focus", "node_id": "start"})
 	if leaked.get("request_id", 0) == 0:
 		_fail("Gua smoke could not create a pending request for reset validation.")

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -338,6 +338,18 @@ func _run() -> void:
 	if clock_order != ["tick:10", "schedule:20", "tick:20", "tick:25"]:
 		_fail("Gua clock did not process schedules and ticks at each step boundary: %s" % [clock_order])
 		return
+	var nested_schedule_order: Array[String] = []
+	var later_schedule_id := ui.clock_schedule(20.0, func(): nested_schedule_order.append("later"))
+	ui.clock_schedule(10.0, func():
+		nested_schedule_order.append("parent")
+		ui.clock_schedule(0.0, func(): nested_schedule_order.append("nested"))
+	)
+	ui.clock_run_for(10.0)
+	ui.update("title")
+	ui.clock_cancel(later_schedule_id)
+	if nested_schedule_order != ["parent", "nested"]:
+		_fail("Gua clock deferred a due schedule created by a running callback: %s" % [nested_schedule_order])
+		return
 
 	var interval_count := [0]
 	var interval_id := [0]

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -373,12 +373,16 @@ func _run() -> void:
 		return
 
 	var reset_interval_count := [0]
+	var tick_count_before_reset := clock_order.size()
 	ui.clock_schedule(1.0, func():
 		reset_interval_count[0] += 1
 		ui.reset_context()
 	, 1.0)
 	ui.clock_run_for(10.0, 10.0)
 	ui.update("title")
+	if clock_order.size() != tick_count_before_reset:
+		_fail("Gua emitted a stale clock tick after a reset callback: %s" % [clock_order])
+		return
 	ui.clock_install(0.0, 10.0)
 	ui.clock_pause()
 	ui.clock_run_for(10.0, 10.0)

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -55,6 +55,13 @@ typedef struct gua_clock_step_t {
     uint64_t generation;
 } gua_clock_step_t;
 
+typedef struct gua_clock_operation_status_t {
+    uint32_t struct_size;
+    uint64_t latest_operation_sequence;
+    uint64_t pending_operation_sequence;
+    uint64_t completed_operation_sequence;
+} gua_clock_operation_status_t;
+
 enum {
     GUA_ACTION_ACCEPTED = 1,
     GUA_ACTION_ERROR_INVALID_ARGUMENT = -1,
@@ -353,6 +360,7 @@ int gua_clock_run_for(gua_context_t* ctx, double duration_ms, double step_ms);
 int gua_clock_advance(gua_context_t* ctx, double duration_ms);
 int gua_clock_resume(gua_context_t* ctx);
 int gua_clock_get_status(gua_context_t* ctx, gua_clock_status_t* out_status);
+int gua_clock_get_operation_status(gua_context_t* ctx, gua_clock_operation_status_t* out_status);
 int gua_clock_copy_status_json(gua_context_t* ctx, char* out_json, int out_json_size);
 int gua_clock_consume_step(gua_context_t* ctx, gua_clock_step_t* out_step);
 int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state);

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -144,7 +144,14 @@ enum {
     GUA_RESET_LOGS = 1U << 4,
     GUA_RESET_SCREENSHOT = 1U << 5,
     GUA_RESET_CLOCK = 1U << 6,
-    GUA_RESET_DEFAULT = GUA_RESET_NODES | GUA_RESET_REQUESTS | GUA_RESET_EVENTS | GUA_RESET_HISTORY | GUA_RESET_CLOCK
+    /* Published legacy value. Use GUA_RESET_DEFAULT_V2 for current default behavior. */
+    GUA_RESET_DEFAULT = GUA_RESET_NODES | GUA_RESET_REQUESTS | GUA_RESET_EVENTS | GUA_RESET_HISTORY,
+    GUA_RESET_DEFAULT_V2 = GUA_RESET_DEFAULT | GUA_RESET_CLOCK
+};
+
+enum {
+    GUA_RESET_FLAGS_VERSION_LEGACY = 0,
+    GUA_RESET_FLAGS_VERSION_CURRENT = 1
 };
 
 enum {
@@ -176,6 +183,7 @@ typedef struct gua_reset_options_t {
     uint32_t flags;
     int strict;
     uint64_t expected_session_epoch;
+    uint32_t flags_version;
 } gua_reset_options_t;
 
 typedef struct gua_reset_report_t {

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -31,6 +31,31 @@ enum {
 };
 
 enum {
+    GUA_CLOCK_OK = 1,
+    GUA_CLOCK_ERROR_INVALID_ARGUMENT = -1,
+    GUA_CLOCK_ERROR_NOT_INSTALLED = -2,
+    GUA_CLOCK_ERROR_INVALID_STATE = -3,
+    GUA_CLOCK_ERROR_EXECUTION_LIMIT = -4
+};
+
+typedef struct gua_clock_status_t {
+    uint32_t struct_size;
+    int installed;
+    int paused;
+    double now_ms;
+    double default_step_ms;
+    double pending_ms;
+    uint64_t generation;
+} gua_clock_status_t;
+
+typedef struct gua_clock_step_t {
+    uint32_t struct_size;
+    double delta_ms;
+    int final_step;
+    uint64_t generation;
+} gua_clock_step_t;
+
+enum {
     GUA_ACTION_ACCEPTED = 1,
     GUA_ACTION_ERROR_INVALID_ARGUMENT = -1,
     GUA_ACTION_ERROR_NODE_NOT_FOUND = -2,
@@ -111,7 +136,8 @@ enum {
     GUA_RESET_HISTORY = 1U << 3,
     GUA_RESET_LOGS = 1U << 4,
     GUA_RESET_SCREENSHOT = 1U << 5,
-    GUA_RESET_DEFAULT = GUA_RESET_NODES | GUA_RESET_REQUESTS | GUA_RESET_EVENTS | GUA_RESET_HISTORY
+    GUA_RESET_CLOCK = 1U << 6,
+    GUA_RESET_DEFAULT = GUA_RESET_NODES | GUA_RESET_REQUESTS | GUA_RESET_EVENTS | GUA_RESET_HISTORY | GUA_RESET_CLOCK
 };
 
 enum {
@@ -321,6 +347,14 @@ const char* gua_get_diagnostics_json(gua_context_t* ctx);
 int gua_copy_diagnostics_json(gua_context_t* ctx, char* out_json, int out_json_size);
 /* Returns version/capability JSON. The required byte size includes the trailing NUL. */
 int gua_copy_version_json(char* out_json, int out_json_size);
+int gua_clock_install(gua_context_t* ctx, double initial_time_ms, double step_ms);
+int gua_clock_pause(gua_context_t* ctx);
+int gua_clock_run_for(gua_context_t* ctx, double duration_ms, double step_ms);
+int gua_clock_advance(gua_context_t* ctx, double duration_ms);
+int gua_clock_resume(gua_context_t* ctx);
+int gua_clock_get_status(gua_context_t* ctx, gua_clock_status_t* out_status);
+int gua_clock_copy_status_json(gua_context_t* ctx, char* out_json, int out_json_size);
+int gua_clock_consume_step(gua_context_t* ctx, gua_clock_step_t* out_step);
 int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state);
 /* Returns 0 rather than a partial state when a v2 string does not fit its fixed output buffer. */
 int gua_get_node_state_v2(gua_context_t* ctx, const char* node_id, gua_node_state_v2_t* out_state);

--- a/native/gua-core/include/gua/gua.hpp
+++ b/native/gua-core/include/gua/gua.hpp
@@ -123,7 +123,9 @@ public:
     void install_clock(double initial_time_ms = 0.0, double step_ms = 1000.0 / 60.0)
     { check_clock(gua_clock_install(context_, initial_time_ms, step_ms)); }
     void pause_clock() { check_clock(gua_clock_pause(context_)); }
-    void run_clock_for(double duration_ms, double step_ms = 1000.0 / 60.0)
+    void run_clock_for(double duration_ms)
+    { run_clock_for(duration_ms, clock_status().default_step_ms); }
+    void run_clock_for(double duration_ms, double step_ms)
     { check_clock(gua_clock_run_for(context_, duration_ms, step_ms)); }
     void resume_clock() { check_clock(gua_clock_resume(context_)); }
     [[nodiscard]] gua_clock_status_t clock_status() const

--- a/native/gua-core/include/gua/gua.hpp
+++ b/native/gua-core/include/gua/gua.hpp
@@ -120,6 +120,17 @@ public:
         return context_;
     }
 
+    void install_clock(double initial_time_ms = 0.0, double step_ms = 1000.0 / 60.0)
+    { check_clock(gua_clock_install(context_, initial_time_ms, step_ms)); }
+    void pause_clock() { check_clock(gua_clock_pause(context_)); }
+    void run_clock_for(double duration_ms, double step_ms = 1000.0 / 60.0)
+    { check_clock(gua_clock_run_for(context_, duration_ms, step_ms)); }
+    void resume_clock() { check_clock(gua_clock_resume(context_)); }
+    [[nodiscard]] gua_clock_status_t clock_status() const
+    { gua_clock_status_t value { sizeof(gua_clock_status_t) }; if (!gua_clock_get_status(context_, &value)) throw std::runtime_error("Failed to inspect Gua clock"); return value; }
+    bool poll_clock_step(gua_clock_step_t& step)
+    { step = gua_clock_step_t { sizeof(gua_clock_step_t) }; return gua_clock_consume_step(context_, &step) != 0; }
+
     void begin_frame(std::string_view screen)
     {
         screen_buffer_.assign(screen);
@@ -353,6 +364,7 @@ public:
     }
 
 private:
+    static void check_clock(int result) { if (result != GUA_CLOCK_OK) throw std::runtime_error("Gua clock operation failed: " + std::to_string(result)); }
     template <typename CopyJson>
     [[nodiscard]] std::string copy_json(CopyJson copy) const
     {

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -376,7 +376,7 @@ bool prepare_clock_operation(
     double quotient = duration_ms / step_ms;
     const double nearest = std::round(quotient);
     const double quotient_tolerance = std::numeric_limits<double>::epsilon() * 8.0 * std::max(1.0, std::abs(quotient));
-    if (std::abs(quotient - nearest) <= quotient_tolerance) quotient = nearest;
+    if (nearest >= 1.0 && std::abs(quotient - nearest) <= quotient_tolerance) quotient = nearest;
     step_count = static_cast<unsigned long long>(std::ceil(quotient));
     while (step_count > 1) {
         const double previous_elapsed_ms = std::min(duration_ms, step_ms * static_cast<double>(step_count - 1));

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -32,7 +32,7 @@ std::string build_version_json(const char* godot_plugin_version = nullptr)
     return "{\"protocolSchemaVersion\":\"2\",\"coreVersion\":\"" GUA_VERSION
         "\",\"runtimeVersion\":\"" GUA_VERSION "\",\"godotPluginVersion\":" + plugin + ",\"adapterVersions\":{}" +
         ",\"abiVersion\":1,\"buildId\":\"" GUA_BUILD_ID
-        "\",\"capabilities\":[\"semantic_ui_tree_v2\",\"detailed_semantic_state_v1\",\"semantic_actions_v2\",\"context_reset_v1\",\"diagnostics_v1\",\"version_v1\",\"capture_screenshot_v1\"]}";
+        "\",\"capabilities\":[\"semantic_ui_tree_v2\",\"detailed_semantic_state_v1\",\"semantic_actions_v2\",\"context_reset_v1\",\"diagnostics_v1\",\"version_v1\",\"capture_screenshot_v1\",\"virtual_clock_v1\"]}";
 }
 
 struct Node {
@@ -339,6 +339,13 @@ struct gua_context_t {
     unsigned long long next_history_sequence = 1;
     std::chrono::steady_clock::time_point diagnostics_history_started_at = std::chrono::steady_clock::now();
     std::string diagnostics_environment_json = "{}";
+    bool clock_installed = false;
+    bool clock_paused = false;
+    double clock_now_ms = 0.0;
+    double clock_default_step_ms = 1000.0 / 60.0;
+    double clock_pending_ms = 0.0;
+    double clock_pending_step_ms = 1000.0 / 60.0;
+    unsigned long long clock_generation = 0;
 };
 
 namespace {
@@ -876,6 +883,98 @@ extern "C" int gua_copy_version_json(char* out_json, int out_json_size)
     return copy_json_string(build_version_json(), out_json, out_json_size);
 }
 
+extern "C" int gua_clock_install(gua_context_t* ctx, double initial_time_ms, double step_ms)
+{
+    if (ctx == nullptr || !std::isfinite(initial_time_ms) || initial_time_ms < 0.0 ||
+        !std::isfinite(step_ms) || step_ms <= 0.0) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(ctx->mutex);
+    ctx->clock_installed = true;
+    ctx->clock_paused = false;
+    ctx->clock_now_ms = initial_time_ms;
+    ctx->clock_default_step_ms = step_ms;
+    ctx->clock_pending_ms = 0.0;
+    ctx->clock_pending_step_ms = step_ms;
+    ++ctx->clock_generation;
+    return GUA_CLOCK_OK;
+}
+
+extern "C" int gua_clock_pause(gua_context_t* ctx)
+{
+    if (ctx == nullptr) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(ctx->mutex);
+    if (!ctx->clock_installed) return GUA_CLOCK_ERROR_NOT_INSTALLED;
+    ctx->clock_paused = true;
+    return GUA_CLOCK_OK;
+}
+
+extern "C" int gua_clock_run_for(gua_context_t* ctx, double duration_ms, double step_ms)
+{
+    if (ctx == nullptr || !std::isfinite(duration_ms) || duration_ms < 0.0 ||
+        !std::isfinite(step_ms) || step_ms <= 0.0) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(ctx->mutex);
+    if (!ctx->clock_installed) return GUA_CLOCK_ERROR_NOT_INSTALLED;
+    if (!ctx->clock_paused || ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
+    if (duration_ms / step_ms > 1000000.0) return GUA_CLOCK_ERROR_EXECUTION_LIMIT;
+    ctx->clock_pending_ms = duration_ms;
+    ctx->clock_pending_step_ms = step_ms;
+    return GUA_CLOCK_OK;
+}
+
+extern "C" int gua_clock_resume(gua_context_t* ctx)
+{
+    if (ctx == nullptr) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(ctx->mutex);
+    if (!ctx->clock_installed) return GUA_CLOCK_ERROR_NOT_INSTALLED;
+    if (ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
+    ctx->clock_paused = false;
+    return GUA_CLOCK_OK;
+}
+
+extern "C" int gua_clock_advance(gua_context_t* ctx, double duration_ms)
+{
+    if (ctx == nullptr || !std::isfinite(duration_ms) || duration_ms < 0.0) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(ctx->mutex);
+    if (!ctx->clock_installed) return GUA_CLOCK_ERROR_NOT_INSTALLED;
+    if (ctx->clock_paused || ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
+    ctx->clock_pending_ms = duration_ms;
+    ctx->clock_pending_step_ms = ctx->clock_default_step_ms;
+    return GUA_CLOCK_OK;
+}
+
+extern "C" int gua_clock_get_status(gua_context_t* ctx, gua_clock_status_t* out_status)
+{
+    if (ctx == nullptr || out_status == nullptr || out_status->struct_size < sizeof(gua_clock_status_t)) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    *out_status = gua_clock_status_t { sizeof(gua_clock_status_t), ctx->clock_installed ? 1 : 0,
+        ctx->clock_paused ? 1 : 0, ctx->clock_now_ms, ctx->clock_default_step_ms,
+        ctx->clock_pending_ms, ctx->clock_generation };
+    return 1;
+}
+
+extern "C" int gua_clock_copy_status_json(gua_context_t* ctx, char* out_json, int out_json_size)
+{
+    if (ctx == nullptr) return copy_json_string("{}", out_json, out_json_size);
+    const std::lock_guard lock(ctx->mutex);
+    char json[320];
+    std::snprintf(json, sizeof(json),
+        "{\"schemaVersion\":1,\"installed\":%s,\"state\":\"%s\",\"nowMs\":%.6f,\"defaultStepMs\":%.6f,\"pendingMs\":%.6f,\"generation\":%llu}",
+        ctx->clock_installed ? "true" : "false", ctx->clock_paused ? "paused" : "running",
+        ctx->clock_now_ms, ctx->clock_default_step_ms, ctx->clock_pending_ms, ctx->clock_generation);
+    return copy_json_string(json, out_json, out_json_size);
+}
+
+extern "C" int gua_clock_consume_step(gua_context_t* ctx, gua_clock_step_t* out_step)
+{
+    if (ctx == nullptr || out_step == nullptr || out_step->struct_size < sizeof(gua_clock_step_t)) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    if (!ctx->clock_installed || ctx->clock_pending_ms <= 0.0) return 0;
+    const double delta = std::min(ctx->clock_pending_ms, ctx->clock_pending_step_ms);
+    ctx->clock_pending_ms = std::max(0.0, ctx->clock_pending_ms - delta);
+    ctx->clock_now_ms += delta;
+    *out_step = gua_clock_step_t { sizeof(gua_clock_step_t), delta, ctx->clock_pending_ms <= 0.0 ? 1 : 0, ctx->clock_generation };
+    return 1;
+}
+
 extern "C" int gua_get_node_state(gua_context_t* ctx, const char* node_id, gua_node_state_t* out_state)
 {
     if (ctx == nullptr || node_id == nullptr || out_state == nullptr) {
@@ -1268,7 +1367,7 @@ extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* 
 {
     if (ctx == nullptr || options == nullptr || options->struct_size < sizeof(gua_reset_options_t) ||
         out_report == nullptr || out_report->struct_size < sizeof(gua_reset_report_t)) return GUA_RESET_ERROR_INVALID_ARGUMENT;
-    const uint32_t known_flags = GUA_RESET_NODES | GUA_RESET_REQUESTS | GUA_RESET_EVENTS | GUA_RESET_HISTORY | GUA_RESET_LOGS | GUA_RESET_SCREENSHOT;
+    const uint32_t known_flags = GUA_RESET_NODES | GUA_RESET_REQUESTS | GUA_RESET_EVENTS | GUA_RESET_HISTORY | GUA_RESET_LOGS | GUA_RESET_SCREENSHOT | GUA_RESET_CLOCK;
     if ((options->flags & ~known_flags) != 0U) return GUA_RESET_ERROR_INVALID_ARGUMENT;
 
     const std::lock_guard lock(ctx->mutex);
@@ -1327,6 +1426,10 @@ extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* 
     if ((options->flags & GUA_RESET_SCREENSHOT) != 0U) {
         ctx->screenshot = Screenshot {};
         ctx->screenshot_json_cache.clear();
+    }
+    if ((options->flags & GUA_RESET_CLOCK) != 0U) {
+        ctx->clock_installed = false; ctx->clock_paused = false; ctx->clock_now_ms = 0.0;
+        ctx->clock_pending_ms = 0.0; ++ctx->clock_generation;
     }
     ctx->frame_sequence = 0;
     ctx->revision = 0;

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -350,20 +350,49 @@ struct gua_context_t {
     double clock_pending_ms = 0.0;
     double clock_pending_step_ms = 1000.0 / 60.0;
     double clock_pending_total_ms = 0.0;
+    double clock_pending_start_ms = 0.0;
+    double clock_pending_elapsed_ms = 0.0;
     double clock_pending_target_ms = 0.0;
+    unsigned long long clock_pending_step_count = 0;
+    unsigned long long clock_pending_step_index = 0;
+    unsigned long long next_clock_operation_sequence = 1;
+    unsigned long long clock_pending_operation_sequence = 0;
+    unsigned long long clock_awaiting_frame_operation_sequence = 0;
+    unsigned long long clock_completed_operation_sequence = 0;
     unsigned long long clock_generation = 0;
 };
 
 namespace {
 
-bool clock_operation_representable(double now_ms, double duration_ms, double step_ms, double& target_ms)
+bool prepare_clock_operation(
+    double now_ms, double duration_ms, double step_ms, double& target_ms, unsigned long long& step_count)
 {
     target_ms = now_ms + duration_ms;
     if (!std::isfinite(target_ms)) return false;
-    if (duration_ms == 0.0) return true;
+    if (duration_ms == 0.0) { step_count = 0; return true; }
     const double emitted_step_ms = std::min(duration_ms, step_ms);
-    return target_ms > now_ms && now_ms + emitted_step_ms > now_ms &&
-        target_ms - emitted_step_ms < target_ms;
+    if (target_ms <= now_ms || now_ms + emitted_step_ms <= now_ms ||
+        target_ms - emitted_step_ms >= target_ms) return false;
+    double quotient = duration_ms / step_ms;
+    const double nearest = std::round(quotient);
+    const double quotient_tolerance = std::numeric_limits<double>::epsilon() * 8.0 * std::max(1.0, std::abs(quotient));
+    if (std::abs(quotient - nearest) <= quotient_tolerance) quotient = nearest;
+    step_count = static_cast<unsigned long long>(std::ceil(quotient));
+    while (step_count > 1) {
+        const double previous_elapsed_ms = std::min(duration_ms, step_ms * static_cast<double>(step_count - 1));
+        if (now_ms + previous_elapsed_ms < target_ms) break;
+        --step_count;
+    }
+    if (step_count == 0) return false;
+    double previous_boundary_ms = now_ms;
+    for (unsigned long long index = 1; index <= step_count; ++index) {
+        const double elapsed_ms = index == step_count ? duration_ms :
+            std::min(duration_ms, step_ms * static_cast<double>(index));
+        const double boundary_ms = index == step_count ? target_ms : now_ms + elapsed_ms;
+        if (!std::isfinite(boundary_ms) || boundary_ms <= previous_boundary_ms) return false;
+        previous_boundary_ms = boundary_ms;
+    }
+    return true;
 }
 
 int copy_json_string(const std::string& json, char* out_json, int out_json_size)
@@ -660,6 +689,11 @@ extern "C" void gua_end_frame(gua_context_t* ctx)
     ctx->staging_nodes.clear();
     ctx->frame_in_progress = false;
     ++ctx->frame_sequence;
+    if (ctx->clock_awaiting_frame_operation_sequence != 0) {
+        ctx->clock_completed_operation_sequence = std::max(
+            ctx->clock_completed_operation_sequence, ctx->clock_awaiting_frame_operation_sequence);
+        ctx->clock_awaiting_frame_operation_sequence = 0;
+    }
     if (semantic_snapshot != ctx->previous_semantic_snapshot) {
         ++ctx->revision;
         ctx->previous_semantic_snapshot = semantic_snapshot;
@@ -902,7 +936,9 @@ extern "C" int gua_copy_version_json(char* out_json, int out_json_size)
 extern "C" int gua_clock_install(gua_context_t* ctx, double initial_time_ms, double step_ms)
 {
     if (ctx == nullptr || !std::isfinite(initial_time_ms) || initial_time_ms < 0.0 ||
-        !std::isfinite(step_ms) || step_ms <= 0.0) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+        !std::isfinite(step_ms) || step_ms <= 0.0 || !std::isfinite(initial_time_ms + step_ms) ||
+        initial_time_ms + step_ms <= initial_time_ms)
+        return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     const std::lock_guard lock(ctx->mutex);
     if (ctx->clock_installed) return GUA_CLOCK_ERROR_INVALID_STATE;
     ctx->clock_installed = true;
@@ -912,7 +948,11 @@ extern "C" int gua_clock_install(gua_context_t* ctx, double initial_time_ms, dou
     ctx->clock_pending_ms = 0.0;
     ctx->clock_pending_step_ms = step_ms;
     ctx->clock_pending_total_ms = 0.0;
+    ctx->clock_pending_start_ms = initial_time_ms;
+    ctx->clock_pending_elapsed_ms = 0.0;
     ctx->clock_pending_target_ms = initial_time_ms;
+    ctx->clock_pending_step_count = 0;
+    ctx->clock_pending_step_index = 0;
     ++ctx->clock_generation;
     return GUA_CLOCK_OK;
 }
@@ -936,12 +976,23 @@ extern "C" int gua_clock_run_for(gua_context_t* ctx, double duration_ms, double 
     if (!ctx->clock_paused || ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
     if (duration_ms / step_ms > 1000000.0) return GUA_CLOCK_ERROR_EXECUTION_LIMIT;
     double target_ms = 0.0;
-    if (!clock_operation_representable(ctx->clock_now_ms, duration_ms, step_ms, target_ms))
+    unsigned long long step_count = 0;
+    if (!prepare_clock_operation(ctx->clock_now_ms, duration_ms, step_ms, target_ms, step_count))
         return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     ctx->clock_pending_ms = duration_ms;
     ctx->clock_pending_step_ms = step_ms;
     ctx->clock_pending_total_ms = duration_ms;
+    ctx->clock_pending_start_ms = ctx->clock_now_ms;
+    ctx->clock_pending_elapsed_ms = 0.0;
     ctx->clock_pending_target_ms = target_ms;
+    ctx->clock_pending_step_count = step_count;
+    ctx->clock_pending_step_index = 0;
+    ctx->clock_pending_operation_sequence = ctx->next_clock_operation_sequence++;
+    if (duration_ms == 0.0) {
+        ctx->clock_awaiting_frame_operation_sequence = std::max(
+            ctx->clock_awaiting_frame_operation_sequence, ctx->clock_pending_operation_sequence);
+        ctx->clock_pending_operation_sequence = 0;
+    }
     return GUA_CLOCK_OK;
 }
 
@@ -963,12 +1014,24 @@ extern "C" int gua_clock_advance(gua_context_t* ctx, double duration_ms)
     if (ctx->clock_paused || ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
     if (duration_ms / ctx->clock_default_step_ms > 1000000.0) return GUA_CLOCK_ERROR_EXECUTION_LIMIT;
     double target_ms = 0.0;
-    if (!clock_operation_representable(ctx->clock_now_ms, duration_ms, ctx->clock_default_step_ms, target_ms))
+    unsigned long long step_count = 0;
+    if (!prepare_clock_operation(
+            ctx->clock_now_ms, duration_ms, ctx->clock_default_step_ms, target_ms, step_count))
         return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     ctx->clock_pending_ms = duration_ms;
     ctx->clock_pending_step_ms = ctx->clock_default_step_ms;
     ctx->clock_pending_total_ms = duration_ms;
+    ctx->clock_pending_start_ms = ctx->clock_now_ms;
+    ctx->clock_pending_elapsed_ms = 0.0;
     ctx->clock_pending_target_ms = target_ms;
+    ctx->clock_pending_step_count = step_count;
+    ctx->clock_pending_step_index = 0;
+    ctx->clock_pending_operation_sequence = ctx->next_clock_operation_sequence++;
+    if (duration_ms == 0.0) {
+        ctx->clock_awaiting_frame_operation_sequence = std::max(
+            ctx->clock_awaiting_frame_operation_sequence, ctx->clock_pending_operation_sequence);
+        ctx->clock_pending_operation_sequence = 0;
+    }
     return GUA_CLOCK_OK;
 }
 
@@ -979,6 +1042,16 @@ extern "C" int gua_clock_get_status(gua_context_t* ctx, gua_clock_status_t* out_
     *out_status = gua_clock_status_t { sizeof(gua_clock_status_t), ctx->clock_installed ? 1 : 0,
         ctx->clock_paused ? 1 : 0, ctx->clock_now_ms, ctx->clock_default_step_ms,
         ctx->clock_pending_ms, ctx->clock_generation };
+    return 1;
+}
+
+extern "C" int gua_clock_get_operation_status(gua_context_t* ctx, gua_clock_operation_status_t* out_status)
+{
+    if (ctx == nullptr || out_status == nullptr || out_status->struct_size < sizeof(gua_clock_operation_status_t)) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    *out_status = gua_clock_operation_status_t { sizeof(gua_clock_operation_status_t),
+        ctx->next_clock_operation_sequence - 1, ctx->clock_pending_operation_sequence,
+        ctx->clock_completed_operation_sequence };
     return 1;
 }
 
@@ -994,7 +1067,8 @@ extern "C" int gua_clock_copy_status_json(gua_context_t* ctx, char* out_json, in
          << "\",\"nowMs\":" << ctx->clock_now_ms
          << ",\"defaultStepMs\":" << ctx->clock_default_step_ms
          << ",\"pendingMs\":" << ctx->clock_pending_ms
-         << ",\"generation\":" << ctx->clock_generation << '}';
+         << ",\"generation\":" << ctx->clock_generation
+         << ",\"completedOperationSequence\":" << ctx->clock_completed_operation_sequence << '}';
     return copy_json_string(json.str(), out_json, out_json_size);
 }
 
@@ -1003,14 +1077,21 @@ extern "C" int gua_clock_consume_step(gua_context_t* ctx, gua_clock_step_t* out_
     if (ctx == nullptr || out_step == nullptr || out_step->struct_size < sizeof(gua_clock_step_t)) return 0;
     const std::lock_guard lock(ctx->mutex);
     if (!ctx->clock_installed || ctx->clock_pending_ms <= 0.0) return 0;
-    const double tolerance = std::numeric_limits<double>::epsilon() * 8.0 *
-        std::max(ctx->clock_pending_total_ms, ctx->clock_pending_step_ms);
-    const bool final_step = ctx->clock_pending_ms <= ctx->clock_pending_step_ms ||
-        ctx->clock_pending_ms - ctx->clock_pending_step_ms <= tolerance;
-    const double delta = final_step ? ctx->clock_pending_ms : ctx->clock_pending_step_ms;
-    ctx->clock_pending_ms = final_step ? 0.0 : ctx->clock_pending_ms - delta;
-    ctx->clock_now_ms = final_step ? ctx->clock_pending_target_ms : ctx->clock_now_ms + delta;
-    if (final_step) ctx->clock_pending_total_ms = 0.0;
+    ++ctx->clock_pending_step_index;
+    const bool final_step = ctx->clock_pending_step_index >= ctx->clock_pending_step_count;
+    const double next_elapsed_ms = final_step ? ctx->clock_pending_total_ms :
+        std::min(ctx->clock_pending_total_ms,
+            ctx->clock_pending_step_ms * static_cast<double>(ctx->clock_pending_step_index));
+    const double delta = next_elapsed_ms - ctx->clock_pending_elapsed_ms;
+    ctx->clock_pending_elapsed_ms = next_elapsed_ms;
+    ctx->clock_pending_ms = final_step ? 0.0 : ctx->clock_pending_total_ms - next_elapsed_ms;
+    ctx->clock_now_ms = final_step ? ctx->clock_pending_target_ms : ctx->clock_pending_start_ms + next_elapsed_ms;
+    if (final_step) {
+        ctx->clock_pending_total_ms = 0.0;
+        ctx->clock_awaiting_frame_operation_sequence = std::max(
+            ctx->clock_awaiting_frame_operation_sequence, ctx->clock_pending_operation_sequence);
+        ctx->clock_pending_operation_sequence = 0;
+    }
     *out_step = gua_clock_step_t { sizeof(gua_clock_step_t), delta, final_step ? 1 : 0, ctx->clock_generation };
     return 1;
 }
@@ -1469,7 +1550,10 @@ extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* 
     }
     if ((options->flags & GUA_RESET_CLOCK) != 0U) {
         ctx->clock_installed = false; ctx->clock_paused = false; ctx->clock_now_ms = 0.0;
-        ctx->clock_pending_ms = 0.0; ctx->clock_pending_total_ms = 0.0; ctx->clock_pending_target_ms = 0.0;
+        ctx->clock_pending_ms = 0.0; ctx->clock_pending_total_ms = 0.0; ctx->clock_pending_elapsed_ms = 0.0;
+        ctx->clock_pending_target_ms = 0.0; ctx->clock_pending_step_count = 0; ctx->clock_pending_step_index = 0;
+        ctx->clock_pending_operation_sequence = 0; ctx->clock_awaiting_frame_operation_sequence = 0;
+        ctx->clock_completed_operation_sequence = ctx->next_clock_operation_sequence - 1;
         ++ctx->clock_generation;
     }
     ctx->frame_sequence = 0;

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -8,7 +8,11 @@
 #include <cmath>
 #include <memory>
 #include <mutex>
+#include <iomanip>
+#include <limits>
+#include <locale>
 #include <regex>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -888,6 +892,7 @@ extern "C" int gua_clock_install(gua_context_t* ctx, double initial_time_ms, dou
     if (ctx == nullptr || !std::isfinite(initial_time_ms) || initial_time_ms < 0.0 ||
         !std::isfinite(step_ms) || step_ms <= 0.0) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     const std::lock_guard lock(ctx->mutex);
+    if (ctx->clock_installed) return GUA_CLOCK_ERROR_INVALID_STATE;
     ctx->clock_installed = true;
     ctx->clock_paused = false;
     ctx->clock_now_ms = initial_time_ms;
@@ -936,6 +941,7 @@ extern "C" int gua_clock_advance(gua_context_t* ctx, double duration_ms)
     const std::lock_guard lock(ctx->mutex);
     if (!ctx->clock_installed) return GUA_CLOCK_ERROR_NOT_INSTALLED;
     if (ctx->clock_paused || ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
+    if (duration_ms / ctx->clock_default_step_ms > 1000000.0) return GUA_CLOCK_ERROR_EXECUTION_LIMIT;
     ctx->clock_pending_ms = duration_ms;
     ctx->clock_pending_step_ms = ctx->clock_default_step_ms;
     return GUA_CLOCK_OK;
@@ -955,12 +961,16 @@ extern "C" int gua_clock_copy_status_json(gua_context_t* ctx, char* out_json, in
 {
     if (ctx == nullptr) return copy_json_string("{}", out_json, out_json_size);
     const std::lock_guard lock(ctx->mutex);
-    char json[320];
-    std::snprintf(json, sizeof(json),
-        "{\"schemaVersion\":1,\"installed\":%s,\"state\":\"%s\",\"nowMs\":%.6f,\"defaultStepMs\":%.6f,\"pendingMs\":%.6f,\"generation\":%llu}",
-        ctx->clock_installed ? "true" : "false", ctx->clock_paused ? "paused" : "running",
-        ctx->clock_now_ms, ctx->clock_default_step_ms, ctx->clock_pending_ms, ctx->clock_generation);
-    return copy_json_string(json, out_json, out_json_size);
+    std::ostringstream json;
+    json.imbue(std::locale::classic());
+    json << std::setprecision(std::numeric_limits<double>::max_digits10)
+         << "{\"schemaVersion\":1,\"installed\":" << (ctx->clock_installed ? "true" : "false")
+         << ",\"state\":\"" << (ctx->clock_paused ? "paused" : "running")
+         << "\",\"nowMs\":" << ctx->clock_now_ms
+         << ",\"defaultStepMs\":" << ctx->clock_default_step_ms
+         << ",\"pendingMs\":" << ctx->clock_pending_ms
+         << ",\"generation\":" << ctx->clock_generation << '}';
+    return copy_json_string(json.str(), out_json, out_json_size);
 }
 
 extern "C" int gua_clock_consume_step(gua_context_t* ctx, gua_clock_step_t* out_step)

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -350,10 +350,21 @@ struct gua_context_t {
     double clock_pending_ms = 0.0;
     double clock_pending_step_ms = 1000.0 / 60.0;
     double clock_pending_total_ms = 0.0;
+    double clock_pending_target_ms = 0.0;
     unsigned long long clock_generation = 0;
 };
 
 namespace {
+
+bool clock_operation_representable(double now_ms, double duration_ms, double step_ms, double& target_ms)
+{
+    target_ms = now_ms + duration_ms;
+    if (!std::isfinite(target_ms)) return false;
+    if (duration_ms == 0.0) return true;
+    const double emitted_step_ms = std::min(duration_ms, step_ms);
+    return target_ms > now_ms && now_ms + emitted_step_ms > now_ms &&
+        target_ms - emitted_step_ms < target_ms;
+}
 
 int copy_json_string(const std::string& json, char* out_json, int out_json_size)
 {
@@ -901,6 +912,7 @@ extern "C" int gua_clock_install(gua_context_t* ctx, double initial_time_ms, dou
     ctx->clock_pending_ms = 0.0;
     ctx->clock_pending_step_ms = step_ms;
     ctx->clock_pending_total_ms = 0.0;
+    ctx->clock_pending_target_ms = initial_time_ms;
     ++ctx->clock_generation;
     return GUA_CLOCK_OK;
 }
@@ -923,10 +935,13 @@ extern "C" int gua_clock_run_for(gua_context_t* ctx, double duration_ms, double 
     if (!ctx->clock_installed) return GUA_CLOCK_ERROR_NOT_INSTALLED;
     if (!ctx->clock_paused || ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
     if (duration_ms / step_ms > 1000000.0) return GUA_CLOCK_ERROR_EXECUTION_LIMIT;
-    if (!std::isfinite(ctx->clock_now_ms + duration_ms)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    double target_ms = 0.0;
+    if (!clock_operation_representable(ctx->clock_now_ms, duration_ms, step_ms, target_ms))
+        return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     ctx->clock_pending_ms = duration_ms;
     ctx->clock_pending_step_ms = step_ms;
     ctx->clock_pending_total_ms = duration_ms;
+    ctx->clock_pending_target_ms = target_ms;
     return GUA_CLOCK_OK;
 }
 
@@ -947,10 +962,13 @@ extern "C" int gua_clock_advance(gua_context_t* ctx, double duration_ms)
     if (!ctx->clock_installed) return GUA_CLOCK_ERROR_NOT_INSTALLED;
     if (ctx->clock_paused || ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
     if (duration_ms / ctx->clock_default_step_ms > 1000000.0) return GUA_CLOCK_ERROR_EXECUTION_LIMIT;
-    if (!std::isfinite(ctx->clock_now_ms + duration_ms)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    double target_ms = 0.0;
+    if (!clock_operation_representable(ctx->clock_now_ms, duration_ms, ctx->clock_default_step_ms, target_ms))
+        return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     ctx->clock_pending_ms = duration_ms;
     ctx->clock_pending_step_ms = ctx->clock_default_step_ms;
     ctx->clock_pending_total_ms = duration_ms;
+    ctx->clock_pending_target_ms = target_ms;
     return GUA_CLOCK_OK;
 }
 
@@ -991,7 +1009,7 @@ extern "C" int gua_clock_consume_step(gua_context_t* ctx, gua_clock_step_t* out_
         ctx->clock_pending_ms - ctx->clock_pending_step_ms <= tolerance;
     const double delta = final_step ? ctx->clock_pending_ms : ctx->clock_pending_step_ms;
     ctx->clock_pending_ms = final_step ? 0.0 : ctx->clock_pending_ms - delta;
-    ctx->clock_now_ms += delta;
+    ctx->clock_now_ms = final_step ? ctx->clock_pending_target_ms : ctx->clock_now_ms + delta;
     if (final_step) ctx->clock_pending_total_ms = 0.0;
     *out_step = gua_clock_step_t { sizeof(gua_clock_step_t), delta, final_step ? 1 : 0, ctx->clock_generation };
     return 1;
@@ -1451,7 +1469,8 @@ extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* 
     }
     if ((options->flags & GUA_RESET_CLOCK) != 0U) {
         ctx->clock_installed = false; ctx->clock_paused = false; ctx->clock_now_ms = 0.0;
-        ctx->clock_pending_ms = 0.0; ctx->clock_pending_total_ms = 0.0; ++ctx->clock_generation;
+        ctx->clock_pending_ms = 0.0; ctx->clock_pending_total_ms = 0.0; ctx->clock_pending_target_ms = 0.0;
+        ++ctx->clock_generation;
     }
     ctx->frame_sequence = 0;
     ctx->revision = 0;

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -20,6 +20,7 @@
 namespace {
 
 std::string escape_json(const std::string& value);
+constexpr double default_clock_step_ms = 1000.0 / 60.0;
 
 #ifndef GUA_VERSION
 #define GUA_VERSION "0.0.0-development"
@@ -346,7 +347,7 @@ struct gua_context_t {
     bool clock_installed = false;
     bool clock_paused = false;
     double clock_now_ms = 0.0;
-    double clock_default_step_ms = 1000.0 / 60.0;
+    double clock_default_step_ms = default_clock_step_ms;
     double clock_pending_ms = 0.0;
     double clock_pending_step_ms = 1000.0 / 60.0;
     double clock_pending_total_ms = 0.0;
@@ -1551,6 +1552,7 @@ extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* 
     }
     if ((options->flags & GUA_RESET_CLOCK) != 0U) {
         ctx->clock_installed = false; ctx->clock_paused = false; ctx->clock_now_ms = 0.0;
+        ctx->clock_default_step_ms = default_clock_step_ms;
         ctx->clock_pending_ms = 0.0; ctx->clock_pending_total_ms = 0.0; ctx->clock_pending_elapsed_ms = 0.0;
         ctx->clock_pending_target_ms = 0.0; ctx->clock_pending_step_count = 0; ctx->clock_pending_step_index = 0;
         ctx->clock_pending_operation_sequence = 0; ctx->clock_awaiting_frame_operation_sequence = 0;

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -349,6 +349,7 @@ struct gua_context_t {
     double clock_default_step_ms = 1000.0 / 60.0;
     double clock_pending_ms = 0.0;
     double clock_pending_step_ms = 1000.0 / 60.0;
+    double clock_pending_total_ms = 0.0;
     unsigned long long clock_generation = 0;
 };
 
@@ -899,6 +900,7 @@ extern "C" int gua_clock_install(gua_context_t* ctx, double initial_time_ms, dou
     ctx->clock_default_step_ms = step_ms;
     ctx->clock_pending_ms = 0.0;
     ctx->clock_pending_step_ms = step_ms;
+    ctx->clock_pending_total_ms = 0.0;
     ++ctx->clock_generation;
     return GUA_CLOCK_OK;
 }
@@ -924,6 +926,7 @@ extern "C" int gua_clock_run_for(gua_context_t* ctx, double duration_ms, double 
     if (!std::isfinite(ctx->clock_now_ms + duration_ms)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     ctx->clock_pending_ms = duration_ms;
     ctx->clock_pending_step_ms = step_ms;
+    ctx->clock_pending_total_ms = duration_ms;
     return GUA_CLOCK_OK;
 }
 
@@ -947,6 +950,7 @@ extern "C" int gua_clock_advance(gua_context_t* ctx, double duration_ms)
     if (!std::isfinite(ctx->clock_now_ms + duration_ms)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     ctx->clock_pending_ms = duration_ms;
     ctx->clock_pending_step_ms = ctx->clock_default_step_ms;
+    ctx->clock_pending_total_ms = duration_ms;
     return GUA_CLOCK_OK;
 }
 
@@ -981,10 +985,15 @@ extern "C" int gua_clock_consume_step(gua_context_t* ctx, gua_clock_step_t* out_
     if (ctx == nullptr || out_step == nullptr || out_step->struct_size < sizeof(gua_clock_step_t)) return 0;
     const std::lock_guard lock(ctx->mutex);
     if (!ctx->clock_installed || ctx->clock_pending_ms <= 0.0) return 0;
-    const double delta = std::min(ctx->clock_pending_ms, ctx->clock_pending_step_ms);
-    ctx->clock_pending_ms = std::max(0.0, ctx->clock_pending_ms - delta);
+    const double tolerance = std::numeric_limits<double>::epsilon() * 8.0 *
+        std::max(ctx->clock_pending_total_ms, ctx->clock_pending_step_ms);
+    const bool final_step = ctx->clock_pending_ms <= ctx->clock_pending_step_ms ||
+        ctx->clock_pending_ms - ctx->clock_pending_step_ms <= tolerance;
+    const double delta = final_step ? ctx->clock_pending_ms : ctx->clock_pending_step_ms;
+    ctx->clock_pending_ms = final_step ? 0.0 : ctx->clock_pending_ms - delta;
     ctx->clock_now_ms += delta;
-    *out_step = gua_clock_step_t { sizeof(gua_clock_step_t), delta, ctx->clock_pending_ms <= 0.0 ? 1 : 0, ctx->clock_generation };
+    if (final_step) ctx->clock_pending_total_ms = 0.0;
+    *out_step = gua_clock_step_t { sizeof(gua_clock_step_t), delta, final_step ? 1 : 0, ctx->clock_generation };
     return 1;
 }
 
@@ -1442,7 +1451,7 @@ extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* 
     }
     if ((options->flags & GUA_RESET_CLOCK) != 0U) {
         ctx->clock_installed = false; ctx->clock_paused = false; ctx->clock_now_ms = 0.0;
-        ctx->clock_pending_ms = 0.0; ++ctx->clock_generation;
+        ctx->clock_pending_ms = 0.0; ctx->clock_pending_total_ms = 0.0; ++ctx->clock_generation;
     }
     ctx->frame_sequence = 0;
     ctx->revision = 0;

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -1082,10 +1082,11 @@ extern "C" int gua_clock_consume_step(gua_context_t* ctx, gua_clock_step_t* out_
     const double next_elapsed_ms = final_step ? ctx->clock_pending_total_ms :
         std::min(ctx->clock_pending_total_ms,
             ctx->clock_pending_step_ms * static_cast<double>(ctx->clock_pending_step_index));
-    const double delta = next_elapsed_ms - ctx->clock_pending_elapsed_ms;
+    const double next_now_ms = final_step ? ctx->clock_pending_target_ms : ctx->clock_pending_start_ms + next_elapsed_ms;
+    const double delta = next_now_ms - ctx->clock_now_ms;
     ctx->clock_pending_elapsed_ms = next_elapsed_ms;
     ctx->clock_pending_ms = final_step ? 0.0 : ctx->clock_pending_total_ms - next_elapsed_ms;
-    ctx->clock_now_ms = final_step ? ctx->clock_pending_target_ms : ctx->clock_pending_start_ms + next_elapsed_ms;
+    ctx->clock_now_ms = next_now_ms;
     if (final_step) {
         ctx->clock_pending_total_ms = 0.0;
         ctx->clock_awaiting_frame_operation_sequence = std::max(

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -371,7 +371,12 @@ bool prepare_clock_operation(
 {
     target_ms = now_ms + duration_ms;
     if (!std::isfinite(target_ms)) return false;
-    if (duration_ms == 0.0) { step_count = 0; return true; }
+    if (duration_ms == 0.0) {
+        const double next_step_ms = now_ms + step_ms;
+        if (!std::isfinite(next_step_ms) || next_step_ms <= now_ms) return false;
+        step_count = 0;
+        return true;
+    }
     const double emitted_step_ms = std::min(duration_ms, step_ms);
     if (target_ms <= now_ms || now_ms + emitted_step_ms <= now_ms ||
         target_ms - emitted_step_ms >= target_ms) return false;

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -920,6 +920,7 @@ extern "C" int gua_clock_run_for(gua_context_t* ctx, double duration_ms, double 
     if (!ctx->clock_installed) return GUA_CLOCK_ERROR_NOT_INSTALLED;
     if (!ctx->clock_paused || ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
     if (duration_ms / step_ms > 1000000.0) return GUA_CLOCK_ERROR_EXECUTION_LIMIT;
+    if (!std::isfinite(ctx->clock_now_ms + duration_ms)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     ctx->clock_pending_ms = duration_ms;
     ctx->clock_pending_step_ms = step_ms;
     return GUA_CLOCK_OK;
@@ -942,6 +943,7 @@ extern "C" int gua_clock_advance(gua_context_t* ctx, double duration_ms)
     if (!ctx->clock_installed) return GUA_CLOCK_ERROR_NOT_INSTALLED;
     if (ctx->clock_paused || ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
     if (duration_ms / ctx->clock_default_step_ms > 1000000.0) return GUA_CLOCK_ERROR_EXECUTION_LIMIT;
+    if (!std::isfinite(ctx->clock_now_ms + duration_ms)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     ctx->clock_pending_ms = duration_ms;
     ctx->clock_pending_step_ms = ctx->clock_default_step_ms;
     return GUA_CLOCK_OK;

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -384,13 +384,12 @@ bool prepare_clock_operation(
     const double nearest = std::round(quotient);
     const double quotient_tolerance = std::numeric_limits<double>::epsilon() * 8.0 * std::max(1.0, std::abs(quotient));
     if (nearest >= 1.0 && std::abs(quotient - nearest) <= quotient_tolerance) quotient = nearest;
-    step_count = static_cast<unsigned long long>(std::ceil(quotient));
+    step_count = std::max(1ULL, static_cast<unsigned long long>(std::ceil(quotient)));
     while (step_count > 1) {
         const double previous_elapsed_ms = std::min(duration_ms, step_ms * static_cast<double>(step_count - 1));
         if (now_ms + previous_elapsed_ms < target_ms) break;
         --step_count;
     }
-    if (step_count == 0) return false;
     double previous_boundary_ms = now_ms;
     for (unsigned long long index = 1; index <= step_count; ++index) {
         const double elapsed_ms = index == step_count ? duration_ms :

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdio>
 #include <deque>
 #include <cstring>
@@ -1488,10 +1489,20 @@ extern "C" int gua_get_context_status(gua_context_t* ctx, gua_context_status_t* 
 
 extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* options, gua_reset_report_t* out_report)
 {
-    if (ctx == nullptr || options == nullptr || options->struct_size < sizeof(gua_reset_options_t) ||
+    constexpr uint32_t legacy_options_size = static_cast<uint32_t>(offsetof(gua_reset_options_t, flags_version));
+    constexpr uint32_t flags_version_size = static_cast<uint32_t>(offsetof(gua_reset_options_t, flags_version) + sizeof(uint32_t));
+    if (ctx == nullptr || options == nullptr || options->struct_size < legacy_options_size ||
         out_report == nullptr || out_report->struct_size < sizeof(gua_reset_report_t)) return GUA_RESET_ERROR_INVALID_ARGUMENT;
+    const uint32_t flags_version = options->struct_size >= flags_version_size
+        ? options->flags_version : GUA_RESET_FLAGS_VERSION_LEGACY;
+    if (flags_version > GUA_RESET_FLAGS_VERSION_CURRENT) return GUA_RESET_ERROR_INVALID_ARGUMENT;
+    uint32_t reset_flags = options->flags;
+    const uint32_t legacy_all = GUA_RESET_DEFAULT | GUA_RESET_LOGS | GUA_RESET_SCREENSHOT;
+    if (flags_version == GUA_RESET_FLAGS_VERSION_LEGACY &&
+        (reset_flags == GUA_RESET_DEFAULT || reset_flags == legacy_all))
+        reset_flags |= GUA_RESET_CLOCK;
     const uint32_t known_flags = GUA_RESET_NODES | GUA_RESET_REQUESTS | GUA_RESET_EVENTS | GUA_RESET_HISTORY | GUA_RESET_LOGS | GUA_RESET_SCREENSHOT | GUA_RESET_CLOCK;
-    if ((options->flags & ~known_flags) != 0U) return GUA_RESET_ERROR_INVALID_ARGUMENT;
+    if ((reset_flags & ~known_flags) != 0U) return GUA_RESET_ERROR_INVALID_ARGUMENT;
 
     const std::lock_guard lock(ctx->mutex);
     *out_report = gua_reset_report_t { sizeof(gua_reset_report_t) };
@@ -1506,22 +1517,22 @@ extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* 
         out_report->result = GUA_RESET_ERROR_STALE_EPOCH;
         return out_report->result;
     }
-    const bool dirty_requests = (options->flags & GUA_RESET_REQUESTS) != 0U &&
+    const bool dirty_requests = (reset_flags & GUA_RESET_REQUESTS) != 0U &&
         (!ctx->action_requests.empty() || !ctx->consumed_requests.empty());
-    const bool dirty_events = (options->flags & GUA_RESET_EVENTS) != 0U && !ctx->events.empty();
+    const bool dirty_events = (reset_flags & GUA_RESET_EVENTS) != 0U && !ctx->events.empty();
     if (options->strict != 0 && (dirty_requests || dirty_events)) {
         out_report->result = GUA_RESET_ERROR_DIRTY;
         return out_report->result;
     }
 
-    out_report->discarded_node_count = (options->flags & GUA_RESET_NODES) != 0U ? static_cast<uint32_t>(ctx->nodes.size()) : 0;
-    out_report->discarded_pending_request_count = (options->flags & GUA_RESET_REQUESTS) != 0U ? static_cast<uint32_t>(ctx->action_requests.size()) : 0;
-    out_report->discarded_in_flight_request_count = (options->flags & GUA_RESET_REQUESTS) != 0U ? static_cast<uint32_t>(ctx->consumed_requests.size()) : 0;
-    out_report->discarded_event_count = (options->flags & GUA_RESET_EVENTS) != 0U ? static_cast<uint32_t>(ctx->events.size()) : 0;
-    out_report->discarded_log_count = (options->flags & GUA_RESET_LOGS) != 0U ? static_cast<uint32_t>(ctx->logs.size()) : 0;
-    out_report->discarded_screenshot = (options->flags & GUA_RESET_SCREENSHOT) != 0U && !ctx->screenshot.data_uri.empty() ? 1 : 0;
+    out_report->discarded_node_count = (reset_flags & GUA_RESET_NODES) != 0U ? static_cast<uint32_t>(ctx->nodes.size()) : 0;
+    out_report->discarded_pending_request_count = (reset_flags & GUA_RESET_REQUESTS) != 0U ? static_cast<uint32_t>(ctx->action_requests.size()) : 0;
+    out_report->discarded_in_flight_request_count = (reset_flags & GUA_RESET_REQUESTS) != 0U ? static_cast<uint32_t>(ctx->consumed_requests.size()) : 0;
+    out_report->discarded_event_count = (reset_flags & GUA_RESET_EVENTS) != 0U ? static_cast<uint32_t>(ctx->events.size()) : 0;
+    out_report->discarded_log_count = (reset_flags & GUA_RESET_LOGS) != 0U ? static_cast<uint32_t>(ctx->logs.size()) : 0;
+    out_report->discarded_screenshot = (reset_flags & GUA_RESET_SCREENSHOT) != 0U && !ctx->screenshot.data_uri.empty() ? 1 : 0;
 
-    if ((options->flags & GUA_RESET_NODES) != 0U) {
+    if ((reset_flags & GUA_RESET_NODES) != 0U) {
         ctx->screen = "unknown";
         ctx->nodes.clear();
         ctx->staging_screen = "unknown";
@@ -1529,28 +1540,28 @@ extern "C" int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* 
         ctx->frame_in_progress = false;
         ctx->staging_valid = true;
     }
-    if ((options->flags & GUA_RESET_REQUESTS) != 0U) {
+    if ((reset_flags & GUA_RESET_REQUESTS) != 0U) {
         ctx->action_requests.clear();
         ctx->consumed_requests.clear();
     }
-    if ((options->flags & GUA_RESET_EVENTS) != 0U) ctx->events.clear();
-    if ((options->flags & GUA_RESET_HISTORY) != 0U) {
+    if ((reset_flags & GUA_RESET_EVENTS) != 0U) ctx->events.clear();
+    if ((reset_flags & GUA_RESET_HISTORY) != 0U) {
         ctx->operation_history.clear();
         ctx->event_history.clear();
         ctx->next_history_sequence = 1;
         ctx->diagnostics_history_started_at = std::chrono::steady_clock::now();
         ctx->diagnostics_json_cache.clear();
     }
-    if ((options->flags & GUA_RESET_LOGS) != 0U) {
+    if ((reset_flags & GUA_RESET_LOGS) != 0U) {
         ctx->logs.clear();
         ctx->next_log_sequence = 1;
         ctx->logs_json_cache.clear();
     }
-    if ((options->flags & GUA_RESET_SCREENSHOT) != 0U) {
+    if ((reset_flags & GUA_RESET_SCREENSHOT) != 0U) {
         ctx->screenshot = Screenshot {};
         ctx->screenshot_json_cache.clear();
     }
-    if ((options->flags & GUA_RESET_CLOCK) != 0U) {
+    if ((reset_flags & GUA_RESET_CLOCK) != 0U) {
         ctx->clock_installed = false; ctx->clock_paused = false; ctx->clock_now_ms = 0.0;
         ctx->clock_default_step_ms = default_clock_step_ms;
         ctx->clock_pending_ms = 0.0; ctx->clock_pending_total_ms = 0.0; ctx->clock_pending_elapsed_ms = 0.0;

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -908,6 +908,7 @@ extern "C" int gua_clock_pause(gua_context_t* ctx)
     if (ctx == nullptr) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     const std::lock_guard lock(ctx->mutex);
     if (!ctx->clock_installed) return GUA_CLOCK_ERROR_NOT_INSTALLED;
+    if (ctx->clock_pending_ms > 0.0) return GUA_CLOCK_ERROR_INVALID_STATE;
     ctx->clock_paused = true;
     return GUA_CLOCK_OK;
 }

--- a/native/gua-core/tests/selector_tests.cpp
+++ b/native/gua-core/tests/selector_tests.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -110,5 +111,12 @@ int main()
 
     int attempts = 0;
     wait_until([&attempts] { return ++attempts == 3; }, "third predicate evaluation", std::chrono::milliseconds(20), std::chrono::milliseconds(1));
+
+    Clock clock(context);
+    clock.install(std::chrono::milliseconds(0), std::chrono::milliseconds(10));
+    clock.pause();
+    std::vector<double> clock_steps;
+    clock.run_for(std::chrono::milliseconds(25), [&](auto delta) { clock_steps.push_back(delta.count()); });
+    assert((clock_steps == std::vector<double> { 10.0, 10.0, 5.0 }));
     gua_destroy_context(context);
 }

--- a/native/gua-core/tests/selector_tests.cpp
+++ b/native/gua-core/tests/selector_tests.cpp
@@ -118,5 +118,23 @@ int main()
     std::vector<double> clock_steps;
     clock.run_for(std::chrono::milliseconds(25), [&](auto delta) { clock_steps.push_back(delta.count()); });
     assert((clock_steps == std::vector<double> { 10.0, 10.0, 5.0 }));
+
+    int throwing_tick_calls = 0;
+    bool tick_error_preserved = false;
+    try {
+        clock.run_for(std::chrono::milliseconds(30), std::chrono::milliseconds(10), [&](auto) {
+            ++throwing_tick_calls;
+            throw std::runtime_error("tick failed");
+        });
+    } catch (const std::runtime_error& error) {
+        tick_error_preserved = std::string(error.what()) == "tick failed";
+    }
+    const auto drained_status = clock.status();
+    assert(tick_error_preserved);
+    assert(throwing_tick_calls == 1);
+    assert(drained_status.now_ms == 55.0);
+    assert(drained_status.pending_ms == 0.0);
+    clock.run_for(std::chrono::milliseconds(10));
+    assert(clock.status().now_ms == 65.0);
     gua_destroy_context(context);
 }

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -98,7 +98,7 @@ int main()
     assert(gua_clock_get_status(context, &clock_status) == 1 && clock_status.pending_ms == 0.0);
 
     gua_context_t* pause_context = gua_create_context();
-    assert(gua_clock_install(pause_context, 0.0, 10.0) == GUA_CLOCK_OK);
+    assert(gua_clock_install(pause_context, 0.0, 250.0) == GUA_CLOCK_OK);
     assert(gua_clock_advance(pause_context, 10.0) == GUA_CLOCK_OK);
     assert(gua_clock_pause(pause_context) == GUA_CLOCK_ERROR_INVALID_STATE);
     clock_step = gua_clock_step_t { sizeof(gua_clock_step_t) };
@@ -108,6 +108,11 @@ int main()
     gua_reset_options_t clock_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 0 };
     gua_reset_report_t clock_reset_report { sizeof(gua_reset_report_t) };
     assert(gua_reset_context(pause_context, &clock_reset, &clock_reset_report) == GUA_RESET_SUCCEEDED);
+    gua_clock_status_t reset_clock_status { sizeof(gua_clock_status_t) };
+    assert(gua_clock_get_status(pause_context, &reset_clock_status) == 1);
+    assert(reset_clock_status.installed == 0 && reset_clock_status.paused == 0);
+    assert(reset_clock_status.now_ms == 0.0 && reset_clock_status.pending_ms == 0.0);
+    assert(reset_clock_status.default_step_ms == 1000.0 / 60.0);
     gua_clock_operation_status_t reset_operation_status { sizeof(gua_clock_operation_status_t) };
     assert(gua_clock_get_operation_status(pause_context, &reset_operation_status) == 1);
     assert(reset_operation_status.latest_operation_sequence == reset_operation_status.completed_operation_sequence);

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -74,6 +74,23 @@ int main()
     gua_context_t* context = gua_create_context();
     assert(context != nullptr);
 
+    assert(gua_clock_pause(context) == GUA_CLOCK_ERROR_NOT_INSTALLED);
+    assert(gua_clock_install(context, 0.0, 10.0) == GUA_CLOCK_OK);
+    assert(gua_clock_pause(context) == GUA_CLOCK_OK);
+    assert(gua_clock_run_for(context, 25.0, 10.0) == GUA_CLOCK_OK);
+    gua_clock_step_t clock_step { sizeof(gua_clock_step_t) };
+    assert(gua_clock_consume_step(context, &clock_step) == 1 && clock_step.delta_ms == 10.0 && clock_step.final_step == 0);
+    clock_step = gua_clock_step_t { sizeof(gua_clock_step_t) };
+    assert(gua_clock_consume_step(context, &clock_step) == 1 && clock_step.delta_ms == 10.0);
+    clock_step = gua_clock_step_t { sizeof(gua_clock_step_t) };
+    assert(gua_clock_consume_step(context, &clock_step) == 1 && clock_step.delta_ms == 5.0 && clock_step.final_step == 1);
+    gua_clock_status_t clock_status { sizeof(gua_clock_status_t) };
+    assert(gua_clock_get_status(context, &clock_status) == 1 && clock_status.now_ms == 25.0 && clock_status.paused == 1);
+    assert(gua_clock_resume(context) == GUA_CLOCK_OK);
+    assert(gua_clock_advance(context, 4.0) == GUA_CLOCK_OK);
+    clock_step = gua_clock_step_t { sizeof(gua_clock_step_t) };
+    assert(gua_clock_consume_step(context, &clock_step) == 1 && clock_step.delta_ms == 4.0);
+
     // A frame is private until end_frame atomically publishes it.
     gua_context_t* atomic_context = gua_create_context();
     gua_begin_frame(atomic_context, "initial-staging");
@@ -304,6 +321,8 @@ int main()
     assert(gua_get_context_status(context, &status) == 1);
     assert(status.session_epoch == 2 && status.frame_sequence == 0 && status.revision == 0);
     assert(status.node_count == 0 && status.pending_request_count == 0 && status.unconsumed_event_count == 0);
+    clock_status = gua_clock_status_t { sizeof(gua_clock_status_t) };
+    assert(gua_clock_get_status(context, &clock_status) == 1 && clock_status.installed == 0);
     const std::string reset_diagnostics = gua_get_diagnostics_json(context);
     assert(reset_diagnostics.find("\"operations\":[]") != std::string::npos);
     assert(reset_diagnostics.find("\"events\":[]") != std::string::npos);

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -105,12 +105,16 @@ int main()
     assert(gua_clock_consume_step(pause_context, &clock_step) == 1);
     assert(gua_clock_pause(pause_context) == GUA_CLOCK_OK);
     assert(gua_clock_run_for(pause_context, 10.0, 10.0) == GUA_CLOCK_OK);
+    gua_reset_options_t clock_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 0 };
+    gua_reset_report_t clock_reset_report { sizeof(gua_reset_report_t) };
+    assert(gua_reset_context(pause_context, &clock_reset, &clock_reset_report) == GUA_RESET_SUCCEEDED);
+    gua_clock_operation_status_t reset_operation_status { sizeof(gua_clock_operation_status_t) };
+    assert(gua_clock_get_operation_status(pause_context, &reset_operation_status) == 1);
+    assert(reset_operation_status.latest_operation_sequence == reset_operation_status.completed_operation_sequence);
     gua_destroy_context(pause_context);
 
     gua_context_t* overflow_context = gua_create_context();
-    assert(gua_clock_install(overflow_context, 1e308, 1e308) == GUA_CLOCK_OK);
-    assert(gua_clock_pause(overflow_context) == GUA_CLOCK_OK);
-    assert(gua_clock_run_for(overflow_context, 1e308, 1e308) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
+    assert(gua_clock_install(overflow_context, 1e308, 1e308) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
     assert(gua_clock_get_status(overflow_context, &clock_status) == 1 &&
         std::isfinite(clock_status.now_ms) && clock_status.pending_ms == 0.0);
     gua_destroy_context(overflow_context);
@@ -149,17 +153,38 @@ int main()
     assert(count_clock_steps(1000.0, 1000.0 / 60.0) == 60);
 
     gua_context_t* magnitude_context = gua_create_context();
-    assert(gua_clock_install(magnitude_context, 1e16, 1.0) == GUA_CLOCK_OK);
+    assert(gua_clock_install(magnitude_context, 1e16, 1.0) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
+    assert(gua_clock_install(magnitude_context, 1e16, 3.0) == GUA_CLOCK_OK);
     assert(gua_clock_pause(magnitude_context) == GUA_CLOCK_OK);
-    assert(gua_clock_run_for(magnitude_context, 100.0, 1.0) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
+    assert(gua_clock_run_for(magnitude_context, 100.0, 3.0) == GUA_CLOCK_OK);
     gua_clock_status_t magnitude_status { sizeof(gua_clock_status_t) };
+    double previous_now = 1e16;
+    int magnitude_steps = 0;
+    gua_clock_step_t magnitude_step { sizeof(gua_clock_step_t) };
+    while (gua_clock_consume_step(magnitude_context, &magnitude_step) == 1) {
+        assert(gua_clock_get_status(magnitude_context, &magnitude_status) == 1);
+        assert(magnitude_status.now_ms > previous_now);
+        previous_now = magnitude_status.now_ms;
+        ++magnitude_steps;
+        magnitude_step = gua_clock_step_t { sizeof(gua_clock_step_t) };
+    }
     assert(gua_clock_get_status(magnitude_context, &magnitude_status) == 1);
-    assert(magnitude_status.now_ms == 1e16 && magnitude_status.pending_ms == 0.0);
+    assert(magnitude_steps == 33 && magnitude_status.now_ms == 1e16 + 100.0 && magnitude_status.pending_ms == 0.0);
+    gua_clock_operation_status_t operation_status { sizeof(gua_clock_operation_status_t) };
+    assert(gua_clock_get_operation_status(magnitude_context, &operation_status) == 1);
+    assert(operation_status.latest_operation_sequence == 1 && operation_status.completed_operation_sequence == 0);
+    gua_begin_frame(magnitude_context, "clock-complete"); gua_end_frame(magnitude_context);
+    assert(gua_clock_get_operation_status(magnitude_context, &operation_status) == 1);
+    assert(operation_status.completed_operation_sequence == 1);
     gua_destroy_context(magnitude_context);
 
     magnitude_context = gua_create_context();
-    assert(gua_clock_install(magnitude_context, 1e16, 1.0) == GUA_CLOCK_OK);
-    assert(gua_clock_advance(magnitude_context, 100.0) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
+    assert(gua_clock_install(magnitude_context, 1e16, 3.0) == GUA_CLOCK_OK);
+    assert(gua_clock_advance(magnitude_context, 100.0) == GUA_CLOCK_OK);
+    magnitude_step = gua_clock_step_t { sizeof(gua_clock_step_t) };
+    while (gua_clock_consume_step(magnitude_context, &magnitude_step) == 1)
+        magnitude_step = gua_clock_step_t { sizeof(gua_clock_step_t) };
+    assert(gua_clock_get_status(magnitude_context, &magnitude_status) == 1 && magnitude_status.now_ms == 1e16 + 100.0);
     gua_destroy_context(magnitude_context);
 
     gua::Context cpp_context;

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -151,6 +151,7 @@ int main()
     };
     assert(count_clock_steps(1.0, 0.1) == 10);
     assert(count_clock_steps(1000.0, 1000.0 / 60.0) == 60);
+    assert(count_clock_steps(1e-16, 1.0) == 1);
 
     gua_context_t* magnitude_context = gua_create_context();
     assert(gua_clock_install(magnitude_context, 1e16, 1.0) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -90,6 +90,26 @@ int main()
     assert(gua_clock_advance(context, 4.0) == GUA_CLOCK_OK);
     clock_step = gua_clock_step_t { sizeof(gua_clock_step_t) };
     assert(gua_clock_consume_step(context, &clock_step) == 1 && clock_step.delta_ms == 4.0);
+    assert(gua_clock_install(context, 0.0, 1.0) == GUA_CLOCK_ERROR_INVALID_STATE);
+    assert(gua_clock_get_status(context, &clock_status) == 1 && clock_status.now_ms == 29.0);
+    assert(gua_clock_advance(context, 10000001.0) == GUA_CLOCK_ERROR_EXECUTION_LIMIT);
+    assert(gua_clock_get_status(context, &clock_status) == 1 && clock_status.pending_ms == 0.0);
+
+    gua_context_t* precision_context = gua_create_context();
+    assert(gua_clock_install(precision_context, 0.0, 1e-7) == GUA_CLOCK_OK);
+    assert(gua_clock_pause(precision_context) == GUA_CLOCK_OK);
+    assert(gua_clock_run_for(precision_context, 2e-7, 1e-7) == GUA_CLOCK_OK);
+    std::vector<char> clock_json(static_cast<std::size_t>(gua_clock_copy_status_json(precision_context, nullptr, 0)));
+    gua_clock_copy_status_json(precision_context, clock_json.data(), static_cast<int>(clock_json.size()));
+    const std::string precise_status(clock_json.data());
+    const auto number_after = [&](const std::string& field) {
+        const auto offset = precise_status.find(field);
+        assert(offset != std::string::npos);
+        return std::stod(precise_status.substr(offset + field.size()));
+    };
+    assert(number_after("\"defaultStepMs\":") == 1e-7);
+    assert(number_after("\"pendingMs\":") == 2e-7);
+    gua_destroy_context(precision_context);
 
     // A frame is private until end_frame atomically publishes it.
     gua_context_t* atomic_context = gua_create_context();

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -165,6 +165,7 @@ int main()
     while (gua_clock_consume_step(magnitude_context, &magnitude_step) == 1) {
         assert(gua_clock_get_status(magnitude_context, &magnitude_status) == 1);
         assert(magnitude_status.now_ms > previous_now);
+        assert(magnitude_step.delta_ms == magnitude_status.now_ms - previous_now);
         previous_now = magnitude_status.now_ms;
         ++magnitude_steps;
         magnitude_step = gua_clock_step_t { sizeof(gua_clock_step_t) };

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -131,6 +131,23 @@ int main()
     assert(number_after("\"pendingMs\":") == 2e-7);
     gua_destroy_context(precision_context);
 
+    const auto count_clock_steps = [](double duration, double step) {
+        gua_context_t* rounding_context = gua_create_context();
+        assert(gua_clock_install(rounding_context, 0.0, step) == GUA_CLOCK_OK);
+        assert(gua_clock_pause(rounding_context) == GUA_CLOCK_OK);
+        assert(gua_clock_run_for(rounding_context, duration, step) == GUA_CLOCK_OK);
+        int count = 0;
+        gua_clock_step_t rounding_step { sizeof(gua_clock_step_t) };
+        while (gua_clock_consume_step(rounding_context, &rounding_step) == 1) ++count;
+        gua_clock_status_t rounding_status { sizeof(gua_clock_status_t) };
+        assert(gua_clock_get_status(rounding_context, &rounding_status) == 1);
+        assert(rounding_status.now_ms == duration && rounding_status.pending_ms == 0.0);
+        gua_destroy_context(rounding_context);
+        return count;
+    };
+    assert(count_clock_steps(1.0, 0.1) == 10);
+    assert(count_clock_steps(1000.0, 1000.0 / 60.0) == 60);
+
     gua::Context cpp_context;
     cpp_context.install_clock(0.0, 10.0);
     cpp_context.pause_clock();

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -2,6 +2,7 @@
 #include "gua/gua.hpp"
 
 #include <cassert>
+#include <cstddef>
 #include <cmath>
 #include <cstring>
 #include <string>
@@ -11,6 +12,15 @@
 #include <vector>
 
 namespace {
+
+struct legacy_reset_options_t {
+    uint32_t struct_size;
+    uint32_t flags;
+    int strict;
+    uint64_t expected_session_epoch;
+};
+
+static_assert(sizeof(legacy_reset_options_t) == offsetof(gua_reset_options_t, flags_version));
 
 void register_checkbox(gua_context_t* context, bool checked)
 {
@@ -105,7 +115,7 @@ int main()
     assert(gua_clock_consume_step(pause_context, &clock_step) == 1);
     assert(gua_clock_pause(pause_context) == GUA_CLOCK_OK);
     assert(gua_clock_run_for(pause_context, 10.0, 10.0) == GUA_CLOCK_OK);
-    gua_reset_options_t clock_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 0 };
+    gua_reset_options_t clock_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT_V2, 0, 0, GUA_RESET_FLAGS_VERSION_CURRENT };
     gua_reset_report_t clock_reset_report { sizeof(gua_reset_report_t) };
     assert(gua_reset_context(pause_context, &clock_reset, &clock_reset_report) == GUA_RESET_SUCCEEDED);
     gua_clock_status_t reset_clock_status { sizeof(gua_clock_status_t) };
@@ -117,6 +127,38 @@ int main()
     assert(gua_clock_get_operation_status(pause_context, &reset_operation_status) == 1);
     assert(reset_operation_status.latest_operation_sequence == reset_operation_status.completed_operation_sequence);
     gua_destroy_context(pause_context);
+
+    gua_context_t* explicit_reset_context = gua_create_context();
+    assert(gua_clock_install(explicit_reset_context, 0.0, 250.0) == GUA_CLOCK_OK);
+    gua_clock_status_t explicit_clock_status { sizeof(gua_clock_status_t) };
+    assert(gua_clock_get_status(explicit_reset_context, &explicit_clock_status) == 1);
+    const auto explicit_generation = explicit_clock_status.generation;
+    gua_reset_options_t explicit_reset {
+        sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 0, GUA_RESET_FLAGS_VERSION_CURRENT
+    };
+    gua_reset_report_t explicit_reset_report { sizeof(gua_reset_report_t) };
+    assert(gua_reset_context(explicit_reset_context, &explicit_reset, &explicit_reset_report) == GUA_RESET_SUCCEEDED);
+    assert(gua_clock_get_status(explicit_reset_context, &explicit_clock_status) == 1);
+    assert(explicit_clock_status.installed == 1 && explicit_clock_status.generation == explicit_generation);
+    gua_destroy_context(explicit_reset_context);
+
+    gua_context_t* legacy_reset_context = gua_create_context();
+    assert(gua_clock_install(legacy_reset_context, 0.0, 250.0) == GUA_CLOCK_OK);
+    legacy_reset_options_t legacy_reset {
+        sizeof(legacy_reset_options_t), GUA_RESET_DEFAULT, 0, 0
+    };
+    gua_reset_report_t legacy_reset_report { sizeof(gua_reset_report_t) };
+    assert(gua_reset_context(legacy_reset_context,
+        reinterpret_cast<const gua_reset_options_t*>(&legacy_reset), &legacy_reset_report) == GUA_RESET_SUCCEEDED);
+    gua_clock_status_t legacy_clock_status { sizeof(gua_clock_status_t) };
+    assert(gua_clock_get_status(legacy_reset_context, &legacy_clock_status) == 1 && legacy_clock_status.installed == 0);
+    assert(gua_clock_install(legacy_reset_context, 0.0, 250.0) == GUA_CLOCK_OK);
+    legacy_reset.flags = GUA_RESET_DEFAULT | GUA_RESET_LOGS | GUA_RESET_SCREENSHOT;
+    legacy_reset_report = gua_reset_report_t { sizeof(gua_reset_report_t) };
+    assert(gua_reset_context(legacy_reset_context,
+        reinterpret_cast<const gua_reset_options_t*>(&legacy_reset), &legacy_reset_report) == GUA_RESET_SUCCEEDED);
+    assert(gua_clock_get_status(legacy_reset_context, &legacy_clock_status) == 1 && legacy_clock_status.installed == 0);
+    gua_destroy_context(legacy_reset_context);
 
     gua_context_t* overflow_context = gua_create_context();
     assert(gua_clock_install(overflow_context, 1e308, 1e308) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
@@ -404,7 +446,7 @@ int main()
     assert(std::strcmp(status.first_pending_node_id, "remember") == 0);
 
     gua_reset_report_t report { sizeof(gua_reset_report_t) };
-    const gua_reset_options_t strict_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 1, 1 };
+    const gua_reset_options_t strict_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT_V2, 1, 1, GUA_RESET_FLAGS_VERSION_CURRENT };
     assert(gua_reset_context(context, &strict_reset, &report) == GUA_RESET_ERROR_DIRTY);
     assert(report.session_epoch == 1);
     assert(report.pending_request_count == 5);
@@ -420,12 +462,12 @@ int main()
     gua_end_frame(other);
 
     report = gua_reset_report_t { sizeof(gua_reset_report_t) };
-    const gua_reset_options_t stale_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 2 };
+    const gua_reset_options_t stale_reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT_V2, 0, 2, GUA_RESET_FLAGS_VERSION_CURRENT };
     assert(gua_reset_context(context, &stale_reset, &report) == GUA_RESET_ERROR_STALE_EPOCH);
     assert(report.session_epoch == 1);
 
     report = gua_reset_report_t { sizeof(gua_reset_report_t) };
-    const gua_reset_options_t reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 1 };
+    const gua_reset_options_t reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT_V2, 0, 1, GUA_RESET_FLAGS_VERSION_CURRENT };
     assert(gua_reset_context(context, &reset, &report) == GUA_RESET_SUCCEEDED);
     assert(report.previous_session_epoch == 1 && report.session_epoch == 2);
     assert(report.discarded_pending_request_count == 5);
@@ -446,7 +488,7 @@ int main()
         GUA_ACTION_STATUS_SUCCEEDED, 0, "focus-target", nullptr, 0 };
     assert(gua_emit_action_result(context, &unsolicited) == 1);
     report = gua_reset_report_t { sizeof(gua_reset_report_t) };
-    const gua_reset_options_t strict_events { sizeof(gua_reset_options_t), GUA_RESET_EVENTS, 1, 2 };
+    const gua_reset_options_t strict_events { sizeof(gua_reset_options_t), GUA_RESET_EVENTS, 1, 2, GUA_RESET_FLAGS_VERSION_CURRENT };
     assert(gua_reset_context(context, &strict_events, &report) == GUA_RESET_ERROR_DIRTY);
     assert(report.unconsumed_event_count == 1);
     assert(report.discarded_event_count == 0);

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -200,10 +200,19 @@ int main()
     assert(count_clock_steps(1000.0, 1000.0 / 60.0) == 60);
     assert(count_clock_steps(1e-16, 1.0) == 1);
 
+    gua_context_t* zero_duration_context = gua_create_context();
+    assert(gua_clock_install(zero_duration_context, 0.0, 10.0) == GUA_CLOCK_OK);
+    assert(gua_clock_pause(zero_duration_context) == GUA_CLOCK_OK);
+    assert(gua_clock_run_for(zero_duration_context, 0.0, 10.0) == GUA_CLOCK_OK);
+    gua_clock_step_t zero_duration_step { sizeof(gua_clock_step_t) };
+    assert(gua_clock_consume_step(zero_duration_context, &zero_duration_step) == 0);
+    gua_destroy_context(zero_duration_context);
+
     gua_context_t* magnitude_context = gua_create_context();
     assert(gua_clock_install(magnitude_context, 1e16, 1.0) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
     assert(gua_clock_install(magnitude_context, 1e16, 3.0) == GUA_CLOCK_OK);
     assert(gua_clock_pause(magnitude_context) == GUA_CLOCK_OK);
+    assert(gua_clock_run_for(magnitude_context, 0.0, 1.0) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
     assert(gua_clock_run_for(magnitude_context, 100.0, 3.0) == GUA_CLOCK_OK);
     gua_clock_status_t magnitude_status { sizeof(gua_clock_status_t) };
     double previous_now = 1e16;

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -97,6 +97,16 @@ int main()
     assert(gua_clock_advance(context, 10000001.0) == GUA_CLOCK_ERROR_EXECUTION_LIMIT);
     assert(gua_clock_get_status(context, &clock_status) == 1 && clock_status.pending_ms == 0.0);
 
+    gua_context_t* pause_context = gua_create_context();
+    assert(gua_clock_install(pause_context, 0.0, 10.0) == GUA_CLOCK_OK);
+    assert(gua_clock_advance(pause_context, 10.0) == GUA_CLOCK_OK);
+    assert(gua_clock_pause(pause_context) == GUA_CLOCK_ERROR_INVALID_STATE);
+    clock_step = gua_clock_step_t { sizeof(gua_clock_step_t) };
+    assert(gua_clock_consume_step(pause_context, &clock_step) == 1);
+    assert(gua_clock_pause(pause_context) == GUA_CLOCK_OK);
+    assert(gua_clock_run_for(pause_context, 10.0, 10.0) == GUA_CLOCK_OK);
+    gua_destroy_context(pause_context);
+
     gua_context_t* overflow_context = gua_create_context();
     assert(gua_clock_install(overflow_context, 1e308, 1e308) == GUA_CLOCK_OK);
     assert(gua_clock_pause(overflow_context) == GUA_CLOCK_OK);

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -200,6 +200,19 @@ int main()
     assert(count_clock_steps(1000.0, 1000.0 / 60.0) == 60);
     assert(count_clock_steps(1e-16, 1.0) == 1);
 
+    gua_context_t* underflow_context = gua_create_context();
+    assert(gua_clock_install(underflow_context, 0.0, 1e308) == GUA_CLOCK_OK);
+    assert(gua_clock_pause(underflow_context) == GUA_CLOCK_OK);
+    assert(gua_clock_run_for(underflow_context, 1e-300, 1e308) == GUA_CLOCK_OK);
+    gua_clock_step_t underflow_step { sizeof(gua_clock_step_t) };
+    assert(gua_clock_consume_step(underflow_context, &underflow_step) == 1);
+    assert(underflow_step.delta_ms == 1e-300 && underflow_step.final_step == 1);
+    gua_clock_status_t underflow_status { sizeof(gua_clock_status_t) };
+    assert(gua_clock_get_status(underflow_context, &underflow_status) == 1);
+    assert(underflow_status.now_ms == 1e-300 && underflow_status.pending_ms == 0.0);
+    assert(gua_clock_consume_step(underflow_context, &underflow_step) == 0);
+    gua_destroy_context(underflow_context);
+
     gua_context_t* zero_duration_context = gua_create_context();
     assert(gua_clock_install(zero_duration_context, 0.0, 10.0) == GUA_CLOCK_OK);
     assert(gua_clock_pause(zero_duration_context) == GUA_CLOCK_OK);

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -148,6 +148,20 @@ int main()
     assert(count_clock_steps(1.0, 0.1) == 10);
     assert(count_clock_steps(1000.0, 1000.0 / 60.0) == 60);
 
+    gua_context_t* magnitude_context = gua_create_context();
+    assert(gua_clock_install(magnitude_context, 1e16, 1.0) == GUA_CLOCK_OK);
+    assert(gua_clock_pause(magnitude_context) == GUA_CLOCK_OK);
+    assert(gua_clock_run_for(magnitude_context, 100.0, 1.0) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
+    gua_clock_status_t magnitude_status { sizeof(gua_clock_status_t) };
+    assert(gua_clock_get_status(magnitude_context, &magnitude_status) == 1);
+    assert(magnitude_status.now_ms == 1e16 && magnitude_status.pending_ms == 0.0);
+    gua_destroy_context(magnitude_context);
+
+    magnitude_context = gua_create_context();
+    assert(gua_clock_install(magnitude_context, 1e16, 1.0) == GUA_CLOCK_OK);
+    assert(gua_clock_advance(magnitude_context, 100.0) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
+    gua_destroy_context(magnitude_context);
+
     gua::Context cpp_context;
     cpp_context.install_clock(0.0, 10.0);
     cpp_context.pause_clock();

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -1,6 +1,8 @@
 #include "gua/gua.h"
+#include "gua/gua.hpp"
 
 #include <cassert>
+#include <cmath>
 #include <cstring>
 #include <string>
 #include <cstdint>
@@ -95,6 +97,14 @@ int main()
     assert(gua_clock_advance(context, 10000001.0) == GUA_CLOCK_ERROR_EXECUTION_LIMIT);
     assert(gua_clock_get_status(context, &clock_status) == 1 && clock_status.pending_ms == 0.0);
 
+    gua_context_t* overflow_context = gua_create_context();
+    assert(gua_clock_install(overflow_context, 1e308, 1e308) == GUA_CLOCK_OK);
+    assert(gua_clock_pause(overflow_context) == GUA_CLOCK_OK);
+    assert(gua_clock_run_for(overflow_context, 1e308, 1e308) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
+    assert(gua_clock_get_status(overflow_context, &clock_status) == 1 &&
+        std::isfinite(clock_status.now_ms) && clock_status.pending_ms == 0.0);
+    gua_destroy_context(overflow_context);
+
     gua_context_t* precision_context = gua_create_context();
     assert(gua_clock_install(precision_context, 0.0, 1e-7) == GUA_CLOCK_OK);
     assert(gua_clock_pause(precision_context) == GUA_CLOCK_OK);
@@ -110,6 +120,15 @@ int main()
     assert(number_after("\"defaultStepMs\":") == 1e-7);
     assert(number_after("\"pendingMs\":") == 2e-7);
     gua_destroy_context(precision_context);
+
+    gua::Context cpp_context;
+    cpp_context.install_clock(0.0, 10.0);
+    cpp_context.pause_clock();
+    cpp_context.run_clock_for(25.0);
+    gua_clock_step_t cpp_step { sizeof(gua_clock_step_t) };
+    assert(cpp_context.poll_clock_step(cpp_step) && cpp_step.delta_ms == 10.0);
+    assert(cpp_context.poll_clock_step(cpp_step) && cpp_step.delta_ms == 10.0);
+    assert(cpp_context.poll_clock_step(cpp_step) && cpp_step.delta_ms == 5.0);
 
     // A frame is private until end_frame atomically publishes it.
     gua_context_t* atomic_context = gua_create_context();

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -7,6 +7,7 @@
 #include <godot_cpp/variant/array.hpp>
 #include <godot_cpp/variant/rect2.hpp>
 #include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/variant/variant.hpp>
 
 namespace godot {
 
@@ -46,7 +47,7 @@ public:
     Dictionary reset_context(const Dictionary& options = Dictionary());
     Dictionary clock_install(double initial_time_ms = 0.0, double step_ms = 1000.0 / 60.0);
     Dictionary clock_pause();
-    Dictionary clock_run_for(double duration_ms, double step_ms = 0.0);
+    Dictionary clock_run_for(double duration_ms, const Variant& step_ms = Variant());
     Dictionary clock_resume();
     Dictionary clock_advance(double duration_ms);
     Dictionary get_clock() const;

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -50,6 +50,7 @@ public:
     Dictionary clock_resume();
     Dictionary clock_advance(double duration_ms);
     Dictionary get_clock() const;
+    Dictionary consume_clock_step();
     Array consume_clock_steps();
     bool start_inspector_bridge(int port = 8765);
     void stop_inspector_bridge();

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -52,6 +52,7 @@ public:
     Dictionary get_clock() const;
     Dictionary consume_clock_step();
     Array consume_clock_steps();
+    void enable_virtual_clock_adapter();
     bool start_inspector_bridge(int port = 8765);
     void stop_inspector_bridge();
     bool inspector_bridge_running() const;

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -4,6 +4,7 @@
 
 #include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/array.hpp>
 #include <godot_cpp/variant/rect2.hpp>
 #include <godot_cpp/variant/string.hpp>
 
@@ -43,6 +44,13 @@ public:
     Dictionary poll_event_v2();
     Dictionary get_context_status() const;
     Dictionary reset_context(const Dictionary& options = Dictionary());
+    Dictionary clock_install(double initial_time_ms = 0.0, double step_ms = 1000.0 / 60.0);
+    Dictionary clock_pause();
+    Dictionary clock_run_for(double duration_ms, double step_ms = 0.0);
+    Dictionary clock_resume();
+    Dictionary clock_advance(double duration_ms);
+    Dictionary get_clock() const;
+    Array consume_clock_steps();
     bool start_inspector_bridge(int port = 8765);
     void stop_inspector_bridge();
     bool inspector_bridge_running() const;

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -346,6 +346,28 @@ Dictionary GuaContext::poll_event_v2()
     return result;
 }
 
+Dictionary GuaContext::get_clock() const
+{
+    gua_clock_status_t status { sizeof(gua_clock_status_t) }; Dictionary result;
+    if (gua_runtime_clock_get_status(runtime_, &status) == 0) return result;
+    result["schema_version"] = 1; result["installed"] = status.installed != 0;
+    result["state"] = status.paused != 0 ? "paused" : "running"; result["now_ms"] = status.now_ms;
+    result["default_step_ms"] = status.default_step_ms; result["pending_ms"] = status.pending_ms; result["generation"] = status.generation;
+    return result;
+}
+Dictionary GuaContext::clock_install(double initial_time_ms, double step_ms) { gua_runtime_clock_install(runtime_, initial_time_ms, step_ms); return get_clock(); }
+Dictionary GuaContext::clock_pause() { gua_runtime_clock_pause(runtime_); return get_clock(); }
+Dictionary GuaContext::clock_run_for(double duration_ms, double step_ms)
+{ const Dictionary status = get_clock(); const double actual = step_ms > 0.0 ? step_ms : static_cast<double>(status["default_step_ms"]); gua_runtime_clock_run_for(runtime_, duration_ms, actual); return get_clock(); }
+Dictionary GuaContext::clock_resume() { gua_runtime_clock_resume(runtime_); return get_clock(); }
+Dictionary GuaContext::clock_advance(double duration_ms) { gua_runtime_clock_advance(runtime_, duration_ms); return get_clock(); }
+Array GuaContext::consume_clock_steps()
+{
+    Array result; gua_clock_step_t step { sizeof(gua_clock_step_t) };
+    while (gua_runtime_clock_consume_step(runtime_, &step) != 0) { Dictionary item; item["delta_ms"] = step.delta_ms; item["final"] = step.final_step != 0; item["generation"] = step.generation; result.push_back(item); step = gua_clock_step_t { sizeof(gua_clock_step_t) }; }
+    return result;
+}
+
 Dictionary GuaContext::get_context_status() const
 {
     gua_context_status_t status { sizeof(gua_context_status_t) };
@@ -448,6 +470,13 @@ void GuaContext::_bind_methods()
     ClassDB::bind_method(D_METHOD("poll_event_v2"), &GuaContext::poll_event_v2);
     ClassDB::bind_method(D_METHOD("get_context_status"), &GuaContext::get_context_status);
     ClassDB::bind_method(D_METHOD("reset_context", "options"), &GuaContext::reset_context, DEFVAL(Dictionary()));
+    ClassDB::bind_method(D_METHOD("clock_install", "initial_time_ms", "step_ms"), &GuaContext::clock_install, DEFVAL(0.0), DEFVAL(1000.0 / 60.0));
+    ClassDB::bind_method(D_METHOD("clock_pause"), &GuaContext::clock_pause);
+    ClassDB::bind_method(D_METHOD("clock_run_for", "duration_ms", "step_ms"), &GuaContext::clock_run_for, DEFVAL(0.0));
+    ClassDB::bind_method(D_METHOD("clock_resume"), &GuaContext::clock_resume);
+    ClassDB::bind_method(D_METHOD("clock_advance", "duration_ms"), &GuaContext::clock_advance);
+    ClassDB::bind_method(D_METHOD("get_clock"), &GuaContext::get_clock);
+    ClassDB::bind_method(D_METHOD("consume_clock_steps"), &GuaContext::consume_clock_steps);
     ClassDB::bind_method(D_METHOD("start_inspector_bridge", "port"), &GuaContext::start_inspector_bridge, DEFVAL(8765));
     ClassDB::bind_method(D_METHOD("stop_inspector_bridge"), &GuaContext::stop_inspector_bridge);
     ClassDB::bind_method(D_METHOD("inspector_bridge_running"), &GuaContext::inspector_bridge_running);

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -104,7 +104,6 @@ GuaContext::GuaContext()
     : runtime_(gua_runtime_create())
 {
     gua_runtime_set_godot_plugin_version(runtime_, GUA_GODOT_PLUGIN_VERSION);
-    gua_runtime_set_virtual_clock_enabled(runtime_, 1);
     if (runtime_ == nullptr) {
         UtilityFunctions::push_error(
             "GuaContext failed to create a Gua runtime. Check that the Gua native library and dependent DLLs are available.");
@@ -388,7 +387,7 @@ Dictionary GuaContext::get_clock() const
 Dictionary GuaContext::clock_install(double initial_time_ms, double step_ms) { return clock_result(runtime_, gua_runtime_clock_install(runtime_, initial_time_ms, step_ms)); }
 Dictionary GuaContext::clock_pause() { return clock_result(runtime_, gua_runtime_clock_pause(runtime_)); }
 Dictionary GuaContext::clock_run_for(double duration_ms, double step_ms)
-{ return clock_result(runtime_, gua_runtime_clock_run_for(runtime_, duration_ms, step_ms)); }
+{ const Dictionary status = get_clock(); const double actual = step_ms == 0.0 ? static_cast<double>(status["default_step_ms"]) : step_ms; return clock_result(runtime_, gua_runtime_clock_run_for(runtime_, duration_ms, actual)); }
 Dictionary GuaContext::clock_resume() { return clock_result(runtime_, gua_runtime_clock_resume(runtime_)); }
 Dictionary GuaContext::clock_advance(double duration_ms) { return clock_result(runtime_, gua_runtime_clock_advance(runtime_, duration_ms)); }
 Dictionary GuaContext::consume_clock_step()
@@ -403,6 +402,11 @@ Array GuaContext::consume_clock_steps()
     Array result; gua_clock_step_t step { sizeof(gua_clock_step_t) };
     while (gua_runtime_clock_consume_step(runtime_, &step) != 0) { Dictionary item; item["delta_ms"] = step.delta_ms; item["final"] = step.final_step != 0; item["generation"] = step.generation; result.push_back(item); step = gua_clock_step_t { sizeof(gua_clock_step_t) }; }
     return result;
+}
+
+void GuaContext::enable_virtual_clock_adapter()
+{
+    gua_runtime_set_virtual_clock_enabled(runtime_, 1);
 }
 
 Dictionary GuaContext::get_context_status() const
@@ -515,6 +519,7 @@ void GuaContext::_bind_methods()
     ClassDB::bind_method(D_METHOD("get_clock"), &GuaContext::get_clock);
     ClassDB::bind_method(D_METHOD("consume_clock_step"), &GuaContext::consume_clock_step);
     ClassDB::bind_method(D_METHOD("consume_clock_steps"), &GuaContext::consume_clock_steps);
+    ClassDB::bind_method(D_METHOD("enable_virtual_clock_adapter"), &GuaContext::enable_virtual_clock_adapter);
     ClassDB::bind_method(D_METHOD("start_inspector_bridge", "port"), &GuaContext::start_inspector_bridge, DEFVAL(8765));
     ClassDB::bind_method(D_METHOD("stop_inspector_bridge"), &GuaContext::stop_inspector_bridge);
     ClassDB::bind_method(D_METHOD("inspector_bridge_running"), &GuaContext::inspector_bridge_running);

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -358,9 +358,16 @@ Dictionary GuaContext::get_clock() const
 Dictionary GuaContext::clock_install(double initial_time_ms, double step_ms) { gua_runtime_clock_install(runtime_, initial_time_ms, step_ms); return get_clock(); }
 Dictionary GuaContext::clock_pause() { gua_runtime_clock_pause(runtime_); return get_clock(); }
 Dictionary GuaContext::clock_run_for(double duration_ms, double step_ms)
-{ const Dictionary status = get_clock(); const double actual = step_ms > 0.0 ? step_ms : static_cast<double>(status["default_step_ms"]); gua_runtime_clock_run_for(runtime_, duration_ms, actual); return get_clock(); }
+{ const Dictionary status = get_clock(); const double actual = step_ms == 0.0 ? static_cast<double>(status["default_step_ms"]) : step_ms; gua_runtime_clock_run_for(runtime_, duration_ms, actual); return get_clock(); }
 Dictionary GuaContext::clock_resume() { gua_runtime_clock_resume(runtime_); return get_clock(); }
 Dictionary GuaContext::clock_advance(double duration_ms) { gua_runtime_clock_advance(runtime_, duration_ms); return get_clock(); }
+Dictionary GuaContext::consume_clock_step()
+{
+    Dictionary result; gua_clock_step_t step { sizeof(gua_clock_step_t) };
+    if (gua_runtime_clock_consume_step(runtime_, &step) == 0) return result;
+    result["delta_ms"] = step.delta_ms; result["final"] = step.final_step != 0; result["generation"] = step.generation;
+    return result;
+}
 Array GuaContext::consume_clock_steps()
 {
     Array result; gua_clock_step_t step { sizeof(gua_clock_step_t) };
@@ -476,6 +483,7 @@ void GuaContext::_bind_methods()
     ClassDB::bind_method(D_METHOD("clock_resume"), &GuaContext::clock_resume);
     ClassDB::bind_method(D_METHOD("clock_advance", "duration_ms"), &GuaContext::clock_advance);
     ClassDB::bind_method(D_METHOD("get_clock"), &GuaContext::get_clock);
+    ClassDB::bind_method(D_METHOD("consume_clock_step"), &GuaContext::consume_clock_step);
     ClassDB::bind_method(D_METHOD("consume_clock_steps"), &GuaContext::consume_clock_steps);
     ClassDB::bind_method(D_METHOD("start_inspector_bridge", "port"), &GuaContext::start_inspector_bridge, DEFVAL(8765));
     ClassDB::bind_method(D_METHOD("stop_inspector_bridge"), &GuaContext::stop_inspector_bridge);

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -47,6 +47,35 @@ const char* action_name(int action)
     }
 }
 
+const char* clock_error_name(int result)
+{
+    switch (result) {
+    case GUA_CLOCK_ERROR_NOT_INSTALLED: return "not_installed";
+    case GUA_CLOCK_ERROR_INVALID_STATE: return "invalid_state";
+    case GUA_CLOCK_ERROR_EXECUTION_LIMIT: return "execution_limit";
+    case GUA_CLOCK_ERROR_INVALID_ARGUMENT: return "invalid_duration";
+    default: return "";
+    }
+}
+
+godot::Dictionary clock_result(gua_runtime_t* runtime, int result)
+{
+    gua_clock_status_t status { sizeof(gua_clock_status_t) };
+    godot::Dictionary value;
+    if (gua_runtime_clock_get_status(runtime, &status) != 0) {
+        value["schema_version"] = 1;
+        value["installed"] = status.installed != 0;
+        value["state"] = status.paused != 0 ? "paused" : "running";
+        value["now_ms"] = status.now_ms;
+        value["default_step_ms"] = status.default_step_ms;
+        value["pending_ms"] = status.pending_ms;
+        value["generation"] = status.generation;
+    }
+    value["result"] = result;
+    value["error"] = clock_error_name(result);
+    return value;
+}
+
 godot::String copy_runtime_json(gua_runtime_t* runtime, int (*copy_json)(gua_runtime_t*, char*, int))
 {
     int required_size = copy_json(runtime, nullptr, 0);
@@ -75,6 +104,7 @@ GuaContext::GuaContext()
     : runtime_(gua_runtime_create())
 {
     gua_runtime_set_godot_plugin_version(runtime_, GUA_GODOT_PLUGIN_VERSION);
+    gua_runtime_set_virtual_clock_enabled(runtime_, 1);
     if (runtime_ == nullptr) {
         UtilityFunctions::push_error(
             "GuaContext failed to create a Gua runtime. Check that the Gua native library and dependent DLLs are available.");
@@ -355,12 +385,12 @@ Dictionary GuaContext::get_clock() const
     result["default_step_ms"] = status.default_step_ms; result["pending_ms"] = status.pending_ms; result["generation"] = status.generation;
     return result;
 }
-Dictionary GuaContext::clock_install(double initial_time_ms, double step_ms) { gua_runtime_clock_install(runtime_, initial_time_ms, step_ms); return get_clock(); }
-Dictionary GuaContext::clock_pause() { gua_runtime_clock_pause(runtime_); return get_clock(); }
+Dictionary GuaContext::clock_install(double initial_time_ms, double step_ms) { return clock_result(runtime_, gua_runtime_clock_install(runtime_, initial_time_ms, step_ms)); }
+Dictionary GuaContext::clock_pause() { return clock_result(runtime_, gua_runtime_clock_pause(runtime_)); }
 Dictionary GuaContext::clock_run_for(double duration_ms, double step_ms)
-{ const Dictionary status = get_clock(); const double actual = step_ms == 0.0 ? static_cast<double>(status["default_step_ms"]) : step_ms; gua_runtime_clock_run_for(runtime_, duration_ms, actual); return get_clock(); }
-Dictionary GuaContext::clock_resume() { gua_runtime_clock_resume(runtime_); return get_clock(); }
-Dictionary GuaContext::clock_advance(double duration_ms) { gua_runtime_clock_advance(runtime_, duration_ms); return get_clock(); }
+{ return clock_result(runtime_, gua_runtime_clock_run_for(runtime_, duration_ms, step_ms)); }
+Dictionary GuaContext::clock_resume() { return clock_result(runtime_, gua_runtime_clock_resume(runtime_)); }
+Dictionary GuaContext::clock_advance(double duration_ms) { return clock_result(runtime_, gua_runtime_clock_advance(runtime_, duration_ms)); }
 Dictionary GuaContext::consume_clock_step()
 {
     Dictionary result; gua_clock_step_t step { sizeof(gua_clock_step_t) };

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -440,9 +440,10 @@ Dictionary GuaContext::reset_context(const Dictionary& source)
 {
     const gua_reset_options_t options {
         sizeof(gua_reset_options_t),
-        static_cast<uint32_t>(static_cast<int64_t>(source.get("flags", GUA_RESET_DEFAULT))),
+        static_cast<uint32_t>(static_cast<int64_t>(source.get("flags", GUA_RESET_DEFAULT_V2))),
         source.get("strict", false) ? 1 : 0,
         static_cast<uint64_t>(static_cast<int64_t>(source.get("expected_session_epoch", 0))),
+        GUA_RESET_FLAGS_VERSION_CURRENT,
     };
     gua_reset_report_t report { sizeof(gua_reset_report_t) };
     const int code = gua_runtime_reset_context(runtime_, &options, &report);

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -386,8 +386,14 @@ Dictionary GuaContext::get_clock() const
 }
 Dictionary GuaContext::clock_install(double initial_time_ms, double step_ms) { return clock_result(runtime_, gua_runtime_clock_install(runtime_, initial_time_ms, step_ms)); }
 Dictionary GuaContext::clock_pause() { return clock_result(runtime_, gua_runtime_clock_pause(runtime_)); }
-Dictionary GuaContext::clock_run_for(double duration_ms, double step_ms)
-{ const Dictionary status = get_clock(); const double actual = step_ms == 0.0 ? static_cast<double>(status["default_step_ms"]) : step_ms; return clock_result(runtime_, gua_runtime_clock_run_for(runtime_, duration_ms, actual)); }
+Dictionary GuaContext::clock_run_for(double duration_ms, const Variant& step_ms)
+{
+    const Dictionary status = get_clock();
+    const double actual = step_ms.get_type() == Variant::NIL
+        ? static_cast<double>(status["default_step_ms"])
+        : static_cast<double>(step_ms);
+    return clock_result(runtime_, gua_runtime_clock_run_for(runtime_, duration_ms, actual));
+}
 Dictionary GuaContext::clock_resume() { return clock_result(runtime_, gua_runtime_clock_resume(runtime_)); }
 Dictionary GuaContext::clock_advance(double duration_ms) { return clock_result(runtime_, gua_runtime_clock_advance(runtime_, duration_ms)); }
 Dictionary GuaContext::consume_clock_step()
@@ -513,7 +519,7 @@ void GuaContext::_bind_methods()
     ClassDB::bind_method(D_METHOD("reset_context", "options"), &GuaContext::reset_context, DEFVAL(Dictionary()));
     ClassDB::bind_method(D_METHOD("clock_install", "initial_time_ms", "step_ms"), &GuaContext::clock_install, DEFVAL(0.0), DEFVAL(1000.0 / 60.0));
     ClassDB::bind_method(D_METHOD("clock_pause"), &GuaContext::clock_pause);
-    ClassDB::bind_method(D_METHOD("clock_run_for", "duration_ms", "step_ms"), &GuaContext::clock_run_for, DEFVAL(0.0));
+    ClassDB::bind_method(D_METHOD("clock_run_for", "duration_ms", "step_ms"), &GuaContext::clock_run_for, DEFVAL(Variant()));
     ClassDB::bind_method(D_METHOD("clock_resume"), &GuaContext::clock_resume);
     ClassDB::bind_method(D_METHOD("clock_advance", "duration_ms"), &GuaContext::clock_advance);
     ClassDB::bind_method(D_METHOD("get_clock"), &GuaContext::get_clock);

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -71,6 +71,8 @@ int gua_runtime_clock_copy_status_json(gua_runtime_t* runtime, char* out_json, i
 int gua_runtime_clock_consume_step(gua_runtime_t* runtime, gua_clock_step_t* out_step);
 void gua_runtime_set_godot_plugin_version(gua_runtime_t* runtime, const char* version);
 void gua_runtime_set_adapter_version(gua_runtime_t* runtime, const char* adapter, const char* version);
+/* Adapter opt-in: enable only when the host pumps and consumes clock steps. */
+void gua_runtime_set_virtual_clock_enabled(gua_runtime_t* runtime, int enabled);
 int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* node_id, gua_node_state_t* out_state);
 int gua_runtime_get_node_state_v2(gua_runtime_t* runtime, const char* node_id, gua_node_state_v2_t* out_state);
 int gua_runtime_find_node_by_id(gua_runtime_t* runtime, const char* node_id, char* out_node_id, int out_node_id_size);

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -61,6 +61,14 @@ int gua_runtime_set_diagnostics_environment_json(gua_runtime_t* runtime, const c
 const char* gua_runtime_get_diagnostics_json(gua_runtime_t* runtime);
 int gua_runtime_copy_diagnostics_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
 int gua_runtime_copy_version_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
+int gua_runtime_clock_install(gua_runtime_t* runtime, double initial_time_ms, double step_ms);
+int gua_runtime_clock_pause(gua_runtime_t* runtime);
+int gua_runtime_clock_run_for(gua_runtime_t* runtime, double duration_ms, double step_ms);
+int gua_runtime_clock_advance(gua_runtime_t* runtime, double duration_ms);
+int gua_runtime_clock_resume(gua_runtime_t* runtime);
+int gua_runtime_clock_get_status(gua_runtime_t* runtime, gua_clock_status_t* out_status);
+int gua_runtime_clock_copy_status_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
+int gua_runtime_clock_consume_step(gua_runtime_t* runtime, gua_clock_step_t* out_step);
 void gua_runtime_set_godot_plugin_version(gua_runtime_t* runtime, const char* version);
 void gua_runtime_set_adapter_version(gua_runtime_t* runtime, const char* adapter, const char* version);
 int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* node_id, gua_node_state_t* out_state);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -62,9 +62,56 @@ int copy_json_string(const std::string& json, char* out_json, int out_json_size)
 void filter_runtime_capabilities(std::string& json, bool virtual_clock_enabled)
 {
     if (virtual_clock_enabled) return;
-    const std::string capability = ",\"virtual_clock_v1\"";
-    const auto position = json.find(capability);
-    if (position != std::string::npos) json.erase(position, capability.size());
+    constexpr std::string_view key = "\"capabilities\":[";
+    constexpr std::string_view capability = "\"virtual_clock_v1\"";
+    const auto key_position = json.find(key);
+    if (key_position == std::string::npos) return;
+    const auto array_begin = key_position + key.size();
+    const auto array_end = json.find(']', array_begin);
+    auto position = json.find(capability, array_begin);
+    if (array_end == std::string::npos || position == std::string::npos || position >= array_end) return;
+    auto size = capability.size();
+    if (position > array_begin && json[position - 1] == ',') {
+        --position;
+        ++size;
+    } else if (position + size < array_end && json[position + size] == ',') {
+        ++size;
+    }
+    json.erase(position, size);
+}
+
+std::string core_version_json()
+{
+    const int size = gua_copy_version_json(nullptr, 0);
+    std::string json(static_cast<std::size_t>(size), '\0');
+    gua_copy_version_json(json.data(), size);
+    json.resize(static_cast<std::size_t>(size - 1));
+    return json;
+}
+
+std::string decorate_version_json(gua_runtime_t* runtime, std::string json)
+{
+    filter_runtime_capabilities(json, runtime->virtual_clock_enabled);
+    if (!runtime->godot_plugin_version.empty()) {
+        const std::string marker = "\"godotPluginVersion\":null";
+        const auto position = json.find(marker);
+        if (position != std::string::npos)
+            json.replace(position, marker.size(), "\"godotPluginVersion\":\"" + escape_json(runtime->godot_plugin_version) + "\"");
+    }
+    const std::string adapter_marker = "\"adapterVersions\":{}";
+    const auto adapter_position = json.find(adapter_marker);
+    if (adapter_position != std::string::npos && !runtime->adapter_versions.empty()) {
+        std::string adapters = "\"adapterVersions\":{";
+        bool first = true;
+        for (const auto& [name, version] : runtime->adapter_versions) {
+            if (!first) adapters += ',';
+            first = false;
+            adapters += "\"" + escape_json(name) + "\":\"" + escape_json(version) + "\"";
+        }
+        adapters += '}';
+        json.replace(adapter_position, adapter_marker.size(), adapters);
+    }
+    return json;
 }
 
 std::string copy_ui_tree_json(gua_runtime_t* runtime)
@@ -97,26 +144,13 @@ std::string copy_diagnostics_json(gua_runtime_t* runtime)
 {
     const std::lock_guard lock(runtime->context_mutex);
     std::string json = gua_get_diagnostics_json(runtime->context);
-    filter_runtime_capabilities(json, runtime->virtual_clock_enabled);
-    if (!runtime->godot_plugin_version.empty()) {
-        const std::string marker = "\"godotPluginVersion\":null";
-        const auto position = json.find(marker);
-        if (position != std::string::npos) {
-            json.replace(position, marker.size(), "\"godotPluginVersion\":\"" + escape_json(runtime->godot_plugin_version) + "\"");
-        }
-    }
-    const std::string adapter_marker = "\"adapterVersions\":{}";
-    const auto adapter_position = json.find(adapter_marker);
-    if (adapter_position != std::string::npos && !runtime->adapter_versions.empty()) {
-        std::string adapters = "\"adapterVersions\":{";
-        bool first = true;
-        for (const auto& [name, version] : runtime->adapter_versions) {
-            if (!first) adapters += ',';
-            first = false;
-            adapters += "\"" + escape_json(name) + "\":\"" + escape_json(version) + "\"";
-        }
-        adapters += '}';
-        json.replace(adapter_position, adapter_marker.size(), adapters);
+    const std::string unfiltered_version = core_version_json();
+    const std::string decorated_version = decorate_version_json(runtime, unfiltered_version);
+    const std::string marker = ",\"version\":" + unfiltered_version + ",\"uiTree\":";
+    const auto marker_position = json.rfind(marker);
+    if (marker_position != std::string::npos) {
+        const auto version_position = marker_position + std::string_view(",\"version\":").size();
+        json.replace(version_position, unfiltered_version.size(), decorated_version);
     }
     return json;
 }
@@ -133,31 +167,7 @@ bool valid_adapter_name(std::string_view adapter)
 std::string copy_version_json(gua_runtime_t* runtime)
 {
     const std::lock_guard lock(runtime->context_mutex);
-    char buffer[2048] {};
-    gua_copy_version_json(buffer, static_cast<int>(sizeof(buffer)));
-    std::string json = buffer;
-    filter_runtime_capabilities(json, runtime->virtual_clock_enabled);
-    if (!runtime->godot_plugin_version.empty()) {
-        const std::string marker = "\"godotPluginVersion\":null";
-        const auto position = json.find(marker);
-        if (position != std::string::npos) {
-            json.replace(position, marker.size(), "\"godotPluginVersion\":\"" + escape_json(runtime->godot_plugin_version) + "\"");
-        }
-    }
-    const std::string adapter_marker = "\"adapterVersions\":{}";
-    const auto adapter_position = json.find(adapter_marker);
-    if (adapter_position != std::string::npos && !runtime->adapter_versions.empty()) {
-        std::string adapters = "\"adapterVersions\":{";
-        bool first = true;
-        for (const auto& [name, version] : runtime->adapter_versions) {
-            if (!first) adapters += ',';
-            first = false;
-            adapters += "\"" + escape_json(name) + "\":\"" + escape_json(version) + "\"";
-        }
-        adapters += '}';
-        json.replace(adapter_position, adapter_marker.size(), adapters);
-    }
-    return json;
+    return decorate_version_json(runtime, core_version_json());
 }
 
 std::string status_json(gua_runtime_t* runtime)

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -3,6 +3,7 @@
 #include "gua/ws_bridge.hpp"
 
 #include <cstdio>
+#include <atomic>
 #include <chrono>
 #include <algorithm>
 #include <deque>
@@ -35,6 +36,7 @@ struct gua_runtime_t {
     std::string godot_plugin_version;
     std::map<std::string, std::string> adapter_versions;
     bool virtual_clock_enabled = false;
+    std::atomic_bool bridge_stopping = false;
     uint64_t next_screenshot_request_id = 1;
     std::deque<gua_screenshot_request_t> screenshot_requests;
     std::unordered_map<uint64_t, ScreenshotBatch> screenshot_batches;
@@ -836,6 +838,7 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
     if (runtime->bridge != nullptr && runtime->bridge->running()) {
         return runtime->bridge->port() == static_cast<unsigned short>(port) ? 1 : 0;
     }
+    runtime->bridge_stopping.store(false);
 
     gua::ws::BridgeHandlers handlers {
         .get_ui_tree_json = [runtime] {
@@ -905,6 +908,8 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
                 unsigned long long completion_after_frame = 0;
                 unsigned long long session_epoch = 0;
                 while (std::chrono::steady_clock::now() < deadline) {
+                    if (runtime->bridge_stopping.load())
+                        return gua::ws::CommandResult { false, {}, "stale_session" };
                     {
                         const std::lock_guard lock(runtime->context_mutex);
                         gua_clock_status_t clock { sizeof(gua_clock_status_t) };
@@ -1076,6 +1081,7 @@ extern "C" void gua_runtime_stop_inspector_bridge(gua_runtime_t* runtime)
         return;
     }
 
+    runtime->bridge_stopping.store(true);
     std::unique_ptr<gua::ws::BridgeServer> bridge;
     {
         const std::lock_guard bridge_lock(runtime->bridge_mutex);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -907,13 +907,16 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
                     {
                         const std::lock_guard lock(runtime->context_mutex);
                         gua_clock_status_t clock { sizeof(gua_clock_status_t) };
+                        gua_clock_operation_status_t operation { sizeof(gua_clock_operation_status_t) };
                         gua_context_status_t context { sizeof(gua_context_status_t) };
                         if (gua_clock_get_status(runtime->context, &clock) == 0 ||
+                            gua_clock_get_operation_status(runtime->context, &operation) == 0 ||
                             gua_get_context_status(runtime->context, &context) == 0)
                             return gua::ws::CommandResult { false, {}, "invalid_state" };
                         if (waiting_for_frame && context.session_epoch != session_epoch)
                             return gua::ws::CommandResult { false, {}, "stale_session" };
-                        if (clock.pending_ms > 0.0) {
+                        if (clock.pending_ms > 0.0 ||
+                            operation.latest_operation_sequence > operation.completed_operation_sequence) {
                             waiting_for_frame = true;
                             completion_after_frame = context.frame_sequence;
                             session_epoch = context.session_epoch;
@@ -933,6 +936,7 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
             const std::lock_guard lock(runtime->context_mutex);
             int result = GUA_CLOCK_ERROR_INVALID_ARGUMENT;
             gua_context_status_t completion_context { sizeof(gua_context_status_t) };
+            gua_clock_operation_status_t operation_status { sizeof(gua_clock_operation_status_t) };
             if (command == "clock_install")
                 result = gua_clock_install(runtime->context, value_ms, step_ms_present ? step_ms : 1000.0 / 60.0);
             else if (command == "clock_run_for") {
@@ -946,9 +950,12 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
             }
             std::string json = copy_clock();
             if (command == "clock_run_for") {
+                if (gua_clock_get_operation_status(runtime->context, &operation_status) == 0)
+                    return gua::ws::CommandResult { false, {}, "invalid_state" };
                 json.pop_back();
                 json += ",\"completionSessionEpoch\":" + std::to_string(completion_context.session_epoch) +
-                    ",\"completionAfterFrameSequence\":" + std::to_string(completion_context.frame_sequence) + '}';
+                    ",\"completionAfterFrameSequence\":" + std::to_string(completion_context.frame_sequence) +
+                    ",\"operationSequence\":" + std::to_string(operation_status.latest_operation_sequence) + '}';
             }
             return gua::ws::CommandResult { true, std::move(json), {} };
         },

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -561,11 +561,6 @@ extern "C" int gua_runtime_clock_run_for(gua_runtime_t* runtime, double duration
 {
     if (!valid_runtime(runtime)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     const std::lock_guard lock(runtime->context_mutex);
-    if (step_ms == 0.0) {
-        gua_clock_status_t status { sizeof(gua_clock_status_t) };
-        if (gua_clock_get_status(runtime->context, &status) == 0) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
-        step_ms = status.default_step_ms;
-    }
     return gua_clock_run_for(runtime->context, duration_ms, step_ms);
 }
 
@@ -875,22 +870,72 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
             json.resize(static_cast<std::size_t>(size - 1));
             return json;
         },
-        .control_clock = [runtime](std::string_view command, double value_ms, double step_ms) {
-            int result = GUA_CLOCK_ERROR_INVALID_ARGUMENT;
-            if (command == "clock_install") result = gua_runtime_clock_install(runtime, value_ms, step_ms == 0.0 ? 1000.0 / 60.0 : step_ms);
-            else if (command == "clock_pause") result = gua_runtime_clock_pause(runtime);
-            else if (command == "clock_run_for") result = gua_runtime_clock_run_for(runtime, value_ms, step_ms);
-            else if (command == "clock_resume") result = gua_runtime_clock_resume(runtime);
-            if (result != GUA_CLOCK_OK) {
-                const char* error = result == GUA_CLOCK_ERROR_NOT_INSTALLED ? "not_installed" :
+        .control_clock = [runtime](std::string_view command, double value_ms, double step_ms, bool step_ms_present) {
+            const auto clock_error = [](int result) {
+                return result == GUA_CLOCK_ERROR_NOT_INSTALLED ? "not_installed" :
                     result == GUA_CLOCK_ERROR_INVALID_STATE ? "invalid_state" :
                     result == GUA_CLOCK_ERROR_EXECUTION_LIMIT ? "execution_limit" : "invalid_duration";
-                return gua::ws::CommandResult { false, {}, error };
+            };
+            const auto copy_clock = [runtime] {
+                const int size = gua_clock_copy_status_json(runtime->context, nullptr, 0);
+                std::string json(static_cast<std::size_t>(size), '\0');
+                gua_clock_copy_status_json(runtime->context, json.data(), size);
+                json.resize(static_cast<std::size_t>(size - 1));
+                return json;
+            };
+
+            if (command == "clock_pause") {
+                const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+                bool waiting_for_frame = false;
+                unsigned long long completion_after_frame = 0;
+                unsigned long long session_epoch = 0;
+                while (std::chrono::steady_clock::now() < deadline) {
+                    {
+                        const std::lock_guard lock(runtime->context_mutex);
+                        gua_clock_status_t clock { sizeof(gua_clock_status_t) };
+                        gua_context_status_t context { sizeof(gua_context_status_t) };
+                        if (gua_clock_get_status(runtime->context, &clock) == 0 ||
+                            gua_get_context_status(runtime->context, &context) == 0)
+                            return gua::ws::CommandResult { false, {}, "invalid_state" };
+                        if (waiting_for_frame && context.session_epoch != session_epoch)
+                            return gua::ws::CommandResult { false, {}, "stale_session" };
+                        if (clock.pending_ms > 0.0) {
+                            waiting_for_frame = true;
+                            completion_after_frame = context.frame_sequence;
+                            session_epoch = context.session_epoch;
+                        } else if (!waiting_for_frame || context.frame_sequence > completion_after_frame) {
+                            const int result = gua_clock_pause(runtime->context);
+                            if (result == GUA_CLOCK_OK)
+                                return gua::ws::CommandResult { true, copy_clock(), {} };
+                            if (result != GUA_CLOCK_ERROR_INVALID_STATE)
+                                return gua::ws::CommandResult { false, {}, clock_error(result) };
+                        }
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
+                return gua::ws::CommandResult { false, {}, "invalid_state" };
             }
-            const int size = gua_runtime_clock_copy_status_json(runtime, nullptr, 0);
-            std::string json(static_cast<std::size_t>(size), '\0');
-            gua_runtime_clock_copy_status_json(runtime, json.data(), size);
-            json.resize(static_cast<std::size_t>(size - 1));
+
+            const std::lock_guard lock(runtime->context_mutex);
+            int result = GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+            gua_context_status_t completion_context { sizeof(gua_context_status_t) };
+            if (command == "clock_install")
+                result = gua_clock_install(runtime->context, value_ms, step_ms_present ? step_ms : 1000.0 / 60.0);
+            else if (command == "clock_run_for") {
+                gua_clock_status_t clock { sizeof(gua_clock_status_t) };
+                if (gua_clock_get_status(runtime->context, &clock) != 0 &&
+                    gua_get_context_status(runtime->context, &completion_context) != 0)
+                    result = gua_clock_run_for(runtime->context, value_ms, step_ms_present ? step_ms : clock.default_step_ms);
+            } else if (command == "clock_resume") result = gua_clock_resume(runtime->context);
+            if (result != GUA_CLOCK_OK) {
+                return gua::ws::CommandResult { false, {}, clock_error(result) };
+            }
+            std::string json = copy_clock();
+            if (command == "clock_run_for") {
+                json.pop_back();
+                json += ",\"completionSessionEpoch\":" + std::to_string(completion_context.session_epoch) +
+                    ",\"completionAfterFrameSequence\":" + std::to_string(completion_context.frame_sequence) + '}';
+            }
             return gua::ws::CommandResult { true, std::move(json), {} };
         },
         .query_nodes_json = [runtime](const gua::ws::QuerySelector& selector) {

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -550,6 +550,11 @@ extern "C" int gua_runtime_clock_run_for(gua_runtime_t* runtime, double duration
 {
     if (!valid_runtime(runtime)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
     const std::lock_guard lock(runtime->context_mutex);
+    if (step_ms == 0.0) {
+        gua_clock_status_t status { sizeof(gua_clock_status_t) };
+        if (gua_clock_get_status(runtime->context, &status) == 0) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+        step_ms = status.default_step_ms;
+    }
     return gua_clock_run_for(runtime->context, duration_ms, step_ms);
 }
 
@@ -854,9 +859,9 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
         },
         .control_clock = [runtime](std::string_view command, double value_ms, double step_ms) {
             int result = GUA_CLOCK_ERROR_INVALID_ARGUMENT;
-            if (command == "clock_install") result = gua_runtime_clock_install(runtime, value_ms, step_ms > 0 ? step_ms : 1000.0 / 60.0);
+            if (command == "clock_install") result = gua_runtime_clock_install(runtime, value_ms, step_ms == 0.0 ? 1000.0 / 60.0 : step_ms);
             else if (command == "clock_pause") result = gua_runtime_clock_pause(runtime);
-            else if (command == "clock_run_for") result = gua_runtime_clock_run_for(runtime, value_ms, step_ms > 0 ? step_ms : 1000.0 / 60.0);
+            else if (command == "clock_run_for") result = gua_runtime_clock_run_for(runtime, value_ms, step_ms);
             else if (command == "clock_resume") result = gua_runtime_clock_resume(runtime);
             if (result != GUA_CLOCK_OK) {
                 const char* error = result == GUA_CLOCK_ERROR_NOT_INSTALLED ? "not_installed" :

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -878,9 +878,10 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
             return runtime->virtual_clock_enabled;
         },
         .get_clock_json = [runtime] {
-            const int size = gua_runtime_clock_copy_status_json(runtime, nullptr, 0);
+            const std::lock_guard lock(runtime->context_mutex);
+            const int size = gua_clock_copy_status_json(runtime->context, nullptr, 0);
             std::string json(static_cast<std::size_t>(size), '\0');
-            gua_runtime_clock_copy_status_json(runtime, json.data(), size);
+            gua_clock_copy_status_json(runtime->context, json.data(), size);
             json.resize(static_cast<std::size_t>(size - 1));
             return json;
         },

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -532,6 +532,62 @@ extern "C" int gua_runtime_copy_version_json(gua_runtime_t* runtime, char* out_j
     return copy_json_string(copy_version_json(runtime), out_json, out_json_size);
 }
 
+extern "C" int gua_runtime_clock_install(gua_runtime_t* runtime, double initial_time_ms, double step_ms)
+{
+    if (!valid_runtime(runtime)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_clock_install(runtime->context, initial_time_ms, step_ms);
+}
+
+extern "C" int gua_runtime_clock_pause(gua_runtime_t* runtime)
+{
+    if (!valid_runtime(runtime)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_clock_pause(runtime->context);
+}
+
+extern "C" int gua_runtime_clock_run_for(gua_runtime_t* runtime, double duration_ms, double step_ms)
+{
+    if (!valid_runtime(runtime)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_clock_run_for(runtime->context, duration_ms, step_ms);
+}
+
+extern "C" int gua_runtime_clock_resume(gua_runtime_t* runtime)
+{
+    if (!valid_runtime(runtime)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_clock_resume(runtime->context);
+}
+
+extern "C" int gua_runtime_clock_advance(gua_runtime_t* runtime, double duration_ms)
+{
+    if (!valid_runtime(runtime)) return GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_clock_advance(runtime->context, duration_ms);
+}
+
+extern "C" int gua_runtime_clock_get_status(gua_runtime_t* runtime, gua_clock_status_t* out_status)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_clock_get_status(runtime->context, out_status);
+}
+
+extern "C" int gua_runtime_clock_copy_status_json(gua_runtime_t* runtime, char* out_json, int out_json_size)
+{
+    if (!valid_runtime(runtime)) return copy_json_string("{}", out_json, out_json_size);
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_clock_copy_status_json(runtime->context, out_json, out_json_size);
+}
+
+extern "C" int gua_runtime_clock_consume_step(gua_runtime_t* runtime, gua_clock_step_t* out_step)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_clock_consume_step(runtime->context, out_step);
+}
+
 extern "C" void gua_runtime_set_godot_plugin_version(gua_runtime_t* runtime, const char* version)
 {
     if (!valid_runtime(runtime)) return;
@@ -788,6 +844,31 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
         },
         .get_version_json = [runtime] {
             return copy_version_json(runtime);
+        },
+        .get_clock_json = [runtime] {
+            const int size = gua_runtime_clock_copy_status_json(runtime, nullptr, 0);
+            std::string json(static_cast<std::size_t>(size), '\0');
+            gua_runtime_clock_copy_status_json(runtime, json.data(), size);
+            json.resize(static_cast<std::size_t>(size - 1));
+            return json;
+        },
+        .control_clock = [runtime](std::string_view command, double value_ms, double step_ms) {
+            int result = GUA_CLOCK_ERROR_INVALID_ARGUMENT;
+            if (command == "clock_install") result = gua_runtime_clock_install(runtime, value_ms, step_ms > 0 ? step_ms : 1000.0 / 60.0);
+            else if (command == "clock_pause") result = gua_runtime_clock_pause(runtime);
+            else if (command == "clock_run_for") result = gua_runtime_clock_run_for(runtime, value_ms, step_ms > 0 ? step_ms : 1000.0 / 60.0);
+            else if (command == "clock_resume") result = gua_runtime_clock_resume(runtime);
+            if (result != GUA_CLOCK_OK) {
+                const char* error = result == GUA_CLOCK_ERROR_NOT_INSTALLED ? "not_installed" :
+                    result == GUA_CLOCK_ERROR_INVALID_STATE ? "invalid_state" :
+                    result == GUA_CLOCK_ERROR_EXECUTION_LIMIT ? "execution_limit" : "invalid_duration";
+                return gua::ws::CommandResult { false, {}, error };
+            }
+            const int size = gua_runtime_clock_copy_status_json(runtime, nullptr, 0);
+            std::string json(static_cast<std::size_t>(size), '\0');
+            gua_runtime_clock_copy_status_json(runtime, json.data(), size);
+            json.resize(static_cast<std::size_t>(size - 1));
+            return gua::ws::CommandResult { true, std::move(json), {} };
         },
         .query_nodes_json = [runtime](const gua::ws::QuerySelector& selector) {
             gua_selector_v1_t native {

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -863,6 +863,10 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
         .get_version_json = [runtime] {
             return copy_version_json(runtime);
         },
+        .clock_supported = [runtime] {
+            const std::lock_guard lock(runtime->context_mutex);
+            return runtime->virtual_clock_enabled;
+        },
         .get_clock_json = [runtime] {
             const int size = gua_runtime_clock_copy_status_json(runtime, nullptr, 0);
             std::string json(static_cast<std::size_t>(size), '\0');

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -217,9 +217,10 @@ void invalidate_screenshot_requests(gua_runtime_t* runtime)
         result = stale_screenshot_json(request_id, status);
 }
 
-std::string reset_report_json(gua_runtime_t* runtime, unsigned long long expected_epoch, unsigned int flags, bool strict)
+std::string reset_report_json(gua_runtime_t* runtime, unsigned long long expected_epoch, unsigned int flags,
+    unsigned int flags_version, bool strict)
 {
-    gua_reset_options_t options { sizeof(gua_reset_options_t), flags, strict ? 1 : 0, expected_epoch };
+    gua_reset_options_t options { sizeof(gua_reset_options_t), flags, strict ? 1 : 0, expected_epoch, flags_version };
     gua_reset_report_t report { sizeof(gua_reset_report_t) };
     const std::lock_guard lock(runtime->context_mutex);
     const int result = gua_reset_context(runtime->context, &options, &report);
@@ -983,8 +984,8 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
             return json;
         },
         .get_context_status_json = [runtime] { return status_json(runtime); },
-        .reset_context_json = [runtime](unsigned long long expected_epoch, unsigned int flags, bool strict) {
-            return reset_report_json(runtime, expected_epoch, flags, strict);
+        .reset_context_json = [runtime](unsigned long long expected_epoch, unsigned int flags, unsigned int flags_version, bool strict) {
+            return reset_report_json(runtime, expected_epoch, flags, flags_version, strict);
         },
         .click_node = [runtime](std::string_view node_id) {
             const std::string id(node_id);

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -34,6 +34,7 @@ struct gua_runtime_t {
     std::string diagnostics_json;
     std::string godot_plugin_version;
     std::map<std::string, std::string> adapter_versions;
+    bool virtual_clock_enabled = false;
     uint64_t next_screenshot_request_id = 1;
     std::deque<gua_screenshot_request_t> screenshot_requests;
     std::unordered_map<uint64_t, ScreenshotBatch> screenshot_batches;
@@ -56,6 +57,14 @@ int copy_json_string(const std::string& json, char* out_json, int out_json_size)
         std::snprintf(out_json, static_cast<std::size_t>(out_json_size), "%s", json.c_str());
     }
     return required_size;
+}
+
+void filter_runtime_capabilities(std::string& json, bool virtual_clock_enabled)
+{
+    if (virtual_clock_enabled) return;
+    const std::string capability = ",\"virtual_clock_v1\"";
+    const auto position = json.find(capability);
+    if (position != std::string::npos) json.erase(position, capability.size());
 }
 
 std::string copy_ui_tree_json(gua_runtime_t* runtime)
@@ -88,6 +97,7 @@ std::string copy_diagnostics_json(gua_runtime_t* runtime)
 {
     const std::lock_guard lock(runtime->context_mutex);
     std::string json = gua_get_diagnostics_json(runtime->context);
+    filter_runtime_capabilities(json, runtime->virtual_clock_enabled);
     if (!runtime->godot_plugin_version.empty()) {
         const std::string marker = "\"godotPluginVersion\":null";
         const auto position = json.find(marker);
@@ -126,6 +136,7 @@ std::string copy_version_json(gua_runtime_t* runtime)
     char buffer[2048] {};
     gua_copy_version_json(buffer, static_cast<int>(sizeof(buffer)));
     std::string json = buffer;
+    filter_runtime_capabilities(json, runtime->virtual_clock_enabled);
     if (!runtime->godot_plugin_version.empty()) {
         const std::string marker = "\"godotPluginVersion\":null";
         const auto position = json.find(marker);
@@ -608,6 +619,13 @@ extern "C" void gua_runtime_set_adapter_version(gua_runtime_t* runtime, const ch
     const std::lock_guard lock(runtime->context_mutex);
     if (version == nullptr || version[0] == '\0') runtime->adapter_versions.erase(adapter);
     else runtime->adapter_versions[adapter] = version;
+}
+
+extern "C" void gua_runtime_set_virtual_clock_enabled(gua_runtime_t* runtime, int enabled)
+{
+    if (!valid_runtime(runtime)) return;
+    const std::lock_guard lock(runtime->context_mutex);
+    runtime->virtual_clock_enabled = enabled != 0;
 }
 
 extern "C" int gua_runtime_get_node_state(gua_runtime_t* runtime, const char* node_id, gua_node_state_t* out_state)

--- a/native/gua-runtime/tests/screenshot_request_tests.cpp
+++ b/native/gua-runtime/tests/screenshot_request_tests.cpp
@@ -52,6 +52,17 @@ int main()
     gua_runtime_begin_frame(runtime, "title");
     gua_runtime_end_frame(runtime);
 
+    assert(gua_runtime_clock_install(runtime, 0.0, 10.0) == GUA_CLOCK_OK);
+    assert(gua_runtime_clock_pause(runtime) == GUA_CLOCK_OK);
+    assert(gua_runtime_clock_run_for(runtime, 25.0, 0.0) == GUA_CLOCK_OK);
+    gua_clock_step_t clock_step { sizeof(gua_clock_step_t) };
+    assert(gua_runtime_clock_consume_step(runtime, &clock_step) == 1 && clock_step.delta_ms == 10.0);
+    clock_step = { sizeof(gua_clock_step_t) };
+    assert(gua_runtime_clock_consume_step(runtime, &clock_step) == 1 && clock_step.delta_ms == 10.0);
+    clock_step = { sizeof(gua_clock_step_t) };
+    assert(gua_runtime_clock_consume_step(runtime, &clock_step) == 1 && clock_step.delta_ms == 5.0 && clock_step.final_step == 1);
+    assert(gua_runtime_clock_run_for(runtime, 1.0, -1.0) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
+
     uint64_t first = 0;
     uint64_t second = 0;
     assert(gua_runtime_enqueue_screenshot_request(runtime, 1, &first) == 1);

--- a/native/gua-runtime/tests/screenshot_request_tests.cpp
+++ b/native/gua-runtime/tests/screenshot_request_tests.cpp
@@ -139,7 +139,7 @@ int main()
     gua_runtime_end_frame(runtime);
     assert(gua_runtime_consume_screenshot_request(runtime, &request) == 1);
     assert(request.session_epoch == 1);
-    gua_reset_options_t reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 1 };
+    gua_reset_options_t reset { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT_V2, 0, 1, GUA_RESET_FLAGS_VERSION_CURRENT };
     gua_reset_report_t reset_report { sizeof(gua_reset_report_t) };
     assert(gua_runtime_reset_context(runtime, &reset, &reset_report) == 1);
     assert(reset_report.result == GUA_RESET_SUCCEEDED);
@@ -159,7 +159,7 @@ int main()
     assert(gua_runtime_consume_screenshot_request(runtime, &request) == 1);
     assert(gua_runtime_complete_screenshot_request(
         runtime, request.request_id, GUA_SCREENSHOT_AVAILABLE, "data:image/png;base64,U0VDUkVU", 1, 1) == 1);
-    reset = { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 2 };
+    reset = { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT_V2, 0, 2, GUA_RESET_FLAGS_VERSION_CURRENT };
     reset_report = { sizeof(gua_reset_report_t) };
     assert(gua_runtime_reset_context(runtime, &reset, &reset_report) == GUA_RESET_SUCCEEDED);
     const std::string reset_completed_json = poll(runtime, completed_before_reset);
@@ -200,7 +200,7 @@ int main()
     });
     std::thread context_resetter([runtime] {
         for (int index = 0; index < 2'000; ++index) {
-            const gua_reset_options_t options { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT, 0, 0 };
+            const gua_reset_options_t options { sizeof(gua_reset_options_t), GUA_RESET_DEFAULT_V2, 0, 0, GUA_RESET_FLAGS_VERSION_CURRENT };
             gua_reset_report_t report { sizeof(gua_reset_report_t) };
             assert(gua_runtime_reset_context(runtime, &options, &report) == GUA_RESET_SUCCEEDED);
         }

--- a/native/gua-runtime/tests/screenshot_request_tests.cpp
+++ b/native/gua-runtime/tests/screenshot_request_tests.cpp
@@ -57,7 +57,8 @@ int main()
 
     assert(gua_runtime_clock_install(runtime, 0.0, 10.0) == GUA_CLOCK_OK);
     assert(gua_runtime_clock_pause(runtime) == GUA_CLOCK_OK);
-    assert(gua_runtime_clock_run_for(runtime, 25.0, 0.0) == GUA_CLOCK_OK);
+    assert(gua_runtime_clock_run_for(runtime, 25.0, 0.0) == GUA_CLOCK_ERROR_INVALID_ARGUMENT);
+    assert(gua_runtime_clock_run_for(runtime, 25.0, 10.0) == GUA_CLOCK_OK);
     gua_clock_step_t clock_step { sizeof(gua_clock_step_t) };
     assert(gua_runtime_clock_consume_step(runtime, &clock_step) == 1 && clock_step.delta_ms == 10.0);
     clock_step = { sizeof(gua_clock_step_t) };

--- a/native/gua-runtime/tests/screenshot_request_tests.cpp
+++ b/native/gua-runtime/tests/screenshot_request_tests.cpp
@@ -30,6 +30,8 @@ int main()
 {
     gua_runtime_t* runtime = gua_runtime_create();
     assert(runtime != nullptr);
+    assert(version(runtime).find("virtual_clock_v1") == std::string::npos);
+    gua_runtime_set_virtual_clock_enabled(runtime, 1);
     gua_runtime_set_adapter_version(runtime, "unity", "0.5.0-preview.3");
     gua_runtime_set_adapter_version(runtime, "Unity", "invalid");
     gua_runtime_set_adapter_version(runtime, "ui-toolkit", "invalid");
@@ -39,6 +41,7 @@ int main()
     assert(version_json.find("\"godotPluginVersion\":\"0.4.0\"") != std::string::npos);
     assert(version_json.find("Unity") == std::string::npos);
     assert(version_json.find("ui-toolkit") == std::string::npos);
+    assert(version_json.find("virtual_clock_v1") != std::string::npos);
     std::thread version_writer([runtime] {
         for (int index = 0; index < 1000; ++index)
             gua_runtime_set_adapter_version(runtime, "unity", index % 2 == 0 ? "0.5.0-preview.3" : "0.5.0-preview.4");

--- a/native/gua-runtime/tests/screenshot_request_tests.cpp
+++ b/native/gua-runtime/tests/screenshot_request_tests.cpp
@@ -24,6 +24,14 @@ std::string version(gua_runtime_t* runtime)
     return buffer.data();
 }
 
+std::string diagnostics(gua_runtime_t* runtime)
+{
+    const int size = gua_runtime_copy_diagnostics_json(runtime, nullptr, 0);
+    std::vector<char> buffer(static_cast<std::size_t>(size));
+    assert(gua_runtime_copy_diagnostics_json(runtime, buffer.data(), size) == size);
+    return buffer.data();
+}
+
 } // namespace
 
 int main()
@@ -31,6 +39,15 @@ int main()
     gua_runtime_t* runtime = gua_runtime_create();
     assert(runtime != nullptr);
     assert(version(runtime).find("virtual_clock_v1") == std::string::npos);
+    assert(gua_runtime_set_diagnostics_environment_json(
+        runtime, "{\"tags\":[\"test\",\"virtual_clock_v1\"]}") == 1);
+    const std::string diagnostics_json = diagnostics(runtime);
+    assert(diagnostics_json.find("\"tags\":[\"test\",\"virtual_clock_v1\"]") != std::string::npos);
+    const auto version_position = diagnostics_json.find("\"version\":");
+    const auto ui_tree_position = diagnostics_json.find(",\"uiTree\":", version_position);
+    assert(version_position != std::string::npos && ui_tree_position != std::string::npos);
+    assert(diagnostics_json.substr(version_position, ui_tree_position - version_position)
+        .find("virtual_clock_v1") == std::string::npos);
     gua_runtime_set_virtual_clock_enabled(runtime, 1);
     gua_runtime_set_adapter_version(runtime, "unity", "0.5.0-preview.3");
     gua_runtime_set_adapter_version(runtime, "Unity", "invalid");

--- a/native/gua-testing/include/gua/testing.hpp
+++ b/native/gua-testing/include/gua/testing.hpp
@@ -542,7 +542,13 @@ public:
     { check(gua_clock_install(context_, initial.count(), step.count())); }
     void pause() const { check(gua_clock_pause(context_)); }
     void run_for(std::chrono::duration<double, std::milli> duration,
-        std::chrono::duration<double, std::milli> step = std::chrono::duration<double, std::milli>(1000.0 / 60.0),
+        const std::function<void(std::chrono::duration<double, std::milli>)>& on_tick = {}) const
+    {
+        const auto current = status();
+        run_for(duration, std::chrono::duration<double, std::milli>(current.default_step_ms), on_tick);
+    }
+    void run_for(std::chrono::duration<double, std::milli> duration,
+        std::chrono::duration<double, std::milli> step,
         const std::function<void(std::chrono::duration<double, std::milli>)>& on_tick = {}) const
     {
         check(gua_clock_run_for(context_, duration.count(), step.count()));

--- a/native/gua-testing/include/gua/testing.hpp
+++ b/native/gua-testing/include/gua/testing.hpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <cctype>
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <filesystem>
 #include <fstream>
@@ -554,11 +555,16 @@ public:
         const std::function<void(std::chrono::duration<double, std::milli>)>& on_tick = {}) const
     {
         check(gua_clock_run_for(context_, duration.count(), step.count()));
+        std::exception_ptr callback_error;
         gua_clock_step_t value { sizeof(gua_clock_step_t) };
         while (gua_clock_consume_step(context_, &value) != 0) {
-            if (on_tick) on_tick(std::chrono::duration<double, std::milli>(value.delta_ms));
+            if (on_tick && callback_error == nullptr) {
+                try { on_tick(std::chrono::duration<double, std::milli>(value.delta_ms)); }
+                catch (...) { callback_error = std::current_exception(); }
+            }
             value = gua_clock_step_t { sizeof(gua_clock_step_t) };
         }
+        if (callback_error != nullptr) std::rethrow_exception(callback_error);
     }
     void resume() const { check(gua_clock_resume(context_)); }
     [[nodiscard]] gua_clock_status_t status() const

--- a/native/gua-testing/include/gua/testing.hpp
+++ b/native/gua-testing/include/gua/testing.hpp
@@ -534,4 +534,30 @@ private:
     gua_context_t* context_;
 };
 
+class Clock {
+public:
+    explicit Clock(gua_context_t* context) : context_(context) { if (!context_) throw std::invalid_argument("Gua Clock requires a context"); }
+    void install(std::chrono::duration<double, std::milli> initial = std::chrono::milliseconds(0),
+        std::chrono::duration<double, std::milli> step = std::chrono::duration<double, std::milli>(1000.0 / 60.0)) const
+    { check(gua_clock_install(context_, initial.count(), step.count())); }
+    void pause() const { check(gua_clock_pause(context_)); }
+    void run_for(std::chrono::duration<double, std::milli> duration,
+        std::chrono::duration<double, std::milli> step = std::chrono::duration<double, std::milli>(1000.0 / 60.0),
+        const std::function<void(std::chrono::duration<double, std::milli>)>& on_tick = {}) const
+    {
+        check(gua_clock_run_for(context_, duration.count(), step.count()));
+        gua_clock_step_t value { sizeof(gua_clock_step_t) };
+        while (gua_clock_consume_step(context_, &value) != 0) {
+            if (on_tick) on_tick(std::chrono::duration<double, std::milli>(value.delta_ms));
+            value = gua_clock_step_t { sizeof(gua_clock_step_t) };
+        }
+    }
+    void resume() const { check(gua_clock_resume(context_)); }
+    [[nodiscard]] gua_clock_status_t status() const
+    { gua_clock_status_t value { sizeof(gua_clock_status_t) }; if (!gua_clock_get_status(context_, &value)) throw std::runtime_error("Failed to inspect Gua clock"); return value; }
+private:
+    static void check(int result) { if (result != GUA_CLOCK_OK) throw std::runtime_error("Gua clock operation failed: " + std::to_string(result)); }
+    gua_context_t* context_;
+};
+
 } // namespace gua::testing

--- a/native/gua-testing/include/gua/testing.hpp
+++ b/native/gua-testing/include/gua/testing.hpp
@@ -519,10 +519,12 @@ public:
             ". Payload values are redacted.");
     }
 
-    [[nodiscard]] gua_reset_report_t reset(bool strict = false, std::uint32_t flags = GUA_RESET_DEFAULT) const
+    [[nodiscard]] gua_reset_report_t reset(bool strict = false, std::uint32_t flags = GUA_RESET_DEFAULT_V2) const
     {
         const auto status = inspect();
-        const gua_reset_options_t options { sizeof(gua_reset_options_t), flags, strict ? 1 : 0, status.session_epoch };
+        const gua_reset_options_t options {
+            sizeof(gua_reset_options_t), flags, strict ? 1 : 0, status.session_epoch, GUA_RESET_FLAGS_VERSION_CURRENT
+        };
         gua_reset_report_t report { sizeof(gua_reset_report_t) };
         const int result = gua_reset_context(context_, &options, &report);
         if (result == GUA_RESET_ERROR_DIRTY) throw std::runtime_error("Strict Gua reset rejected dirty state without discarding it");

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -48,6 +48,7 @@ struct BridgeHandlers {
     std::function<CommandResult(unsigned long long after_frame_sequence, unsigned int timeout_ms)> capture_screenshot;
     std::function<std::string()> get_diagnostics_json;
     std::function<std::string()> get_version_json;
+    std::function<bool()> clock_supported;
     std::function<std::string()> get_clock_json;
     std::function<CommandResult(std::string_view command, double value_ms, double step_ms, bool step_ms_present)> control_clock;
     std::function<std::string(const QuerySelector& selector)> query_nodes_json;

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -53,7 +53,7 @@ struct BridgeHandlers {
     std::function<CommandResult(std::string_view command, double value_ms, double step_ms, bool step_ms_present)> control_clock;
     std::function<std::string(const QuerySelector& selector)> query_nodes_json;
     std::function<std::string()> get_context_status_json;
-    std::function<std::string(unsigned long long expected_epoch, unsigned int flags, bool strict)> reset_context_json;
+    std::function<std::string(unsigned long long expected_epoch, unsigned int flags, unsigned int flags_version, bool strict)> reset_context_json;
     std::function<bool(std::string_view node_id)> click_node;
     std::function<bool(std::string_view node_id)> focus_node;
     std::function<bool(std::string_view key)> press_key;

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -49,7 +49,7 @@ struct BridgeHandlers {
     std::function<std::string()> get_diagnostics_json;
     std::function<std::string()> get_version_json;
     std::function<std::string()> get_clock_json;
-    std::function<CommandResult(std::string_view command, double value_ms, double step_ms)> control_clock;
+    std::function<CommandResult(std::string_view command, double value_ms, double step_ms, bool step_ms_present)> control_clock;
     std::function<std::string(const QuerySelector& selector)> query_nodes_json;
     std::function<std::string()> get_context_status_json;
     std::function<std::string(unsigned long long expected_epoch, unsigned int flags, bool strict)> reset_context_json;

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -48,6 +48,8 @@ struct BridgeHandlers {
     std::function<CommandResult(unsigned long long after_frame_sequence, unsigned int timeout_ms)> capture_screenshot;
     std::function<std::string()> get_diagnostics_json;
     std::function<std::string()> get_version_json;
+    std::function<std::string()> get_clock_json;
+    std::function<CommandResult(std::string_view command, double value_ms, double step_ms)> control_clock;
     std::function<std::string(const QuerySelector& selector)> query_nodes_json;
     std::function<std::string()> get_context_status_json;
     std::function<std::string(unsigned long long expected_epoch, unsigned int flags, bool strict)> reset_context_json;

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -42,8 +42,11 @@ struct Command {
     unsigned long long expected_session_epoch = 0;
     unsigned long long after_frame_sequence = 0;
     unsigned int timeout_ms = 10000;
-    unsigned int reset_flags = 15;
+    unsigned int reset_flags = 79;
     bool strict = false;
+    double initial_time_ms = 0;
+    double duration_ms = 0;
+    double step_ms = 0;
 };
 
 struct ClientConnection {
@@ -620,8 +623,11 @@ Command parse_command(std::string_view json)
     command.expected_session_epoch = json_uint64_field(json, "expectedSessionEpoch").value_or(0);
     command.after_frame_sequence = json_uint64_field(json, "afterFrameSequence").value_or(0);
     command.timeout_ms = static_cast<unsigned int>(std::clamp(json_int_field(json, "timeoutMs").value_or(10000), 1, 300000));
-    command.reset_flags = static_cast<unsigned int>(json_int_field(json, "flags").value_or(15));
+    command.reset_flags = static_cast<unsigned int>(json_int_field(json, "flags").value_or(79));
     command.strict = json_bool_field(json, "strict");
+    command.initial_time_ms = json_number_field(json, "initialTimeMs").value_or(0);
+    command.duration_ms = json_number_field(json, "durationMs").value_or(0);
+    command.step_ms = json_number_field(json, "stepMs").value_or(0);
     return command;
 }
 
@@ -934,6 +940,19 @@ private:
                 return handlers_.get_version_json
                     ? ok_response(command.id, handlers_.get_version_json())
                     : error_response(command.id, "get_version is not supported by this bridge");
+            }
+            if (command.type == "get_clock") {
+                return handlers_.get_clock_json
+                    ? ok_response(command.id, handlers_.get_clock_json())
+                    : error_response(command.id, "unsupported");
+            }
+            if (command.type == "clock_install" || command.type == "clock_pause" ||
+                command.type == "clock_run_for" || command.type == "clock_resume") {
+                if (!handlers_.control_clock) return error_response(command.id, "unsupported");
+                const auto result = handlers_.control_clock(command.type,
+                    command.type == "clock_install" ? command.initial_time_ms : command.duration_ms,
+                    command.step_ms);
+                return result.ok ? ok_response(command.id, result.json) : error_response(command.id, result.error);
             }
             if (command.type == "query_nodes") {
                 if (!handlers_.query_nodes_json) {

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -435,21 +435,64 @@ void send_text_frame(SOCKET socket, std::string_view text)
     send_all(socket, frame.data(), frame.size());
 }
 
+std::optional<std::size_t> json_top_level_field_start(std::string_view json, std::string_view field)
+{
+    const std::size_t root = json.find_first_not_of(" \t\r\n");
+    if (root == std::string_view::npos || json[root] != '{') return std::nullopt;
+
+    int object_depth = 0;
+    int array_depth = 0;
+    bool in_string = false;
+    bool escaped = false;
+    for (std::size_t index = root; index < json.size(); ++index) {
+        const char ch = json[index];
+        if (in_string) {
+            if (escaped) escaped = false;
+            else if (ch == '\\') escaped = true;
+            else if (ch == '"') in_string = false;
+            continue;
+        }
+        if (ch == '"') {
+            std::size_t previous = index;
+            while (previous > root && (json[previous - 1U] == ' ' || json[previous - 1U] == '\t' ||
+                json[previous - 1U] == '\r' || json[previous - 1U] == '\n')) --previous;
+            const bool top_level_key = object_depth == 1 && array_depth == 0 && previous > root &&
+                (json[previous - 1U] == '{' || json[previous - 1U] == ',');
+            if (!top_level_key) {
+                in_string = true;
+                continue;
+            }
+
+            std::size_t end = index + 1U;
+            bool key_escaped = false;
+            for (; end < json.size(); ++end) {
+                if (key_escaped) key_escaped = false;
+                else if (json[end] == '\\') key_escaped = true;
+                else if (json[end] == '"') break;
+            }
+            if (end == json.size()) return std::nullopt;
+            std::size_t colon = json.find_first_not_of(" \t\r\n", end + 1U);
+            if (colon == std::string_view::npos || json[colon] != ':') return std::nullopt;
+            const bool matches = json.substr(index + 1U, end - index - 1U) == field;
+            std::size_t value = json.find_first_not_of(" \t\r\n", colon + 1U);
+            if (matches) return value == std::string_view::npos ? std::nullopt : std::optional<std::size_t>(value);
+            index = end;
+            continue;
+        }
+        if (ch == '{') ++object_depth;
+        else if (ch == '}') {
+            if (--object_depth == 0) break;
+        } else if (ch == '[') ++array_depth;
+        else if (ch == ']') --array_depth;
+    }
+    return std::nullopt;
+}
+
 std::optional<std::string> json_string_field(std::string_view json, std::string_view field)
 {
-    const std::string key = "\"" + std::string(field) + "\"";
-    const std::size_t key_position = json.find(key);
-    if (key_position == std::string_view::npos) {
-        return std::nullopt;
-    }
-    const std::size_t colon = json.find(':', key_position + key.size());
-    if (colon == std::string_view::npos) {
-        return std::nullopt;
-    }
-    std::size_t quote = colon + 1U;
-    while (quote < json.size() && json[quote] == ' ') {
-        ++quote;
-    }
+    const auto start = json_top_level_field_start(json, field);
+    if (!start.has_value()) return std::nullopt;
+    const std::size_t quote = *start;
     if (quote >= json.size() || json[quote] != '"') {
         return std::nullopt;
     }
@@ -532,20 +575,9 @@ std::optional<std::string> json_string_field(std::string_view json, std::string_
 
 std::optional<int> json_int_field(std::string_view json, std::string_view field)
 {
-    const std::string key = "\"" + std::string(field) + "\"";
-    const std::size_t key_position = json.find(key);
-    if (key_position == std::string_view::npos) {
-        return std::nullopt;
-    }
-    const std::size_t colon = json.find(':', key_position + key.size());
-    if (colon == std::string_view::npos) {
-        return std::nullopt;
-    }
-
-    std::size_t start = colon + 1U;
-    while (start < json.size() && json[start] == ' ') {
-        ++start;
-    }
+    const auto value_start = json_top_level_field_start(json, field);
+    if (!value_start.has_value()) return std::nullopt;
+    const std::size_t start = *value_start;
     std::size_t end = start;
     while (end < json.size() && json[end] >= '0' && json[end] <= '9') {
         ++end;
@@ -559,13 +591,9 @@ std::optional<int> json_int_field(std::string_view json, std::string_view field)
 
 std::optional<unsigned long long> json_uint64_field(std::string_view json, std::string_view field)
 {
-    const std::string key = "\"" + std::string(field) + "\"";
-    const std::size_t key_position = json.find(key);
-    if (key_position == std::string_view::npos) return std::nullopt;
-    const std::size_t colon = json.find(':', key_position + key.size());
-    if (colon == std::string_view::npos) return std::nullopt;
-    std::size_t start = json.find_first_not_of(" \t", colon + 1U);
-    if (start == std::string_view::npos) return std::nullopt;
+    const auto value_start = json_top_level_field_start(json, field);
+    if (!value_start.has_value()) return std::nullopt;
+    const std::size_t start = *value_start;
     std::size_t end = start;
     while (end < json.size() && std::isdigit(static_cast<unsigned char>(json[end]))) ++end;
     if (end == start) return std::nullopt;
@@ -575,13 +603,9 @@ std::optional<unsigned long long> json_uint64_field(std::string_view json, std::
 
 std::optional<double> json_number_field(std::string_view json, std::string_view field)
 {
-    const std::string key = "\"" + std::string(field) + "\"";
-    const std::size_t key_position = json.find(key);
-    if (key_position == std::string_view::npos) return std::nullopt;
-    const std::size_t colon = json.find(':', key_position + key.size());
-    if (colon == std::string_view::npos) return std::nullopt;
-    std::size_t start = json.find_first_not_of(" \t\r\n", colon + 1U);
-    if (start == std::string_view::npos) return std::nullopt;
+    const auto value_start = json_top_level_field_start(json, field);
+    if (!value_start.has_value()) return std::nullopt;
+    const std::size_t start = *value_start;
 
     std::size_t end = start;
     if (json[end] == '-') {
@@ -625,18 +649,13 @@ std::optional<double> json_number_field(std::string_view json, std::string_view 
 
 bool json_has_field(std::string_view json, std::string_view field)
 {
-    return json.find("\"" + std::string(field) + "\"") != std::string_view::npos;
+    return json_top_level_field_start(json, field).has_value();
 }
 
 bool json_bool_field(std::string_view json, std::string_view field, bool fallback = false)
 {
-    const std::string key = "\"" + std::string(field) + "\"";
-    const std::size_t key_position = json.find(key);
-    if (key_position == std::string_view::npos) return fallback;
-    const std::size_t colon = json.find(':', key_position + key.size());
-    if (colon == std::string_view::npos) return fallback;
-    const std::size_t start = json.find_first_not_of(" \t", colon + 1U);
-    return start != std::string_view::npos && json.substr(start, 4) == "true";
+    const auto start = json_top_level_field_start(json, field);
+    return start.has_value() ? json.substr(*start, 4) == "true" : fallback;
 }
 
 Command parse_command(std::string_view json)

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -949,13 +949,14 @@ private:
                     : error_response(command.id, "get_version is not supported by this bridge");
             }
             if (command.type == "get_clock") {
-                return handlers_.get_clock_json
+                return handlers_.clock_supported && handlers_.clock_supported() && handlers_.get_clock_json
                     ? ok_response(command.id, handlers_.get_clock_json())
                     : error_response(command.id, "unsupported");
             }
             if (command.type == "clock_install" || command.type == "clock_pause" ||
                 command.type == "clock_run_for" || command.type == "clock_resume") {
-                if (!handlers_.control_clock) return error_response(command.id, "unsupported");
+                if (!handlers_.clock_supported || !handlers_.clock_supported() || !handlers_.control_clock)
+                    return error_response(command.id, "unsupported");
                 const auto result = handlers_.control_clock(command.type,
                     command.type == "clock_install" ? command.initial_time_ms : command.duration_ms,
                     command.step_ms, command.step_ms_present);

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -47,6 +47,7 @@ struct Command {
     double initial_time_ms = 0;
     double duration_ms = 0;
     double step_ms = 0;
+    bool step_ms_present = false;
 };
 
 struct ClientConnection {
@@ -582,6 +583,11 @@ std::optional<double> json_number_field(std::string_view json, std::string_view 
     return std::stod(std::string(json.substr(start, end - start)));
 }
 
+bool json_has_field(std::string_view json, std::string_view field)
+{
+    return json.find("\"" + std::string(field) + "\"") != std::string_view::npos;
+}
+
 bool json_bool_field(std::string_view json, std::string_view field, bool fallback = false)
 {
     const std::string key = "\"" + std::string(field) + "\"";
@@ -628,6 +634,7 @@ Command parse_command(std::string_view json)
     command.initial_time_ms = json_number_field(json, "initialTimeMs").value_or(0);
     command.duration_ms = json_number_field(json, "durationMs").value_or(0);
     command.step_ms = json_number_field(json, "stepMs").value_or(0);
+    command.step_ms_present = json_has_field(json, "stepMs");
     return command;
 }
 
@@ -951,7 +958,7 @@ private:
                 if (!handlers_.control_clock) return error_response(command.id, "unsupported");
                 const auto result = handlers_.control_clock(command.type,
                     command.type == "clock_install" ? command.initial_time_ms : command.duration_ms,
-                    command.step_ms);
+                    command.step_ms, command.step_ms_present);
                 return result.ok ? ok_response(command.id, result.json) : error_response(command.id, result.error);
             }
             if (command.type == "query_nodes") {

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -580,11 +580,39 @@ std::optional<double> json_number_field(std::string_view json, std::string_view 
     if (key_position == std::string_view::npos) return std::nullopt;
     const std::size_t colon = json.find(':', key_position + key.size());
     if (colon == std::string_view::npos) return std::nullopt;
-    std::size_t start = json.find_first_not_of(" \t", colon + 1U);
+    std::size_t start = json.find_first_not_of(" \t\r\n", colon + 1U);
     if (start == std::string_view::npos) return std::nullopt;
+
     std::size_t end = start;
-    while (end < json.size() && (std::isdigit(static_cast<unsigned char>(json[end])) || json[end] == '-' || json[end] == '+' || json[end] == '.' || json[end] == 'e' || json[end] == 'E')) ++end;
-    if (end == start) return std::nullopt;
+    if (json[end] == '-') {
+        if (++end == json.size()) return std::nullopt;
+    }
+    if (json[end] == '0') {
+        ++end;
+        if (end < json.size() && std::isdigit(static_cast<unsigned char>(json[end]))) return std::nullopt;
+    } else if (json[end] >= '1' && json[end] <= '9') {
+        while (end < json.size() && std::isdigit(static_cast<unsigned char>(json[end]))) ++end;
+    } else {
+        return std::nullopt;
+    }
+    if (end < json.size() && json[end] == '.') {
+        ++end;
+        const std::size_t fraction_start = end;
+        while (end < json.size() && std::isdigit(static_cast<unsigned char>(json[end]))) ++end;
+        if (end == fraction_start) return std::nullopt;
+    }
+    if (end < json.size() && (json[end] == 'e' || json[end] == 'E')) {
+        ++end;
+        if (end < json.size() && (json[end] == '+' || json[end] == '-')) ++end;
+        const std::size_t exponent_start = end;
+        while (end < json.size() && std::isdigit(static_cast<unsigned char>(json[end]))) ++end;
+        if (end == exponent_start) return std::nullopt;
+    }
+    std::size_t delimiter = end;
+    while (delimiter < json.size() && (json[delimiter] == ' ' || json[delimiter] == '\t' ||
+        json[delimiter] == '\r' || json[delimiter] == '\n')) ++delimiter;
+    if (delimiter == json.size() || (json[delimiter] != ',' && json[delimiter] != '}' && json[delimiter] != ']'))
+        return std::nullopt;
     try {
         std::size_t parsed = 0;
         const std::string token(json.substr(start, end - start));

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <cstdint>
 #include <cctype>
+#include <cmath>
 #include <cstring>
 #include <future>
 #include <iostream>
@@ -552,7 +553,8 @@ std::optional<int> json_int_field(std::string_view json, std::string_view field)
     if (end == start) {
         return std::nullopt;
     }
-    return std::stoi(std::string(json.substr(start, end - start)));
+    try { return std::stoi(std::string(json.substr(start, end - start))); }
+    catch (const std::exception&) { return std::nullopt; }
 }
 
 std::optional<unsigned long long> json_uint64_field(std::string_view json, std::string_view field)
@@ -567,7 +569,8 @@ std::optional<unsigned long long> json_uint64_field(std::string_view json, std::
     std::size_t end = start;
     while (end < json.size() && std::isdigit(static_cast<unsigned char>(json[end]))) ++end;
     if (end == start) return std::nullopt;
-    return std::stoull(std::string(json.substr(start, end - start)));
+    try { return std::stoull(std::string(json.substr(start, end - start))); }
+    catch (const std::exception&) { return std::nullopt; }
 }
 
 std::optional<double> json_number_field(std::string_view json, std::string_view field)
@@ -582,7 +585,14 @@ std::optional<double> json_number_field(std::string_view json, std::string_view 
     std::size_t end = start;
     while (end < json.size() && (std::isdigit(static_cast<unsigned char>(json[end])) || json[end] == '-' || json[end] == '+' || json[end] == '.' || json[end] == 'e' || json[end] == 'E')) ++end;
     if (end == start) return std::nullopt;
-    return std::stod(std::string(json.substr(start, end - start)));
+    try {
+        std::size_t parsed = 0;
+        const std::string token(json.substr(start, end - start));
+        const double value = std::stod(token, &parsed);
+        return parsed == token.size() && std::isfinite(value) ? std::optional<double>(value) : std::nullopt;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
 }
 
 bool json_has_field(std::string_view json, std::string_view field)

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -45,7 +45,9 @@ struct Command {
     unsigned int reset_flags = 79;
     bool strict = false;
     double initial_time_ms = 0;
+    bool initial_time_ms_valid = true;
     double duration_ms = 0;
+    bool duration_ms_valid = false;
     double step_ms = 0;
     bool step_ms_present = false;
 };
@@ -631,8 +633,12 @@ Command parse_command(std::string_view json)
     command.timeout_ms = static_cast<unsigned int>(std::clamp(json_int_field(json, "timeoutMs").value_or(10000), 1, 300000));
     command.reset_flags = static_cast<unsigned int>(json_int_field(json, "flags").value_or(79));
     command.strict = json_bool_field(json, "strict");
-    command.initial_time_ms = json_number_field(json, "initialTimeMs").value_or(0);
-    command.duration_ms = json_number_field(json, "durationMs").value_or(0);
+    const auto initial_time_ms = json_number_field(json, "initialTimeMs");
+    command.initial_time_ms = initial_time_ms.value_or(0);
+    command.initial_time_ms_valid = !json_has_field(json, "initialTimeMs") || initial_time_ms.has_value();
+    const auto duration_ms = json_number_field(json, "durationMs");
+    command.duration_ms = duration_ms.value_or(0);
+    command.duration_ms_valid = duration_ms.has_value();
     command.step_ms = json_number_field(json, "stepMs").value_or(0);
     command.step_ms_present = json_has_field(json, "stepMs");
     return command;
@@ -957,6 +963,10 @@ private:
                 command.type == "clock_run_for" || command.type == "clock_resume") {
                 if (!handlers_.clock_supported || !handlers_.clock_supported() || !handlers_.control_clock)
                     return error_response(command.id, "unsupported");
+                if (command.type == "clock_install" && !command.initial_time_ms_valid)
+                    return error_response(command.id, "invalid_duration");
+                if (command.type == "clock_run_for" && !command.duration_ms_valid)
+                    return error_response(command.id, "invalid_duration");
                 const auto result = handlers_.control_clock(command.type,
                     command.type == "clock_install" ? command.initial_time_ms : command.duration_ms,
                     command.step_ms, command.step_ms_present);

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -44,6 +44,8 @@ struct Command {
     unsigned long long after_frame_sequence = 0;
     unsigned int timeout_ms = 10000;
     unsigned int reset_flags = 79;
+    unsigned int reset_flags_version = 1;
+    bool reset_flags_version_valid = true;
     bool strict = false;
     double initial_time_ms = 0;
     bool initial_time_ms_valid = true;
@@ -688,7 +690,12 @@ Command parse_command(std::string_view json)
     command.expected_session_epoch = json_uint64_field(json, "expectedSessionEpoch").value_or(0);
     command.after_frame_sequence = json_uint64_field(json, "afterFrameSequence").value_or(0);
     command.timeout_ms = static_cast<unsigned int>(std::clamp(json_int_field(json, "timeoutMs").value_or(10000), 1, 300000));
+    const bool reset_flags_present = json_has_field(json, "flags");
     command.reset_flags = static_cast<unsigned int>(json_int_field(json, "flags").value_or(79));
+    const auto reset_flags_version = json_int_field(json, "flagsVersion");
+    command.reset_flags_version = static_cast<unsigned int>(reset_flags_version.value_or(reset_flags_present ? 0 : 1));
+    command.reset_flags_version_valid = !json_has_field(json, "flagsVersion") ||
+        (reset_flags_version.has_value() && *reset_flags_version == 1);
     command.strict = json_bool_field(json, "strict");
     const auto initial_time_ms = json_number_field(json, "initialTimeMs");
     command.initial_time_ms = initial_time_ms.value_or(0);
@@ -1043,8 +1050,9 @@ private:
             if (command.type == "reset_context") {
                 if (!handlers_.reset_context_json) return error_response(command.id, "reset_context is not supported by this bridge");
                 if (command.expected_session_epoch == 0) return error_response(command.id, "reset_context requires expectedSessionEpoch");
+                if (!command.reset_flags_version_valid) return error_response(command.id, "reset_context requires flagsVersion 1 when supplied");
                 return ok_response(command.id, handlers_.reset_context_json(
-                    command.expected_session_epoch, command.reset_flags, command.strict));
+                    command.expected_session_epoch, command.reset_flags, command.reset_flags_version, command.strict));
             }
             if (command.type == "poll_events") {
                 return handlers_.poll_action_event_json

--- a/native/gua-ws-bridge/src/ws_bridge_win32.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge_win32.cpp
@@ -587,6 +587,11 @@ std::optional<int> json_int_field(std::string_view json, std::string_view field)
     if (end == start) {
         return std::nullopt;
     }
+    std::size_t delimiter = end;
+    while (delimiter < json.size() && (json[delimiter] == ' ' || json[delimiter] == '\t' ||
+        json[delimiter] == '\r' || json[delimiter] == '\n')) ++delimiter;
+    if (delimiter == json.size() || (json[delimiter] != ',' && json[delimiter] != '}' && json[delimiter] != ']'))
+        return std::nullopt;
     try { return std::stoi(std::string(json.substr(start, end - start))); }
     catch (const std::exception&) { return std::nullopt; }
 }
@@ -599,6 +604,11 @@ std::optional<unsigned long long> json_uint64_field(std::string_view json, std::
     std::size_t end = start;
     while (end < json.size() && std::isdigit(static_cast<unsigned char>(json[end]))) ++end;
     if (end == start) return std::nullopt;
+    std::size_t delimiter = end;
+    while (delimiter < json.size() && (json[delimiter] == ' ' || json[delimiter] == '\t' ||
+        json[delimiter] == '\r' || json[delimiter] == '\n')) ++delimiter;
+    if (delimiter == json.size() || (json[delimiter] != ',' && json[delimiter] != '}' && json[delimiter] != ']'))
+        return std::nullopt;
     try { return std::stoull(std::string(json.substr(start, end - start))); }
     catch (const std::exception&) { return std::nullopt; }
 }

--- a/packages/bridge-ws/package.json
+++ b/packages/bridge-ws/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "dev": "bun run src/index.ts",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "bun test test"
   },
   "dependencies": {
     "@gua/inspector": "workspace:*"

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -69,7 +69,7 @@ function ok(id: number, result: GuaInspectorResult): GuaInspectorResponse {
   return { id, ok: true, result };
 }
 
-class DemoRuntime {
+export class DemoRuntime {
   private clock: GuaClockStatus = { schemaVersion: 1, installed: false, state: "running", nowMs: 0, defaultStepMs: 1000 / 60, pendingMs: 0, generation: 0, completedOperationSequence: 0 };
   private nextClockOperationSequence = 1;
   private screen: "title" | "loading" = "title";
@@ -123,7 +123,7 @@ class DemoRuntime {
     };
   }
   getClock() { return this.clock; }
-  installClock(initial = 0, step = 1000 / 60) { if (step <= 0) throw new Error("invalid_duration"); this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 }; return this.clock; }
+  installClock(initial = 0, step = 1000 / 60) { if (this.clock.installed) throw new Error("invalid_state"); if (step <= 0) throw new Error("invalid_duration"); this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 }; return this.clock; }
   pauseClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "paused" }; return this.clock; }
   runClockFor(duration: number, step?: number) {
     if (this.clock.state !== "paused") throw new Error("invalid_state");
@@ -234,31 +234,33 @@ function node(
 
 const runtime = new DemoRuntime();
 
-const server = Bun.serve({
-  port,
-  fetch(request, server) {
-    if (server.upgrade(request)) {
-      return undefined;
-    }
+if (import.meta.main) {
+  const server = Bun.serve({
+    port,
+    fetch(request, server) {
+      if (server.upgrade(request)) {
+        return undefined;
+      }
 
-    return Response.json({
-      name: "Gua WebSocket bridge",
-      websocket: `ws://127.0.0.1:${port}`,
-      commands: ["get_ui_tree", "get_logs", "get_screenshot", "click_node", "focus_node", "press_key"],
-    });
-  },
-  websocket: {
-    open() {
-      runtime.log("info", "Inspector connected.");
+      return Response.json({
+        name: "Gua WebSocket bridge",
+        websocket: `ws://127.0.0.1:${port}`,
+        commands: ["get_ui_tree", "get_logs", "get_screenshot", "click_node", "focus_node", "press_key"],
+      });
     },
-    message(socket, message) {
-      const response = handleMessage(message);
-      socket.send(JSON.stringify(response));
+    websocket: {
+      open() {
+        runtime.log("info", "Inspector connected.");
+      },
+      message(socket, message) {
+        const response = handleMessage(message);
+        socket.send(JSON.stringify(response));
+      },
+      close() {
+        runtime.log("info", "Inspector disconnected.");
+      },
     },
-    close() {
-      runtime.log("info", "Inspector disconnected.");
-    },
-  },
-});
+  });
 
-console.log(`Gua WebSocket bridge listening on ws://127.0.0.1:${server.port}`);
+  console.log(`Gua WebSocket bridge listening on ws://127.0.0.1:${server.port}`);
+}

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -145,6 +145,7 @@ export class DemoRuntime {
     const emittedStep = Math.min(duration, selectedStep);
     if (!Number.isFinite(duration) || duration < 0 || !Number.isFinite(nextTime) || duration > 0 && nextTime <= this.clock.nowMs ||
         !Number.isFinite(selectedStep) || selectedStep <= 0 ||
+        !Number.isFinite(this.clock.nowMs + selectedStep) || this.clock.nowMs + selectedStep <= this.clock.nowMs ||
         duration > 0 && (this.clock.nowMs + emittedStep <= this.clock.nowMs || nextTime - emittedStep >= nextTime))
       throw new Error("invalid_duration");
     const operationSequence = this.nextClockOperationSequence++;

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -123,12 +123,19 @@ export class DemoRuntime {
     };
   }
   getClock() { return this.clock; }
-  installClock(initial = 0, step = 1000 / 60) { if (this.clock.installed) throw new Error("invalid_state"); if (!Number.isFinite(initial) || initial < 0 || !Number.isFinite(step) || step <= 0) throw new Error("invalid_duration"); this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 }; return this.clock; }
+  installClock(initial = 0, step = 1000 / 60) {
+    if (this.clock.installed) throw new Error("invalid_state");
+    const nextTime = initial + step;
+    if (!Number.isFinite(initial) || initial < 0 || !Number.isFinite(step) || step <= 0 ||
+        !Number.isFinite(nextTime) || nextTime <= initial) throw new Error("invalid_duration");
+    this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 };
+    return this.clock;
+  }
   pauseClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "paused" }; return this.clock; }
   runClockFor(duration: number, step?: number) {
     if (this.clock.state !== "paused") throw new Error("invalid_state");
     const nextTime = this.clock.nowMs + duration;
-    if (!Number.isFinite(duration) || duration < 0 || !Number.isFinite(nextTime) ||
+    if (!Number.isFinite(duration) || duration < 0 || !Number.isFinite(nextTime) || duration > 0 && nextTime <= this.clock.nowMs ||
         step !== undefined && (!Number.isFinite(step) || step <= 0)) throw new Error("invalid_duration");
     const operationSequence = this.nextClockOperationSequence++;
     this.clock = { ...this.clock, nowMs: nextTime };

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -141,8 +141,12 @@ export class DemoRuntime {
   runClockFor(duration: number, step?: number) {
     if (this.clock.state !== "paused") throw new Error("invalid_state");
     const nextTime = this.clock.nowMs + duration;
+    const selectedStep = step ?? this.clock.defaultStepMs;
+    const emittedStep = Math.min(duration, selectedStep);
     if (!Number.isFinite(duration) || duration < 0 || !Number.isFinite(nextTime) || duration > 0 && nextTime <= this.clock.nowMs ||
-        step !== undefined && (!Number.isFinite(step) || step <= 0)) throw new Error("invalid_duration");
+        !Number.isFinite(selectedStep) || selectedStep <= 0 ||
+        duration > 0 && (this.clock.nowMs + emittedStep <= this.clock.nowMs || nextTime - emittedStep >= nextTime))
+      throw new Error("invalid_duration");
     const operationSequence = this.nextClockOperationSequence++;
     this.clock = { ...this.clock, nowMs: nextTime };
     const result = { ...this.clock, operationSequence, completionSessionEpoch: 1, completionAfterFrameSequence: this.frameSequence };

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -70,7 +70,8 @@ function ok(id: number, result: GuaInspectorResult): GuaInspectorResponse {
 }
 
 class DemoRuntime {
-  private clock: GuaClockStatus = { schemaVersion: 1, installed: false, state: "running", nowMs: 0, defaultStepMs: 1000 / 60, pendingMs: 0, generation: 0 };
+  private clock: GuaClockStatus = { schemaVersion: 1, installed: false, state: "running", nowMs: 0, defaultStepMs: 1000 / 60, pendingMs: 0, generation: 0, completedOperationSequence: 0 };
+  private nextClockOperationSequence = 1;
   private screen: "title" | "loading" = "title";
   private focusedNodeId = "start";
   private frameSequence = 1;
@@ -127,9 +128,14 @@ class DemoRuntime {
   runClockFor(duration: number, step?: number) {
     if (this.clock.state !== "paused") throw new Error("invalid_state");
     if (step !== undefined && step <= 0) throw new Error("invalid_duration");
+    const operationSequence = this.nextClockOperationSequence++;
     this.clock = { ...this.clock, nowMs: this.clock.nowMs + duration };
-    const result = { ...this.clock, completionSessionEpoch: 1, completionAfterFrameSequence: this.frameSequence };
-    setTimeout(() => { this.frameSequence += 1; this.revision += 1; }, 0);
+    const result = { ...this.clock, operationSequence, completionSessionEpoch: 1, completionAfterFrameSequence: this.frameSequence };
+    setTimeout(() => {
+      this.clock = { ...this.clock, completedOperationSequence: operationSequence };
+      this.frameSequence += 1;
+      this.revision += 1;
+    }, 0);
     return result;
   }
   resumeClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "running" }; return this.clock; }

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -122,13 +122,15 @@ class DemoRuntime {
     };
   }
   getClock() { return this.clock; }
-  installClock(initial = 0, step = 1000 / 60) { this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 }; return this.clock; }
+  installClock(initial = 0, step = 1000 / 60) { if (step <= 0) throw new Error("invalid_duration"); this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 }; return this.clock; }
   pauseClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "paused" }; return this.clock; }
   runClockFor(duration: number, step?: number) {
     if (this.clock.state !== "paused") throw new Error("invalid_state");
+    if (step !== undefined && step <= 0) throw new Error("invalid_duration");
     this.clock = { ...this.clock, nowMs: this.clock.nowMs + duration, defaultStepMs: step ?? this.clock.defaultStepMs };
+    const result = { ...this.clock, completionSessionEpoch: 1, completionAfterFrameSequence: this.frameSequence };
     setTimeout(() => { this.frameSequence += 1; this.revision += 1; }, 0);
-    return this.clock;
+    return result;
   }
   resumeClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "running" }; return this.clock; }
 

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -136,7 +136,6 @@ export class DemoRuntime {
     setTimeout(() => {
       this.clock = { ...this.clock, completedOperationSequence: operationSequence };
       this.frameSequence += 1;
-      this.revision += 1;
     }, 0);
     return result;
   }

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -5,13 +5,14 @@ import type {
   GuaScreenshot,
   GuaUiTree,
   GuaClockStatus,
+  GuaContextStatus,
 } from "@gua/inspector/core";
 
 const defaultPort = 8765;
 const port = Number.parseInt(Bun.env.GUA_BRIDGE_PORT ?? Bun.argv[2] ?? `${defaultPort}`, 10);
-type GuaInspectorResult = GuaUiTree | GuaLogEntry[] | GuaScreenshot | GuaClockStatus | null;
+type GuaInspectorResult = GuaUiTree | GuaLogEntry[] | GuaScreenshot | GuaClockStatus | GuaContextStatus | null;
 
-function handleMessage(message: string | Buffer): GuaInspectorResponse {
+export function handleMessage(message: string | Buffer, target: DemoRuntime = runtime): GuaInspectorResponse {
   if (typeof message !== "string") {
     return { id: 0, ok: false, error: "Expected a JSON text message." };
   }
@@ -26,38 +27,39 @@ function handleMessage(message: string | Buffer): GuaInspectorResponse {
   try {
     switch (command.type) {
       case "get_ui_tree":
-        return ok(command.id, runtime.getUiTree());
+        return ok(command.id, target.getUiTree());
       case "get_logs":
-        return ok(command.id, runtime.getLogs());
+        return ok(command.id, target.getLogs());
       case "get_screenshot":
-        return ok(command.id, runtime.getScreenshot());
-      case "get_clock": return ok(command.id, runtime.getClock());
-      case "clock_install": return ok(command.id, runtime.installClock(command.initialTimeMs, command.stepMs));
-      case "clock_pause": return ok(command.id, runtime.pauseClock());
-      case "clock_run_for": return ok(command.id, runtime.runClockFor(command.durationMs, command.stepMs));
-      case "clock_resume": return ok(command.id, runtime.resumeClock());
+        return ok(command.id, target.getScreenshot());
+      case "get_context_status": return ok(command.id, target.getContextStatus());
+      case "get_clock": return ok(command.id, target.getClock());
+      case "clock_install": return ok(command.id, target.installClock(command.initialTimeMs, command.stepMs));
+      case "clock_pause": return ok(command.id, target.pauseClock());
+      case "clock_run_for": return ok(command.id, target.runClockFor(command.durationMs, command.stepMs));
+      case "clock_resume": return ok(command.id, target.resumeClock());
       case "poll_events":
         return ok(command.id, null);
       case "click_node":
-        runtime.clickNode(command.nodeId);
+        target.clickNode(command.nodeId);
         return ok(command.id, null);
       case "focus_node":
-        runtime.focusNode(command.nodeId);
+        target.focusNode(command.nodeId);
         return ok(command.id, null);
       case "press_key":
-        runtime.pressKey(command.key);
+        target.pressKey(command.key);
         return ok(command.id, null);
       case "set_value":
-        runtime.log("info", `set_value(${command.nodeId})`);
+        target.log("info", `set_value(${command.nodeId})`);
         return ok(command.id, null);
       case "set_checked":
-        runtime.log("info", `set_checked(${command.nodeId}, ${command.checked})`);
+        target.log("info", `set_checked(${command.nodeId}, ${command.checked})`);
         return ok(command.id, null);
       case "select":
-        runtime.log("info", `select(${command.nodeId}, ${command.value})`);
+        target.log("info", `select(${command.nodeId}, ${command.value})`);
         return ok(command.id, null);
       case "scroll":
-        runtime.log("info", `scroll(${command.nodeId}, ${command.deltaX}, ${command.deltaY})`);
+        target.log("info", `scroll(${command.nodeId}, ${command.deltaX}, ${command.deltaY})`);
         return ok(command.id, null);
     }
   } catch (error) {
@@ -124,6 +126,23 @@ export class DemoRuntime {
       dataUri: `data:image/svg+xml,${encodeURIComponent(this.renderScreenshotSvg())}`,
       width: 1280,
       height: 720,
+    };
+  }
+  getContextStatus(): GuaContextStatus {
+    return {
+      sessionEpoch: 1,
+      frameSequence: this.frameSequence,
+      revision: this.revision,
+      nodeCount: this.getUiTree().nodes.length,
+      pendingRequestCount: 0,
+      inFlightRequestCount: 0,
+      unconsumedEventCount: 0,
+      logCount: this.logs.length,
+      hasScreenshot: true,
+      firstPendingAction: 0,
+      firstPendingNodeId: "",
+      firstEventAction: 0,
+      firstEventNodeId: "",
     };
   }
   getClock() { this.advanceRunningClock(); return this.clock; }

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -72,6 +72,8 @@ function ok(id: number, result: GuaInspectorResult): GuaInspectorResponse {
 export class DemoRuntime {
   private clock: GuaClockStatus = { schemaVersion: 1, installed: false, state: "running", nowMs: 0, defaultStepMs: 1000 / 60, pendingMs: 0, generation: 0, completedOperationSequence: 0 };
   private nextClockOperationSequence = 1;
+  private runningClockStartMs = 0;
+  private runningClockStartTimeMs = 0;
   private screen: "title" | "loading" = "title";
   private focusedNodeId = "start";
   private frameSequence = 1;
@@ -80,6 +82,8 @@ export class DemoRuntime {
     { sequence: 1, level: "info", message: "Demo runtime started." },
     { sequence: 2, level: "debug", message: "Serving Gua protocol snapshots over WebSocket." },
   ];
+
+  constructor(private readonly monotonicNow: () => number = () => performance.now()) {}
 
   getUiTree(): GuaUiTree {
     if (this.screen === "loading") {
@@ -122,16 +126,18 @@ export class DemoRuntime {
       height: 720,
     };
   }
-  getClock() { return this.clock; }
+  getClock() { this.advanceRunningClock(); return this.clock; }
   installClock(initial = 0, step = 1000 / 60) {
     if (this.clock.installed) throw new Error("invalid_state");
     const nextTime = initial + step;
     if (!Number.isFinite(initial) || initial < 0 || !Number.isFinite(step) || step <= 0 ||
         !Number.isFinite(nextTime) || nextTime <= initial) throw new Error("invalid_duration");
     this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 };
+    this.runningClockStartMs = initial;
+    this.runningClockStartTimeMs = this.monotonicNow();
     return this.clock;
   }
-  pauseClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "paused" }; return this.clock; }
+  pauseClock() { if (!this.clock.installed) throw new Error("not_installed"); this.advanceRunningClock(); this.clock = { ...this.clock, state: "paused" }; return this.clock; }
   runClockFor(duration: number, step?: number) {
     if (this.clock.state !== "paused") throw new Error("invalid_state");
     const nextTime = this.clock.nowMs + duration;
@@ -146,7 +152,15 @@ export class DemoRuntime {
     }, 0);
     return result;
   }
-  resumeClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "running" }; return this.clock; }
+  resumeClock() { if (!this.clock.installed) throw new Error("not_installed"); this.advanceRunningClock(); this.clock = { ...this.clock, state: "running" }; this.runningClockStartMs = this.clock.nowMs; this.runningClockStartTimeMs = this.monotonicNow(); return this.clock; }
+
+  private advanceRunningClock() {
+    if (!this.clock.installed || this.clock.state !== "running") return;
+    const elapsedMs = Math.max(0, this.monotonicNow() - this.runningClockStartTimeMs);
+    const nextTime = this.runningClockStartMs + elapsedMs;
+    if (Number.isFinite(nextTime) && nextTime > this.clock.nowMs)
+      this.clock = { ...this.clock, nowMs: nextTime };
+  }
 
   clickNode(nodeId: string): void {
     this.assertNodeExists(nodeId);

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -4,11 +4,12 @@ import type {
   GuaLogEntry,
   GuaScreenshot,
   GuaUiTree,
+  GuaClockStatus,
 } from "@gua/inspector/core";
 
 const defaultPort = 8765;
 const port = Number.parseInt(Bun.env.GUA_BRIDGE_PORT ?? Bun.argv[2] ?? `${defaultPort}`, 10);
-type GuaInspectorResult = GuaUiTree | GuaLogEntry[] | GuaScreenshot | null;
+type GuaInspectorResult = GuaUiTree | GuaLogEntry[] | GuaScreenshot | GuaClockStatus | null;
 
 function handleMessage(message: string | Buffer): GuaInspectorResponse {
   if (typeof message !== "string") {
@@ -30,6 +31,11 @@ function handleMessage(message: string | Buffer): GuaInspectorResponse {
         return ok(command.id, runtime.getLogs());
       case "get_screenshot":
         return ok(command.id, runtime.getScreenshot());
+      case "get_clock": return ok(command.id, runtime.getClock());
+      case "clock_install": return ok(command.id, runtime.installClock(command.initialTimeMs, command.stepMs));
+      case "clock_pause": return ok(command.id, runtime.pauseClock());
+      case "clock_run_for": return ok(command.id, runtime.runClockFor(command.durationMs, command.stepMs));
+      case "clock_resume": return ok(command.id, runtime.resumeClock());
       case "poll_events":
         return ok(command.id, null);
       case "click_node":
@@ -64,6 +70,7 @@ function ok(id: number, result: GuaInspectorResult): GuaInspectorResponse {
 }
 
 class DemoRuntime {
+  private clock: GuaClockStatus = { schemaVersion: 1, installed: false, state: "running", nowMs: 0, defaultStepMs: 1000 / 60, pendingMs: 0, generation: 0 };
   private screen: "title" | "loading" = "title";
   private focusedNodeId = "start";
   private frameSequence = 1;
@@ -114,6 +121,11 @@ class DemoRuntime {
       height: 720,
     };
   }
+  getClock() { return this.clock; }
+  installClock(initial = 0, step = 1000 / 60) { this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 }; return this.clock; }
+  pauseClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "paused" }; return this.clock; }
+  runClockFor(duration: number, step?: number) { if (this.clock.state !== "paused") throw new Error("invalid_state"); this.clock = { ...this.clock, nowMs: this.clock.nowMs + duration, defaultStepMs: step ?? this.clock.defaultStepMs }; return this.clock; }
+  resumeClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "running" }; return this.clock; }
 
   clickNode(nodeId: string): void {
     this.assertNodeExists(nodeId);

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -127,7 +127,7 @@ class DemoRuntime {
   runClockFor(duration: number, step?: number) {
     if (this.clock.state !== "paused") throw new Error("invalid_state");
     if (step !== undefined && step <= 0) throw new Error("invalid_duration");
-    this.clock = { ...this.clock, nowMs: this.clock.nowMs + duration, defaultStepMs: step ?? this.clock.defaultStepMs };
+    this.clock = { ...this.clock, nowMs: this.clock.nowMs + duration };
     const result = { ...this.clock, completionSessionEpoch: 1, completionAfterFrameSequence: this.frameSequence };
     setTimeout(() => { this.frameSequence += 1; this.revision += 1; }, 0);
     return result;

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -123,13 +123,15 @@ export class DemoRuntime {
     };
   }
   getClock() { return this.clock; }
-  installClock(initial = 0, step = 1000 / 60) { if (this.clock.installed) throw new Error("invalid_state"); if (step <= 0) throw new Error("invalid_duration"); this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 }; return this.clock; }
+  installClock(initial = 0, step = 1000 / 60) { if (this.clock.installed) throw new Error("invalid_state"); if (!Number.isFinite(initial) || initial < 0 || !Number.isFinite(step) || step <= 0) throw new Error("invalid_duration"); this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 }; return this.clock; }
   pauseClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "paused" }; return this.clock; }
   runClockFor(duration: number, step?: number) {
     if (this.clock.state !== "paused") throw new Error("invalid_state");
-    if (step !== undefined && step <= 0) throw new Error("invalid_duration");
+    const nextTime = this.clock.nowMs + duration;
+    if (!Number.isFinite(duration) || duration < 0 || !Number.isFinite(nextTime) ||
+        step !== undefined && (!Number.isFinite(step) || step <= 0)) throw new Error("invalid_duration");
     const operationSequence = this.nextClockOperationSequence++;
-    this.clock = { ...this.clock, nowMs: this.clock.nowMs + duration };
+    this.clock = { ...this.clock, nowMs: nextTime };
     const result = { ...this.clock, operationSequence, completionSessionEpoch: 1, completionAfterFrameSequence: this.frameSequence };
     setTimeout(() => {
       this.clock = { ...this.clock, completedOperationSequence: operationSequence };

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -124,7 +124,12 @@ class DemoRuntime {
   getClock() { return this.clock; }
   installClock(initial = 0, step = 1000 / 60) { this.clock = { ...this.clock, installed: true, state: "running", nowMs: initial, defaultStepMs: step, generation: this.clock.generation + 1 }; return this.clock; }
   pauseClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "paused" }; return this.clock; }
-  runClockFor(duration: number, step?: number) { if (this.clock.state !== "paused") throw new Error("invalid_state"); this.clock = { ...this.clock, nowMs: this.clock.nowMs + duration, defaultStepMs: step ?? this.clock.defaultStepMs }; return this.clock; }
+  runClockFor(duration: number, step?: number) {
+    if (this.clock.state !== "paused") throw new Error("invalid_state");
+    this.clock = { ...this.clock, nowMs: this.clock.nowMs + duration, defaultStepMs: step ?? this.clock.defaultStepMs };
+    setTimeout(() => { this.frameSequence += 1; this.revision += 1; }, 0);
+    return this.clock;
+  }
   resumeClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "running" }; return this.clock; }
 
   clickNode(nodeId: string): void {

--- a/packages/bridge-ws/test/clock.test.ts
+++ b/packages/bridge-ws/test/clock.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { DemoRuntime } from "../src/index";
+
+describe("DemoRuntime virtual clock", () => {
+  test("rejects installation until the current timeline is reset", () => {
+    const runtime = new DemoRuntime();
+    expect(runtime.installClock(100, 10).nowMs).toBe(100);
+
+    expect(() => runtime.installClock(0, 5)).toThrow("invalid_state");
+    expect(runtime.getClock().nowMs).toBe(100);
+    expect(runtime.getClock().defaultStepMs).toBe(10);
+  });
+});

--- a/packages/bridge-ws/test/clock.test.ts
+++ b/packages/bridge-ws/test/clock.test.ts
@@ -10,4 +10,14 @@ describe("DemoRuntime virtual clock", () => {
     expect(runtime.getClock().nowMs).toBe(100);
     expect(runtime.getClock().defaultStepMs).toBe(10);
   });
+
+  test("rejects durations that would rewind or overflow the timeline", () => {
+    const runtime = new DemoRuntime();
+    runtime.installClock(100, 10);
+    runtime.pauseClock();
+
+    expect(() => runtime.runClockFor(-25)).toThrow("invalid_duration");
+    expect(() => runtime.runClockFor(Number.POSITIVE_INFINITY)).toThrow("invalid_duration");
+    expect(runtime.getClock().nowMs).toBe(100);
+  });
 });

--- a/packages/bridge-ws/test/clock.test.ts
+++ b/packages/bridge-ws/test/clock.test.ts
@@ -20,4 +20,19 @@ describe("DemoRuntime virtual clock", () => {
     expect(() => runtime.runClockFor(Number.POSITIVE_INFINITY)).toThrow("invalid_duration");
     expect(runtime.getClock().nowMs).toBe(100);
   });
+
+  test("advances the completion frame without inventing a semantic revision", async () => {
+    const runtime = new DemoRuntime();
+    runtime.installClock(0, 10);
+    runtime.pauseClock();
+    const before = runtime.getUiTree();
+    const operation = runtime.runClockFor(10);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const after = runtime.getUiTree();
+    expect(after.frameSequence).toBe(before.frameSequence + 1);
+    expect(after.revision).toBe(before.revision);
+    expect(runtime.getClock().completedOperationSequence).toBe(operation.operationSequence);
+  });
 });

--- a/packages/bridge-ws/test/clock.test.ts
+++ b/packages/bridge-ws/test/clock.test.ts
@@ -29,6 +29,7 @@ describe("DemoRuntime virtual clock", () => {
     runtime.pauseClock();
     expect(() => runtime.runClockFor(1)).toThrow("invalid_duration");
     expect(() => runtime.runClockFor(100, 1)).toThrow("invalid_duration");
+    expect(() => runtime.runClockFor(0, 1)).toThrow("invalid_duration");
     expect(runtime.getClock().nowMs).toBe(1e16);
   });
 

--- a/packages/bridge-ws/test/clock.test.ts
+++ b/packages/bridge-ws/test/clock.test.ts
@@ -3,7 +3,7 @@ import { DemoRuntime } from "../src/index";
 
 describe("DemoRuntime virtual clock", () => {
   test("rejects installation until the current timeline is reset", () => {
-    const runtime = new DemoRuntime();
+    const runtime = new DemoRuntime(() => 0);
     expect(runtime.installClock(100, 10).nowMs).toBe(100);
 
     expect(() => runtime.installClock(0, 5)).toThrow("invalid_state");
@@ -12,7 +12,7 @@ describe("DemoRuntime virtual clock", () => {
   });
 
   test("rejects durations that would rewind or overflow the timeline", () => {
-    const runtime = new DemoRuntime();
+    const runtime = new DemoRuntime(() => 0);
     runtime.installClock(100, 10);
     runtime.pauseClock();
 
@@ -22,7 +22,7 @@ describe("DemoRuntime virtual clock", () => {
   });
 
   test("rejects steps and runs that cannot advance a large timeline", () => {
-    const runtime = new DemoRuntime();
+    const runtime = new DemoRuntime(() => 0);
     expect(() => runtime.installClock(1e16, 1)).toThrow("invalid_duration");
 
     runtime.installClock(1e16, 2);
@@ -32,7 +32,7 @@ describe("DemoRuntime virtual clock", () => {
   });
 
   test("advances the completion frame without inventing a semantic revision", async () => {
-    const runtime = new DemoRuntime();
+    const runtime = new DemoRuntime(() => 0);
     runtime.installClock(0, 10);
     runtime.pauseClock();
     const before = runtime.getUiTree();
@@ -44,5 +44,21 @@ describe("DemoRuntime virtual clock", () => {
     expect(after.frameSequence).toBe(before.frameSequence + 1);
     expect(after.revision).toBe(before.revision);
     expect(runtime.getClock().completedOperationSequence).toBe(operation.operationSequence);
+  });
+
+  test("advances running time from a monotonic source and freezes while paused", () => {
+    let monotonicNow = 1_000;
+    const runtime = new DemoRuntime(() => monotonicNow);
+    runtime.installClock(100, 10);
+
+    monotonicNow += 25;
+    expect(runtime.getClock().nowMs).toBe(125);
+    runtime.pauseClock();
+    monotonicNow += 50;
+    expect(runtime.getClock().nowMs).toBe(125);
+
+    runtime.resumeClock();
+    monotonicNow += 10;
+    expect(runtime.getClock().nowMs).toBe(135);
   });
 });

--- a/packages/bridge-ws/test/clock.test.ts
+++ b/packages/bridge-ws/test/clock.test.ts
@@ -21,6 +21,16 @@ describe("DemoRuntime virtual clock", () => {
     expect(runtime.getClock().nowMs).toBe(100);
   });
 
+  test("rejects steps and runs that cannot advance a large timeline", () => {
+    const runtime = new DemoRuntime();
+    expect(() => runtime.installClock(1e16, 1)).toThrow("invalid_duration");
+
+    runtime.installClock(1e16, 2);
+    runtime.pauseClock();
+    expect(() => runtime.runClockFor(1)).toThrow("invalid_duration");
+    expect(runtime.getClock().nowMs).toBe(1e16);
+  });
+
   test("advances the completion frame without inventing a semantic revision", async () => {
     const runtime = new DemoRuntime();
     runtime.installClock(0, 10);

--- a/packages/bridge-ws/test/clock.test.ts
+++ b/packages/bridge-ws/test/clock.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { DemoRuntime } from "../src/index";
+import { DemoRuntime, handleMessage } from "../src/index";
 
 describe("DemoRuntime virtual clock", () => {
   test("rejects installation until the current timeline is reset", () => {
@@ -46,6 +46,14 @@ describe("DemoRuntime virtual clock", () => {
     expect(after.frameSequence).toBe(before.frameSequence + 1);
     expect(after.revision).toBe(before.revision);
     expect(runtime.getClock().completedOperationSequence).toBe(operation.operationSequence);
+    const response = handleMessage(JSON.stringify({ id: 9, type: "get_context_status" }), runtime);
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      const status = response.result as { sessionEpoch: number; frameSequence: number; revision: number };
+      expect(status.sessionEpoch).toBe(1);
+      expect(status.frameSequence).toBe(after.frameSequence);
+      expect(status.revision).toBe(after.revision);
+    }
   });
 
   test("advances running time from a monotonic source and freezes while paused", () => {

--- a/packages/bridge-ws/test/clock.test.ts
+++ b/packages/bridge-ws/test/clock.test.ts
@@ -28,6 +28,7 @@ describe("DemoRuntime virtual clock", () => {
     runtime.installClock(1e16, 2);
     runtime.pauseClock();
     expect(() => runtime.runClockFor(1)).toThrow("invalid_duration");
+    expect(() => runtime.runClockFor(100, 1)).toThrow("invalid_duration");
     expect(runtime.getClock().nowMs).toBe(1e16);
   });
 

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   type GuaInspectorClient,
+  type GuaClockStatus,
   type GuaNode,
   type InspectorSnapshot,
   type InspectorState,
@@ -43,6 +44,7 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
   const [baselineDataUri, setBaselineDataUri] = useState<string | null>(null);
   const [visualResult, setVisualResult] = useState<BrowserVisualResult | null>(null);
   const [secretsJson, setSecretsJson] = useState("{}");
+  const [clock, setClock] = useState<GuaClockStatus | null>(null);
 
   useEffect(() => {
     if (client !== undefined) {
@@ -57,6 +59,7 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
     try {
       const snapshot = await readSnapshot(inspectorClient);
       setState((current) => updateInspectorState(current, snapshot));
+      try { setClock(await inspectorClient.getClock()); } catch { setClock(null); }
       setStatus("idle");
     } catch (caught) {
       setError((caught as Error).message);
@@ -236,6 +239,14 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
         />
         <ScreenshotPanel screenshot={state.screenshot} selectedNode={selectedNode} />
         <LogPanel logs={state.logs} />
+        <ClockPanel
+          clock={clock}
+          onInstall={async (step) => setClock(await inspectorClient.installClock(0, step))}
+          onPause={async () => setClock(await inspectorClient.pauseClock())}
+          onRunFor={async (duration, step) => { setClock(await inspectorClient.runClockFor(duration, step)); await refresh(); }}
+          onResume={async () => setClock(await inspectorClient.resumeClock())}
+          onError={(message) => setError(message)}
+        />
         <AutomationPanel
           recording={recording}
           lastRecording={lastRecording}
@@ -264,6 +275,29 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
       </main>
     </div>
   );
+}
+
+function ClockPanel({ clock, onInstall, onPause, onRunFor, onResume, onError }: {
+  clock: GuaClockStatus | null;
+  onInstall(step?: number): Promise<void>; onPause(): Promise<void>;
+  onRunFor(duration: number, step?: number): Promise<void>; onResume(): Promise<void>;
+  onError(message: string): void;
+}) {
+  const [duration, setDuration] = useState("1000");
+  const [step, setStep] = useState("");
+  const parsedStep = step === "" ? undefined : Number(step);
+  const run = (action: () => Promise<void>) => void action().catch((caught) => onError((caught as Error).message));
+  return <section className="gua-panel">
+    <PanelHeader title="Virtual Clock" detail={clock === null ? "unsupported" : `${clock.state} · ${clock.nowMs.toFixed(2)} ms`} />
+    <div className="gua-clock-controls">
+      <input aria-label="Clock duration milliseconds" type="number" min="0" value={duration} onChange={(e) => setDuration(e.currentTarget.value)} />
+      <input aria-label="Clock step milliseconds" type="number" min="0.001" placeholder="default step" value={step} onChange={(e) => setStep(e.currentTarget.value)} />
+      <button type="button" disabled={clock === null || clock.installed} onClick={() => run(() => onInstall(parsedStep))}>Install</button>
+      <button type="button" disabled={clock === null || !clock.installed || clock.state === "paused"} onClick={() => run(onPause)}>Pause</button>
+      <button type="button" disabled={clock === null || clock.state !== "paused" || Number(duration) < 0} onClick={() => run(() => onRunFor(Number(duration), parsedStep))}>Run for</button>
+      <button type="button" disabled={clock === null || clock.state !== "paused"} onClick={() => run(onResume)}>Resume</button>
+    </div>
+  </section>;
 }
 
 function closeClient(client: GuaInspectorClient): void {

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -45,6 +45,7 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
   const [visualResult, setVisualResult] = useState<BrowserVisualResult | null>(null);
   const [secretsJson, setSecretsJson] = useState("{}");
   const [clock, setClock] = useState<GuaClockStatus | null>(null);
+  const clockRequestSequence = useRef(0);
 
   useEffect(() => {
     if (client !== undefined) {
@@ -53,19 +54,29 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
     }
   }, [client]);
 
+  const refreshClock = useCallback(async () => {
+    const sequence = ++clockRequestSequence.current;
+    try {
+      const nextClock = await inspectorClient.getClock();
+      if (sequence === clockRequestSequence.current) setClock(nextClock);
+    } catch {
+      if (sequence === clockRequestSequence.current) setClock(null);
+    }
+  }, [inspectorClient]);
+
   const refresh = useCallback(async () => {
     setStatus("refreshing");
     setError(null);
     try {
       const snapshot = await readSnapshot(inspectorClient);
       setState((current) => updateInspectorState(current, snapshot));
-      try { setClock(await inspectorClient.getClock()); } catch { setClock(null); }
+      await refreshClock();
       setStatus("idle");
     } catch (caught) {
       setError((caught as Error).message);
       setStatus("error");
     }
-  }, [inspectorClient]);
+  }, [inspectorClient, refreshClock]);
 
   useEffect(() => {
     void refresh();
@@ -78,14 +89,16 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
 
     const unsubscribe = maybeSubscribable.subscribeSnapshots?.((snapshot) => {
       setState((current) => updateInspectorState(current, snapshot));
+      void refreshClock();
       setStatus("idle");
       setError(null);
     });
 
     return () => {
+      ++clockRequestSequence.current;
       unsubscribe?.();
     };
-  }, [inspectorClient]);
+  }, [inspectorClient, refreshClock]);
 
   useEffect(() => {
     if (!autoRefresh) {
@@ -102,6 +115,7 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
   const connectMock = () => {
     closeClient(inspectorClient);
     setState(createInspectorState());
+    setClock(null);
     setError(null);
     setClientLabel("Mock runtime");
     setInspectorClient(new MockInspectorClient());
@@ -111,6 +125,7 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
     closeClient(inspectorClient);
     window.localStorage.setItem("gua.inspector.wsUrl", webSocketUrl);
     setState(createInspectorState());
+    setClock(null);
     setError(null);
     setClientLabel(webSocketUrl);
     setInspectorClient(new WebSocketInspectorClient(webSocketUrl));

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -8,6 +8,7 @@ import {
   type InspectorState,
   MockInspectorClient,
   WebSocketInspectorClient,
+  createCoalescedAsyncRunner,
   createInspectorState,
   getSelectedNode,
   readSnapshot,
@@ -45,7 +46,10 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
   const [visualResult, setVisualResult] = useState<BrowserVisualResult | null>(null);
   const [secretsJson, setSecretsJson] = useState("{}");
   const [clock, setClock] = useState<GuaClockStatus | null>(null);
-  const clockRequestSequence = useRef(0);
+  const clockRefresh = useRef<{
+    client: GuaInspectorClient;
+    run: () => Promise<void>;
+  } | null>(null);
 
   useEffect(() => {
     if (client !== undefined) {
@@ -54,14 +58,25 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
     }
   }, [client]);
 
-  const refreshClock = useCallback(async () => {
-    const sequence = ++clockRequestSequence.current;
-    try {
-      const nextClock = await inspectorClient.getClock();
-      if (sequence === clockRequestSequence.current) setClock(nextClock);
-    } catch {
-      if (sequence === clockRequestSequence.current) setClock(null);
+  const refreshClock = useCallback(() => {
+    let entry = clockRefresh.current;
+    if (entry?.client !== inspectorClient) {
+      const nextEntry: NonNullable<typeof clockRefresh.current> = {
+        client: inspectorClient,
+        run: async () => undefined,
+      };
+      nextEntry.run = createCoalescedAsyncRunner(async () => {
+        try {
+          const nextClock = await inspectorClient.getClock();
+          if (clockRefresh.current === nextEntry) setClock(nextClock);
+        } catch {
+          if (clockRefresh.current === nextEntry) setClock(null);
+        }
+      });
+      clockRefresh.current = nextEntry;
+      entry = nextEntry;
     }
+    return entry.run();
   }, [inspectorClient]);
 
   const refresh = useCallback(async () => {
@@ -95,7 +110,7 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
     });
 
     return () => {
-      ++clockRequestSequence.current;
+      if (clockRefresh.current?.client === inspectorClient) clockRefresh.current = null;
       unsubscribe?.();
     };
   }, [inspectorClient, refreshClock]);

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -45,6 +45,7 @@ export interface GuaScreenshot {
   width: number;
   height: number;
 }
+export interface GuaClockStatus { schemaVersion: 1; installed: boolean; state: "running" | "paused"; nowMs: number; defaultStepMs: number; pendingMs: number; generation: number; }
 
 export interface InspectorPanel {
   id: "tree" | "node" | "screenshot" | "logs";
@@ -68,6 +69,11 @@ export interface GuaInspectorClient {
   performAction(action: SemanticActionInput): Promise<ActionOutcome>;
   clickNode(nodeId: string): Promise<void>;
   focusNode(nodeId: string): Promise<void>;
+  getClock(): Promise<GuaClockStatus>;
+  installClock(initialTimeMs?: number, stepMs?: number): Promise<GuaClockStatus>;
+  pauseClock(): Promise<GuaClockStatus>;
+  runClockFor(durationMs: number, stepMs?: number): Promise<GuaClockStatus>;
+  resumeClock(): Promise<GuaClockStatus>;
 }
 
 export type GuaInspectorCommand =
@@ -77,6 +83,9 @@ export type GuaInspectorCommand =
   | { id: number; type: "poll_events"; requestId: number }
   | { id: number; type: "click_node"; nodeId: string }
   | { id: number; type: "focus_node"; nodeId: string }
+  | { id: number; type: "get_clock" | "clock_pause" | "clock_resume" }
+  | { id: number; type: "clock_install"; initialTimeMs?: number; stepMs?: number }
+  | { id: number; type: "clock_run_for"; durationMs: number; stepMs?: number }
   | { id: number; type: "set_value"; nodeId: string; value: string; sensitive?: boolean }
   | { id: number; type: "set_checked"; nodeId: string; checked: boolean }
   | { id: number; type: "select"; nodeId: string; value: string }
@@ -90,6 +99,9 @@ type GuaInspectorCommandInput =
   | { type: "poll_events"; requestId: number }
   | { type: "click_node"; nodeId: string }
   | { type: "focus_node"; nodeId: string }
+  | { type: "get_clock" | "clock_pause" | "clock_resume" }
+  | { type: "clock_install"; initialTimeMs?: number; stepMs?: number }
+  | { type: "clock_run_for"; durationMs: number; stepMs?: number }
   | { type: "set_value"; nodeId: string; value: string; sensitive?: boolean }
   | { type: "set_checked"; nodeId: string; checked: boolean }
   | { type: "select"; nodeId: string; value: string }
@@ -178,6 +190,7 @@ export async function readSnapshot(client: GuaInspectorClient): Promise<Inspecto
 }
 
 export class MockInspectorClient implements GuaInspectorClient {
+  private clock: GuaClockStatus = { schemaVersion: 1, installed: false, state: "running", nowMs: 0, defaultStepMs: 1000 / 60, pendingMs: 0, generation: 0 };
   private logs: GuaLogEntry[] = [
     { sequence: 1, level: "info", message: "Inspector connected to mock runtime." },
     { sequence: 2, level: "debug", message: "Title screen snapshot received." },
@@ -321,6 +334,11 @@ export class MockInspectorClient implements GuaInspectorClient {
       },
     ];
   }
+  async getClock() { return this.clock; }
+  async installClock(initialTimeMs = 0, stepMs = 1000 / 60) { this.clock = { ...this.clock, installed: true, state: "running", nowMs: initialTimeMs, defaultStepMs: stepMs, generation: this.clock.generation + 1 }; return this.clock; }
+  async pauseClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "paused" }; return this.clock; }
+  async runClockFor(durationMs: number, stepMs?: number) { if (this.clock.state !== "paused") throw new Error("invalid_state"); this.clock = { ...this.clock, nowMs: this.clock.nowMs + durationMs, defaultStepMs: stepMs ?? this.clock.defaultStepMs }; return this.clock; }
+  async resumeClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "running" }; return this.clock; }
 }
 
 function actionCommand(action: SemanticActionInput): GuaInspectorCommandInput {
@@ -377,6 +395,20 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
   async getScreenshot(): Promise<GuaScreenshot> {
     return this.request<GuaScreenshot>({ type: "get_screenshot" });
   }
+
+  async getClock(): Promise<GuaClockStatus> { return this.request({ type: "get_clock" }); }
+  async installClock(initialTimeMs = 0, stepMs?: number): Promise<GuaClockStatus> { return this.request({ type: "clock_install", initialTimeMs, stepMs }); }
+  async pauseClock(): Promise<GuaClockStatus> { return this.request({ type: "clock_pause" }); }
+  async runClockFor(durationMs: number, stepMs?: number): Promise<GuaClockStatus> {
+    let status = await this.request<GuaClockStatus>({ type: "clock_run_for", durationMs, stepMs });
+    const started = Date.now();
+    while (status.pendingMs > 0 && Date.now() - started < this.requestTimeoutMs) {
+      await new Promise((resolve) => window.setTimeout(resolve, 5)); status = await this.getClock();
+    }
+    if (status.pendingMs > 0) throw new Error("Timed out waiting for Gua clock run_for completion.");
+    return status;
+  }
+  async resumeClock(): Promise<GuaClockStatus> { return this.request({ type: "clock_resume" }); }
 
   async performAction(action: SemanticActionInput): Promise<ActionOutcome> {
     const command = actionCommand(action);

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -401,12 +401,16 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
   async pauseClock(): Promise<GuaClockStatus> { return this.request({ type: "clock_pause" }); }
   async runClockFor(durationMs: number, stepMs?: number): Promise<GuaClockStatus> {
     let status = await this.request<GuaClockStatus>({ type: "clock_run_for", durationMs, stepMs });
+    const before = await this.getUiTree();
     const started = Date.now();
-    while (status.pendingMs > 0 && Date.now() - started < this.requestTimeoutMs) {
-      await new Promise((resolve) => window.setTimeout(resolve, 5)); status = await this.getClock();
+    while (Date.now() - started < this.requestTimeoutMs) {
+      const tree = await this.getUiTree();
+      if (tree.sessionEpoch !== before.sessionEpoch) throw new Error("stale_session");
+      if (status.pendingMs <= 0 && tree.frameSequence > before.frameSequence) return status;
+      await new Promise((resolve) => window.setTimeout(resolve, 5));
+      status = await this.getClock();
     }
-    if (status.pendingMs > 0) throw new Error("Timed out waiting for Gua clock run_for completion.");
-    return status;
+    throw new Error("Timed out waiting for Gua clock run_for host completion.");
   }
   async resumeClock(): Promise<GuaClockStatus> { return this.request({ type: "clock_resume" }); }
 

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -371,6 +371,28 @@ interface PendingRequest {
   timeoutId: ReturnType<typeof setTimeout>;
 }
 
+const clockPauseResponseTimeoutMs = 11_000;
+
+export function createCoalescedAsyncRunner(task: () => Promise<void>): () => Promise<void> {
+  let active: Promise<void> | null = null;
+  let rerunRequested = false;
+
+  return () => {
+    rerunRequested = true;
+    if (active !== null) return active;
+
+    active = (async () => {
+      do {
+        rerunRequested = false;
+        await task();
+      } while (rerunRequested);
+    })().finally(() => {
+      active = null;
+    });
+    return active;
+  };
+}
+
 export class WebSocketInspectorClient implements GuaInspectorClient {
   private socket: WebSocket | null = null;
   private connectPromise: Promise<WebSocket> | null = null;
@@ -398,7 +420,9 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
 
   async getClock(): Promise<GuaClockStatus> { return this.request({ type: "get_clock" }); }
   async installClock(initialTimeMs = 0, stepMs?: number): Promise<GuaClockStatus> { return this.request({ type: "clock_install", initialTimeMs, stepMs }); }
-  async pauseClock(): Promise<GuaClockStatus> { return this.request({ type: "clock_pause" }); }
+  async pauseClock(): Promise<GuaClockStatus> {
+    return this.request({ type: "clock_pause" }, Math.max(this.requestTimeoutMs, clockPauseResponseTimeoutMs));
+  }
   async runClockFor(durationMs: number, stepMs?: number): Promise<GuaClockStatus> {
     let status = await this.request<GuaClockStatus>({ type: "clock_run_for", durationMs, stepMs });
     const completionEpoch = status.completionSessionEpoch;
@@ -459,7 +483,7 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
     };
   }
 
-  private async request<T>(command: GuaInspectorCommandInput): Promise<T> {
+  private async request<T>(command: GuaInspectorCommandInput, timeoutMs = this.requestTimeoutMs): Promise<T> {
     const socket = await this.connect();
     const id = this.nextId++;
     const payload = { ...command, id } as GuaInspectorCommand;
@@ -468,7 +492,7 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
       const timeoutId = setTimeout(() => {
         this.pending.delete(id);
         reject(new Error(`Timed out waiting for ${command.type}.`));
-      }, this.requestTimeoutMs);
+      }, timeoutMs);
 
       this.pending.set(id, {
         resolve: (value) => resolve(value as T),

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -45,7 +45,7 @@ export interface GuaScreenshot {
   width: number;
   height: number;
 }
-export interface GuaClockStatus { schemaVersion: 1; installed: boolean; state: "running" | "paused"; nowMs: number; defaultStepMs: number; pendingMs: number; generation: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number; }
+export interface GuaClockStatus { schemaVersion: 1; installed: boolean; state: "running" | "paused"; nowMs: number; defaultStepMs: number; pendingMs: number; generation: number; completedOperationSequence?: number; operationSequence?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number; }
 
 export interface InspectorPanel {
   id: "tree" | "node" | "screenshot" | "logs";
@@ -403,12 +403,13 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
     let status = await this.request<GuaClockStatus>({ type: "clock_run_for", durationMs, stepMs });
     const completionEpoch = status.completionSessionEpoch;
     const completionFrame = status.completionAfterFrameSequence;
-    if (completionEpoch === undefined || completionFrame === undefined) throw new Error("unsupported");
+    const operationSequence = status.operationSequence;
+    if (completionEpoch === undefined || completionFrame === undefined || operationSequence === undefined) throw new Error("unsupported");
     const started = Date.now();
     while (Date.now() - started < this.requestTimeoutMs) {
       const tree = await this.getUiTree();
       if (tree.sessionEpoch !== completionEpoch) throw new Error("stale_session");
-      if (status.pendingMs <= 0 && tree.frameSequence > completionFrame) return status;
+      if ((status.completedOperationSequence ?? 0) >= operationSequence && tree.frameSequence > completionFrame) return status;
       await new Promise((resolve) => window.setTimeout(resolve, 5));
       status = await this.getClock();
     }

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -45,7 +45,7 @@ export interface GuaScreenshot {
   width: number;
   height: number;
 }
-export interface GuaClockStatus { schemaVersion: 1; installed: boolean; state: "running" | "paused"; nowMs: number; defaultStepMs: number; pendingMs: number; generation: number; }
+export interface GuaClockStatus { schemaVersion: 1; installed: boolean; state: "running" | "paused"; nowMs: number; defaultStepMs: number; pendingMs: number; generation: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number; }
 
 export interface InspectorPanel {
   id: "tree" | "node" | "screenshot" | "logs";
@@ -401,12 +401,14 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
   async pauseClock(): Promise<GuaClockStatus> { return this.request({ type: "clock_pause" }); }
   async runClockFor(durationMs: number, stepMs?: number): Promise<GuaClockStatus> {
     let status = await this.request<GuaClockStatus>({ type: "clock_run_for", durationMs, stepMs });
-    const before = await this.getUiTree();
+    const completionEpoch = status.completionSessionEpoch;
+    const completionFrame = status.completionAfterFrameSequence;
+    if (completionEpoch === undefined || completionFrame === undefined) throw new Error("unsupported");
     const started = Date.now();
     while (Date.now() - started < this.requestTimeoutMs) {
       const tree = await this.getUiTree();
-      if (tree.sessionEpoch !== before.sessionEpoch) throw new Error("stale_session");
-      if (status.pendingMs <= 0 && tree.frameSequence > before.frameSequence) return status;
+      if (tree.sessionEpoch !== completionEpoch) throw new Error("stale_session");
+      if (status.pendingMs <= 0 && tree.frameSequence > completionFrame) return status;
       await new Promise((resolve) => window.setTimeout(resolve, 5));
       status = await this.getClock();
     }

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -45,7 +45,7 @@ export interface GuaScreenshot {
   width: number;
   height: number;
 }
-export interface GuaClockStatus { schemaVersion: 1; installed: boolean; state: "running" | "paused"; nowMs: number; defaultStepMs: number; pendingMs: number; generation: number; completedOperationSequence?: number; operationSequence?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number; }
+export interface GuaClockStatus { schemaVersion: 1; installed: boolean; state: "running" | "paused"; nowMs: number; defaultStepMs: number; pendingMs: number; generation: number; completedOperationSequence: number; operationSequence?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number; }
 
 export interface InspectorPanel {
   id: "tree" | "node" | "screenshot" | "logs";
@@ -190,7 +190,7 @@ export async function readSnapshot(client: GuaInspectorClient): Promise<Inspecto
 }
 
 export class MockInspectorClient implements GuaInspectorClient {
-  private clock: GuaClockStatus = { schemaVersion: 1, installed: false, state: "running", nowMs: 0, defaultStepMs: 1000 / 60, pendingMs: 0, generation: 0 };
+  private clock: GuaClockStatus = { schemaVersion: 1, installed: false, state: "running", nowMs: 0, defaultStepMs: 1000 / 60, pendingMs: 0, generation: 0, completedOperationSequence: 0 };
   private logs: GuaLogEntry[] = [
     { sequence: 1, level: "info", message: "Inspector connected to mock runtime." },
     { sequence: 2, level: "debug", message: "Title screen snapshot received." },
@@ -433,7 +433,7 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
     while (Date.now() - started < this.requestTimeoutMs) {
       const tree = await this.getUiTree();
       if (tree.sessionEpoch !== completionEpoch) throw new Error("stale_session");
-      if ((status.completedOperationSequence ?? 0) >= operationSequence && tree.frameSequence > completionFrame) return status;
+      if (status.completedOperationSequence >= operationSequence && tree.frameSequence > completionFrame) return status;
       await new Promise((resolve) => window.setTimeout(resolve, 5));
       status = await this.getClock();
     }

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -67,6 +67,7 @@ export interface GuaInspectorClient {
   getUiTree(): Promise<GuaUiTree>;
   getLogs(): Promise<GuaLogEntry[]>;
   getScreenshot(): Promise<GuaScreenshot>;
+  getContextStatus(): Promise<GuaContextStatus>;
   performAction(action: SemanticActionInput): Promise<ActionOutcome>;
   clickNode(nodeId: string): Promise<void>;
   focusNode(nodeId: string): Promise<void>;
@@ -297,6 +298,16 @@ export class MockInspectorClient implements GuaInspectorClient {
     };
   }
 
+  async getContextStatus(): Promise<GuaContextStatus> {
+    return {
+      sessionEpoch: 1, frameSequence: this.frameSequence, revision: this.revision,
+      nodeCount: (await this.getUiTree()).nodes.length, pendingRequestCount: 0,
+      inFlightRequestCount: 0, unconsumedEventCount: 0, logCount: this.logs.length,
+      hasScreenshot: false, firstPendingAction: 0, firstPendingNodeId: "",
+      firstEventAction: 0, firstEventNodeId: "",
+    };
+  }
+
   async performAction(action: SemanticActionInput): Promise<ActionOutcome> {
     if (action.action === "click") await this.clickNode(action.nodeId as string);
     else if (action.action === "focus") await this.focusNode(action.nodeId as string);
@@ -421,6 +432,10 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
     return this.request<GuaScreenshot>({ type: "get_screenshot" });
   }
 
+  async getContextStatus(): Promise<GuaContextStatus> {
+    return this.request<GuaContextStatus>({ type: "get_context_status" });
+  }
+
   async getClock(): Promise<GuaClockStatus> { return this.request({ type: "get_clock" }); }
   async installClock(initialTimeMs = 0, stepMs?: number): Promise<GuaClockStatus> { return this.request({ type: "clock_install", initialTimeMs, stepMs }); }
   async pauseClock(): Promise<GuaClockStatus> {
@@ -434,9 +449,9 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
     if (completionEpoch === undefined || completionFrame === undefined || operationSequence === undefined) throw new Error("unsupported");
     const started = Date.now();
     while (Date.now() - started < this.requestTimeoutMs) {
-      const tree = await this.getUiTree();
-      if (tree.sessionEpoch !== completionEpoch) throw new Error("stale_session");
-      if (status.completedOperationSequence >= operationSequence && tree.frameSequence > completionFrame) return status;
+      const context = await this.getContextStatus();
+      if (context.sessionEpoch !== completionEpoch) throw new Error("stale_session");
+      if (status.completedOperationSequence >= operationSequence && context.frameSequence > completionFrame) return status;
       await new Promise((resolve) => window.setTimeout(resolve, 5));
       status = await this.getClock();
     }

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -46,6 +46,7 @@ export interface GuaScreenshot {
   height: number;
 }
 export interface GuaClockStatus { schemaVersion: 1; installed: boolean; state: "running" | "paused"; nowMs: number; defaultStepMs: number; pendingMs: number; generation: number; completedOperationSequence: number; operationSequence?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number; }
+export interface GuaContextStatus { sessionEpoch: number; frameSequence: number; revision: number; nodeCount: number; pendingRequestCount: number; inFlightRequestCount: number; unconsumedEventCount: number; logCount: number; hasScreenshot: boolean; firstPendingAction: number; firstPendingNodeId: string; firstEventAction: number; firstEventNodeId: string; }
 
 export interface InspectorPanel {
   id: "tree" | "node" | "screenshot" | "logs";
@@ -80,6 +81,7 @@ export type GuaInspectorCommand =
   | { id: number; type: "get_ui_tree" }
   | { id: number; type: "get_logs" }
   | { id: number; type: "get_screenshot" }
+  | { id: number; type: "get_context_status" }
   | { id: number; type: "poll_events"; requestId: number }
   | { id: number; type: "click_node"; nodeId: string }
   | { id: number; type: "focus_node"; nodeId: string }
@@ -96,6 +98,7 @@ type GuaInspectorCommandInput =
   | { type: "get_ui_tree" }
   | { type: "get_logs" }
   | { type: "get_screenshot" }
+  | { type: "get_context_status" }
   | { type: "poll_events"; requestId: number }
   | { type: "click_node"; nodeId: string }
   | { type: "focus_node"; nodeId: string }

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -337,7 +337,7 @@ export class MockInspectorClient implements GuaInspectorClient {
   async getClock() { return this.clock; }
   async installClock(initialTimeMs = 0, stepMs = 1000 / 60) { this.clock = { ...this.clock, installed: true, state: "running", nowMs: initialTimeMs, defaultStepMs: stepMs, generation: this.clock.generation + 1 }; return this.clock; }
   async pauseClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "paused" }; return this.clock; }
-  async runClockFor(durationMs: number, stepMs?: number) { if (this.clock.state !== "paused") throw new Error("invalid_state"); this.clock = { ...this.clock, nowMs: this.clock.nowMs + durationMs, defaultStepMs: stepMs ?? this.clock.defaultStepMs }; return this.clock; }
+  async runClockFor(durationMs: number, stepMs?: number) { if (this.clock.state !== "paused") throw new Error("invalid_state"); if (stepMs !== undefined && stepMs <= 0) throw new Error("invalid_duration"); this.clock = { ...this.clock, nowMs: this.clock.nowMs + durationMs }; return this.clock; }
   async resumeClock() { if (!this.clock.installed) throw new Error("not_installed"); this.clock = { ...this.clock, state: "running" }; return this.clock; }
 }
 

--- a/packages/inspector/src/styles.css
+++ b/packages/inspector/src/styles.css
@@ -60,6 +60,8 @@ button:disabled {
   min-height: 100vh;
   background: #0f1216;
 }
+.gua-clock-controls { display: grid; grid-template-columns: 1fr 1fr auto auto auto auto; gap: 0.5rem; padding: 0.75rem; }
+.gua-clock-controls input { min-width: 0; }
 
 .gua-topbar {
   align-items: center;

--- a/packages/inspector/test/automation.test.ts
+++ b/packages/inspector/test/automation.test.ts
@@ -8,8 +8,11 @@ describe("InspectorRecorder", () => {
     const client = new MockInspectorClient();
     await client.installClock(0, 10);
     await client.pauseClock();
-    const status = await client.runClockFor(25);
+    const overridden = await client.runClockFor(4, 4);
+    expect(overridden.defaultStepMs).toBe(10);
+    const status = await client.runClockFor(21);
     expect(status.nowMs).toBe(25);
+    expect(status.defaultStepMs).toBe(10);
     expect(status.state).toBe("paused");
   });
   test("exports schema v1 and redacts sensitive values", () => {

--- a/packages/inspector/test/automation.test.ts
+++ b/packages/inspector/test/automation.test.ts
@@ -1,9 +1,29 @@
 import { describe, expect, test } from "bun:test";
 
 import { InspectorRecorder, validateRecording } from "../src/automation";
-import { MockInspectorClient } from "../src/core";
+import { MockInspectorClient, createCoalescedAsyncRunner } from "../src/core";
 
 describe("InspectorRecorder", () => {
+  test("coalesces snapshot-driven clock refreshes without starving updates", async () => {
+    const releases: Array<() => void> = [];
+    let calls = 0;
+    const refresh = createCoalescedAsyncRunner(async () => {
+      calls += 1;
+      await new Promise<void>((resolve) => releases.push(resolve));
+    });
+
+    const first = refresh();
+    const second = refresh();
+    refresh();
+    expect(calls).toBe(1);
+
+    releases.shift()?.();
+    await waitUntil(() => calls === 2);
+    releases.shift()?.();
+    await Promise.all([first, second]);
+    expect(calls).toBe(2);
+  });
+
   test("controls the mock virtual clock deterministically", async () => {
     const client = new MockInspectorClient();
     await client.installClock(0, 10);
@@ -33,3 +53,11 @@ describe("InspectorRecorder", () => {
     expect(JSON.stringify(recording)).not.toContain("not-written");
   });
 });
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let index = 0; index < 20; index += 1) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  throw new Error("Timed out waiting for condition.");
+}

--- a/packages/inspector/test/automation.test.ts
+++ b/packages/inspector/test/automation.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, test } from "bun:test";
 
 import { InspectorRecorder, validateRecording } from "../src/automation";
+import { MockInspectorClient } from "../src/core";
 
 describe("InspectorRecorder", () => {
+  test("controls the mock virtual clock deterministically", async () => {
+    const client = new MockInspectorClient();
+    await client.installClock(0, 10);
+    await client.pauseClock();
+    const status = await client.runClockFor(25);
+    expect(status.nowMs).toBe(25);
+    expect(status.state).toBe("paused");
+  });
   test("exports schema v1 and redacts sensitive values", () => {
     const recorder = new InspectorRecorder();
     recorder.start();

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,5 +1,9 @@
 # gui-mcp
 
+Virtual-time tools are `get_clock`, `clock_install`, `clock_pause`,
+`clock_run_for`, and `clock_resume`. They control only work explicitly connected
+to GuaClock, not engine-global time.
+
 `gui-mcp` is the MCP server for the Gua runtime UI automation protocol.
 
 It proxies MCP tool calls to a running Gua WebSocket bridge, so game runtimes keep

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -783,8 +783,16 @@ class GuaBridgeClient {
       if (tree.sessionEpoch !== completionEpoch) throw new Error("stale_session");
       if ((result.pendingMs ?? 0) <= 0 && (tree.frameSequence ?? 0) > completionFrame) return result;
       await sleep(5);
-      const status = await this.request<{ pendingMs: number }>({ type: "get_clock" });
-      result = { ...result, pendingMs: status.pendingMs };
+      const status = await this.request<{
+        schemaVersion: number;
+        installed: boolean;
+        state: "running" | "paused";
+        nowMs: number;
+        defaultStepMs: number;
+        pendingMs: number;
+        generation: number;
+      }>({ type: "get_clock" });
+      result = { ...result, ...status };
     }
     throw new Error("Timed out waiting for Gua clock run_for host completion.");
   }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -114,6 +114,7 @@ export interface GuaMcpServerOptions {
 }
 
 const defaultBridgeUrl = "ws://127.0.0.1:8765";
+const clockPauseResponseTimeoutMs = 11_000;
 
 export const guaMcpTools = [
   "get_ui_tree",
@@ -510,7 +511,7 @@ async function executeTool(
     case "clock_pause":
       return bridge.controlClock({ type: "clock_pause" });
     case "clock_run_for":
-      return bridge.controlClock({ type: "clock_run_for", durationMs: readNumberArg(args, "durationMs", 0), stepMs: readOptionalNumberArg(args, "stepMs") });
+      return bridge.controlClock(parseClockRunForArguments(args));
     case "clock_resume":
       return bridge.controlClock({ type: "clock_resume" });
     case "start_recording":
@@ -772,7 +773,10 @@ class GuaBridgeClient {
   async controlClock(command: { type: "clock_install"; initialTimeMs?: number; stepMs?: number } |
     { type: "clock_run_for"; durationMs: number; stepMs?: number } | { type: "clock_pause" | "clock_resume" }): Promise<unknown>
   {
-    let result = await this.request<{ pendingMs?: number; completedOperationSequence?: number; operationSequence?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number }>(command);
+    const responseTimeoutMs = command.type === "clock_pause"
+      ? Math.max(this.requestTimeoutMs, clockPauseResponseTimeoutMs)
+      : this.requestTimeoutMs;
+    let result = await this.request<{ pendingMs?: number; completedOperationSequence?: number; operationSequence?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number }>(command, responseTimeoutMs);
     if (command.type !== "clock_run_for") return result;
     const completionEpoch = result.completionSessionEpoch;
     const completionFrame = result.completionAfterFrameSequence;
@@ -848,7 +852,7 @@ class GuaBridgeClient {
     this.connectPromise = null;
   }
 
-  private async request<T>(command: BridgeCommandInput): Promise<T> {
+  private async request<T>(command: BridgeCommandInput, timeoutMs = this.requestTimeoutMs): Promise<T> {
     const socket = await this.connect();
     const id = this.nextId++;
     const payload = { ...command, id } as BridgeCommand;
@@ -857,7 +861,7 @@ class GuaBridgeClient {
       const timeoutId = setTimeout(() => {
         this.pending.delete(id);
         reject(new Error(`Timed out waiting for Gua bridge command: ${command.type}`));
-      }, this.requestTimeoutMs);
+      }, timeoutMs);
 
       this.pending.set(id, {
         resolve: (value) => resolve(value as T),
@@ -1046,6 +1050,19 @@ function readNumberArg(args: Record<string, unknown>, name: string, fallback: nu
   if (value === undefined) return fallback;
   if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`Expected finite number argument: ${name}`);
   return value;
+}
+
+export function parseClockRunForArguments(args: Record<string, unknown>): {
+  type: "clock_run_for";
+  durationMs: number;
+  stepMs?: number;
+} {
+  if (args.durationMs === undefined) throw new Error("Expected finite number argument: durationMs");
+  return {
+    type: "clock_run_for",
+    durationMs: readNumberArg(args, "durationMs", 0),
+    stepMs: readOptionalNumberArg(args, "stepMs"),
+  };
 }
 
 function readOptionalNumberArg(args: Record<string, unknown>, name: string): number | undefined {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -772,16 +772,19 @@ class GuaBridgeClient {
   async controlClock(command: { type: "clock_install"; initialTimeMs?: number; stepMs?: number } |
     { type: "clock_run_for"; durationMs: number; stepMs?: number } | { type: "clock_pause" | "clock_resume" }): Promise<unknown>
   {
-    const result = await this.request<{ pendingMs?: number }>(command);
+    let result = await this.request<{ pendingMs?: number }>(command);
     if (command.type !== "clock_run_for") return result;
+    const before = await this.getUiTree();
+    const beforeFrameSequence = before.frameSequence ?? 0;
     const started = Date.now();
-    while ((result.pendingMs ?? 0) > 0 && Date.now() - started < 10000) {
+    while (Date.now() - started < 10000) {
+      const tree = await this.getUiTree();
+      if (tree.sessionEpoch !== before.sessionEpoch) throw new Error("stale_session");
+      if ((result.pendingMs ?? 0) <= 0 && (tree.frameSequence ?? 0) > beforeFrameSequence) return result;
       await sleep(5);
-      const status = await this.request<{ pendingMs: number }>({ type: "get_clock" });
-      if (status.pendingMs <= 0) return status;
+      result = await this.request<{ pendingMs: number }>({ type: "get_clock" });
     }
-    if ((result.pendingMs ?? 0) > 0) throw new Error("Timed out waiting for Gua clock run_for completion.");
-    return result;
+    throw new Error("Timed out waiting for Gua clock run_for host completion.");
   }
 
   async performAction(input: SemanticActionInput): Promise<GuaActionReceipt | null> {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -776,7 +776,7 @@ class GuaBridgeClient {
     const responseTimeoutMs = command.type === "clock_pause"
       ? Math.max(this.requestTimeoutMs, clockPauseResponseTimeoutMs)
       : this.requestTimeoutMs;
-    let result = await this.request<{ pendingMs?: number; completedOperationSequence?: number; operationSequence?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number }>(command, responseTimeoutMs);
+    let result = await this.request<{ pendingMs?: number; completedOperationSequence: number; operationSequence?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number }>(command, responseTimeoutMs);
     if (command.type !== "clock_run_for") return result;
     const completionEpoch = result.completionSessionEpoch;
     const completionFrame = result.completionAfterFrameSequence;
@@ -786,7 +786,7 @@ class GuaBridgeClient {
     while (Date.now() - started < 10000) {
       const tree = await this.getUiTree();
       if (tree.sessionEpoch !== completionEpoch) throw new Error("stale_session");
-      if ((result.completedOperationSequence ?? 0) >= operationSequence && (tree.frameSequence ?? 0) > completionFrame) return result;
+      if (result.completedOperationSequence >= operationSequence && (tree.frameSequence ?? 0) > completionFrame) return result;
       await sleep(5);
       const status = await this.request<{
         schemaVersion: number;
@@ -796,7 +796,7 @@ class GuaBridgeClient {
         defaultStepMs: number;
         pendingMs: number;
         generation: number;
-        completedOperationSequence?: number;
+        completedOperationSequence: number;
       }>({ type: "get_clock" });
       result = { ...result, ...status };
     }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -772,17 +772,19 @@ class GuaBridgeClient {
   async controlClock(command: { type: "clock_install"; initialTimeMs?: number; stepMs?: number } |
     { type: "clock_run_for"; durationMs: number; stepMs?: number } | { type: "clock_pause" | "clock_resume" }): Promise<unknown>
   {
-    let result = await this.request<{ pendingMs?: number }>(command);
+    let result = await this.request<{ pendingMs?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number }>(command);
     if (command.type !== "clock_run_for") return result;
-    const before = await this.getUiTree();
-    const beforeFrameSequence = before.frameSequence ?? 0;
+    const completionEpoch = result.completionSessionEpoch;
+    const completionFrame = result.completionAfterFrameSequence;
+    if (completionEpoch === undefined || completionFrame === undefined) throw new Error("unsupported");
     const started = Date.now();
     while (Date.now() - started < 10000) {
       const tree = await this.getUiTree();
-      if (tree.sessionEpoch !== before.sessionEpoch) throw new Error("stale_session");
-      if ((result.pendingMs ?? 0) <= 0 && (tree.frameSequence ?? 0) > beforeFrameSequence) return result;
+      if (tree.sessionEpoch !== completionEpoch) throw new Error("stale_session");
+      if ((result.pendingMs ?? 0) <= 0 && (tree.frameSequence ?? 0) > completionFrame) return result;
       await sleep(5);
-      result = await this.request<{ pendingMs: number }>({ type: "get_clock" });
+      const status = await this.request<{ pendingMs: number }>({ type: "get_clock" });
+      result = { ...result, pendingMs: status.pendingMs };
     }
     throw new Error("Timed out waiting for Gua clock run_for host completion.");
   }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -127,6 +127,11 @@ export const guaMcpTools = [
   "wait_for_node",
   "get_screenshot",
   "get_logs",
+  "get_clock",
+  "clock_install",
+  "clock_pause",
+  "clock_run_for",
+  "clock_resume",
   "start_recording",
   "stop_recording",
   "save_recording",
@@ -223,6 +228,15 @@ const tools: McpTool[] = [
     description: "Read ordered runtime logs from the running game bridge.",
     inputSchema: objectSchema({}),
   },
+  { name: "get_clock", description: "Read the opt-in Gua virtual clock state.", inputSchema: objectSchema({}) },
+  { name: "clock_install", description: "Install the Gua virtual clock in running state.", inputSchema: objectSchema({
+    initialTimeMs: { type: "number", minimum: 0 }, stepMs: { type: "number", exclusiveMinimum: 0 },
+  }) },
+  { name: "clock_pause", description: "Pause work explicitly driven by GuaClock.", inputSchema: objectSchema({}) },
+  { name: "clock_run_for", description: "Advance a paused GuaClock without waiting for wall time.", inputSchema: objectSchema({
+    durationMs: { type: "number", minimum: 0 }, stepMs: { type: "number", exclusiveMinimum: 0 },
+  }, ["durationMs"]) },
+  { name: "clock_resume", description: "Resume real-time advancement of GuaClock.", inputSchema: objectSchema({}) },
   {
     name: "start_recording",
     description: "Start recording semantic actions invoked through this MCP server.",
@@ -489,6 +503,16 @@ async function executeTool(
       return bridge.getScreenshot();
     case "get_logs":
       return bridge.getLogs();
+    case "get_clock":
+      return bridge.getClock();
+    case "clock_install":
+      return bridge.controlClock({ type: "clock_install", initialTimeMs: readNumberArg(args, "initialTimeMs", 0), stepMs: readOptionalNumberArg(args, "stepMs") });
+    case "clock_pause":
+      return bridge.controlClock({ type: "clock_pause" });
+    case "clock_run_for":
+      return bridge.controlClock({ type: "clock_run_for", durationMs: readNumberArg(args, "durationMs", 0), stepMs: readOptionalNumberArg(args, "stepMs") });
+    case "clock_resume":
+      return bridge.controlClock({ type: "clock_resume" });
     case "start_recording":
       return { ...automation.startRecording(), artifactDirectory: automation.artifactRoot };
     case "stop_recording": {
@@ -744,6 +768,22 @@ class GuaBridgeClient {
     return this.request<GuaScreenshot>({ type: "get_screenshot" });
   }
 
+  async getClock(): Promise<unknown> { return this.request({ type: "get_clock" }); }
+  async controlClock(command: { type: "clock_install"; initialTimeMs?: number; stepMs?: number } |
+    { type: "clock_run_for"; durationMs: number; stepMs?: number } | { type: "clock_pause" | "clock_resume" }): Promise<unknown>
+  {
+    const result = await this.request<{ pendingMs?: number }>(command);
+    if (command.type !== "clock_run_for") return result;
+    const started = Date.now();
+    while ((result.pendingMs ?? 0) > 0 && Date.now() - started < 10000) {
+      await sleep(5);
+      const status = await this.request<{ pendingMs: number }>({ type: "get_clock" });
+      if (status.pendingMs <= 0) return status;
+    }
+    if ((result.pendingMs ?? 0) > 0) throw new Error("Timed out waiting for Gua clock run_for completion.");
+    return result;
+  }
+
   async performAction(input: SemanticActionInput): Promise<GuaActionReceipt | null> {
     const type = actionCommandType(input.action);
     return this.request<GuaActionReceipt | null>(compactResult({
@@ -898,6 +938,9 @@ type BridgeCommandInput =
   | { type: "get_logs" }
   | { type: "get_screenshot" }
   | { type: "poll_events"; requestId: number }
+  | { type: "get_clock" | "clock_pause" | "clock_resume" }
+  | { type: "clock_install"; initialTimeMs?: number; stepMs?: number }
+  | { type: "clock_run_for"; durationMs: number; stepMs?: number }
   | {
       type: "click_node" | "focus_node" | "set_value" | "set_checked" | "select" | "scroll" | "press_key";
       nodeId?: string;
@@ -986,6 +1029,13 @@ function readIntegerArg(args: Record<string, unknown>, name: string, fallback: n
 function readNumberArg(args: Record<string, unknown>, name: string, fallback: number): number {
   const value = args[name];
   if (value === undefined) return fallback;
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`Expected finite number argument: ${name}`);
+  return value;
+}
+
+function readOptionalNumberArg(args: Record<string, unknown>, name: string): number | undefined {
+  const value = args[name];
+  if (value === undefined) return undefined;
   if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`Expected finite number argument: ${name}`);
   return value;
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -772,16 +772,17 @@ class GuaBridgeClient {
   async controlClock(command: { type: "clock_install"; initialTimeMs?: number; stepMs?: number } |
     { type: "clock_run_for"; durationMs: number; stepMs?: number } | { type: "clock_pause" | "clock_resume" }): Promise<unknown>
   {
-    let result = await this.request<{ pendingMs?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number }>(command);
+    let result = await this.request<{ pendingMs?: number; completedOperationSequence?: number; operationSequence?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number }>(command);
     if (command.type !== "clock_run_for") return result;
     const completionEpoch = result.completionSessionEpoch;
     const completionFrame = result.completionAfterFrameSequence;
-    if (completionEpoch === undefined || completionFrame === undefined) throw new Error("unsupported");
+    const operationSequence = result.operationSequence;
+    if (completionEpoch === undefined || completionFrame === undefined || operationSequence === undefined) throw new Error("unsupported");
     const started = Date.now();
     while (Date.now() - started < 10000) {
       const tree = await this.getUiTree();
       if (tree.sessionEpoch !== completionEpoch) throw new Error("stale_session");
-      if ((result.pendingMs ?? 0) <= 0 && (tree.frameSequence ?? 0) > completionFrame) return result;
+      if ((result.completedOperationSequence ?? 0) >= operationSequence && (tree.frameSequence ?? 0) > completionFrame) return result;
       await sleep(5);
       const status = await this.request<{
         schemaVersion: number;
@@ -791,6 +792,7 @@ class GuaBridgeClient {
         defaultStepMs: number;
         pendingMs: number;
         generation: number;
+        completedOperationSequence?: number;
       }>({ type: "get_clock" });
       result = { ...result, ...status };
     }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -106,6 +106,11 @@ interface GuaActionEvent {
   revision: number;
 }
 
+interface GuaContextStatus {
+  sessionEpoch: number;
+  frameSequence: number;
+}
+
 type BridgeResult = unknown;
 
 export interface GuaMcpServerOptions {
@@ -769,6 +774,10 @@ class GuaBridgeClient {
     return this.request<GuaScreenshot>({ type: "get_screenshot" });
   }
 
+  async getContextStatus(): Promise<GuaContextStatus> {
+    return this.request<GuaContextStatus>({ type: "get_context_status" });
+  }
+
   async getClock(): Promise<unknown> { return this.request({ type: "get_clock" }); }
   async controlClock(command: { type: "clock_install"; initialTimeMs?: number; stepMs?: number } |
     { type: "clock_run_for"; durationMs: number; stepMs?: number } | { type: "clock_pause" | "clock_resume" }): Promise<unknown>
@@ -784,9 +793,9 @@ class GuaBridgeClient {
     if (completionEpoch === undefined || completionFrame === undefined || operationSequence === undefined) throw new Error("unsupported");
     const started = Date.now();
     while (Date.now() - started < 10000) {
-      const tree = await this.getUiTree();
-      if (tree.sessionEpoch !== completionEpoch) throw new Error("stale_session");
-      if (result.completedOperationSequence >= operationSequence && (tree.frameSequence ?? 0) > completionFrame) return result;
+      const context = await this.getContextStatus();
+      if (context.sessionEpoch !== completionEpoch) throw new Error("stale_session");
+      if (result.completedOperationSequence >= operationSequence && context.frameSequence > completionFrame) return result;
       await sleep(5);
       const status = await this.request<{
         schemaVersion: number;
@@ -956,6 +965,7 @@ type BridgeCommandInput =
   | { type: "get_ui_tree" }
   | { type: "get_logs" }
   | { type: "get_screenshot" }
+  | { type: "get_context_status" }
   | { type: "poll_events"; requestId: number }
   | { type: "get_clock" | "clock_pause" | "clock_resume" }
   | { type: "clock_install"; initialTimeMs?: number; stepMs?: number }

--- a/packages/mcp/test/automation.test.ts
+++ b/packages/mcp/test/automation.test.ts
@@ -22,6 +22,8 @@ describe("GuaAutomationManager", () => {
     expect(guaMcpTools).toContain("replay_recording");
     expect(guaMcpTools).toContain("compare_screenshot");
     expect(guaMcpTools).toContain("get_visual_artifacts");
+    expect(guaMcpTools).toContain("clock_pause");
+    expect(guaMcpTools).toContain("clock_run_for");
   });
 
   test("records, redacts, saves, and reloads semantic operations", async () => {

--- a/packages/mcp/test/automation.test.ts
+++ b/packages/mcp/test/automation.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { PNG } from "pngjs";
 
 import { GuaAutomationManager } from "../src/automation";
-import { guaMcpTools } from "../src/index";
+import { guaMcpTools, parseClockRunForArguments } from "../src/index";
 
 const roots: string[] = [];
 
@@ -15,6 +15,15 @@ afterEach(async () => {
 });
 
 describe("GuaAutomationManager", () => {
+  test("rejects clock_run_for without its required duration", () => {
+    expect(() => parseClockRunForArguments({})).toThrow("durationMs");
+    expect(parseClockRunForArguments({ durationMs: 25 })).toEqual({
+      type: "clock_run_for",
+      durationMs: 25,
+      stepMs: undefined,
+    });
+  });
+
   test("publishes the AI recording and visual tool surface", () => {
     expect(guaMcpTools).toContain("start_recording");
     expect(guaMcpTools).toContain("stop_recording");

--- a/protocol/fixtures/clock-v1.json
+++ b/protocol/fixtures/clock-v1.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "installed": true,
+  "state": "paused",
+  "nowMs": 2000,
+  "defaultStepMs": 16.666667,
+  "pendingMs": 0,
+  "generation": 1
+}

--- a/protocol/fixtures/clock-v1.json
+++ b/protocol/fixtures/clock-v1.json
@@ -5,5 +5,6 @@
   "nowMs": 2000,
   "defaultStepMs": 16.666667,
   "pendingMs": 0,
-  "generation": 1
+  "generation": 1,
+  "completedOperationSequence": 0
 }

--- a/protocol/schema/clock.schema.json
+++ b/protocol/schema/clock.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://gua.dev/schema/clock.schema.json",
   "title": "Gua Virtual Clock Status",
   "type": "object",
-  "required": ["schemaVersion", "installed", "state", "nowMs", "defaultStepMs", "pendingMs", "generation"],
+  "required": ["schemaVersion", "installed", "state", "nowMs", "defaultStepMs", "pendingMs", "generation", "completedOperationSequence"],
   "additionalProperties": false,
   "properties": {
     "schemaVersion": { "const": 1 },

--- a/protocol/schema/clock.schema.json
+++ b/protocol/schema/clock.schema.json
@@ -13,6 +13,8 @@
     "defaultStepMs": { "type": "number", "exclusiveMinimum": 0 },
     "pendingMs": { "type": "number", "minimum": 0 },
     "generation": { "type": "integer", "minimum": 0 },
+    "completedOperationSequence": { "type": "integer", "minimum": 0 },
+    "operationSequence": { "type": "integer", "minimum": 1 },
     "completionSessionEpoch": { "type": "integer", "minimum": 1 },
     "completionAfterFrameSequence": { "type": "integer", "minimum": 0 }
   }

--- a/protocol/schema/clock.schema.json
+++ b/protocol/schema/clock.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gua.dev/schema/clock.schema.json",
+  "title": "Gua Virtual Clock Status",
+  "type": "object",
+  "required": ["schemaVersion", "installed", "state", "nowMs", "defaultStepMs", "pendingMs", "generation"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "installed": { "type": "boolean" },
+    "state": { "enum": ["running", "paused"] },
+    "nowMs": { "type": "number", "minimum": 0 },
+    "defaultStepMs": { "type": "number", "exclusiveMinimum": 0 },
+    "pendingMs": { "type": "number", "minimum": 0 },
+    "generation": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/protocol/schema/clock.schema.json
+++ b/protocol/schema/clock.schema.json
@@ -12,6 +12,8 @@
     "nowMs": { "type": "number", "minimum": 0 },
     "defaultStepMs": { "type": "number", "exclusiveMinimum": 0 },
     "pendingMs": { "type": "number", "minimum": 0 },
-    "generation": { "type": "integer", "minimum": 0 }
+    "generation": { "type": "integer", "minimum": 0 },
+    "completionSessionEpoch": { "type": "integer", "minimum": 1 },
+    "completionAfterFrameSequence": { "type": "integer", "minimum": 0 }
   }
 }

--- a/protocol/schema/commands.schema.json
+++ b/protocol/schema/commands.schema.json
@@ -107,6 +107,7 @@
         "type": { "const": "reset_context" },
         "expectedSessionEpoch": { "type": "integer", "minimum": 1 },
         "flags": { "type": "integer", "minimum": 0, "maximum": 127, "default": 79 },
+        "flagsVersion": { "const": 1 },
         "strict": { "type": "boolean", "default": false }
       }
     },

--- a/protocol/schema/commands.schema.json
+++ b/protocol/schema/commands.schema.json
@@ -12,6 +12,8 @@
     { "$ref": "#/$defs/scrollAction" },
     { "$ref": "#/$defs/resetContext" },
     { "$ref": "#/$defs/captureScreenshot" },
+    { "$ref": "#/$defs/clockInstall" },
+    { "$ref": "#/$defs/clockRunFor" },
     { "$ref": "#/$defs/textInput" },
     { "$ref": "#/$defs/moveGamepad" },
     { "$ref": "#/$defs/simpleCommand" }
@@ -104,7 +106,7 @@
       "properties": {
         "type": { "const": "reset_context" },
         "expectedSessionEpoch": { "type": "integer", "minimum": 1 },
-        "flags": { "type": "integer", "minimum": 0, "maximum": 63, "default": 15 },
+        "flags": { "type": "integer", "minimum": 0, "maximum": 127, "default": 79 },
         "strict": { "type": "boolean", "default": false }
       }
     },
@@ -116,6 +118,26 @@
         "type": { "const": "capture_screenshot" },
         "afterFrameSequence": { "type": ["integer", "null"], "minimum": 0 },
         "timeoutMs": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "clockInstall": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "clock_install" },
+        "initialTimeMs": { "type": "number", "minimum": 0, "default": 0 },
+        "stepMs": { "type": "number", "exclusiveMinimum": 0 }
+      }
+    },
+    "clockRunFor": {
+      "type": "object",
+      "required": ["type", "durationMs"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "clock_run_for" },
+        "durationMs": { "type": "number", "minimum": 0 },
+        "stepMs": { "type": "number", "exclusiveMinimum": 0 }
       }
     },
     "textInput": {
@@ -143,7 +165,7 @@
       "additionalProperties": false,
       "properties": {
         "type": {
-          "enum": ["get_screenshot", "get_logs", "get_diagnostics", "get_version", "get_context_status", "poll_events"]
+          "enum": ["get_screenshot", "get_logs", "get_diagnostics", "get_version", "get_context_status", "poll_events", "get_clock", "clock_pause", "clock_resume"]
         }
       }
     }

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -61,8 +61,10 @@ so sensitive values cannot leak through teardown diagnostics.
 Reset is scoped to one `gua_context_t` / `gua_runtime_t`; it does not use global
 state and cannot affect another context. The selectable flags are nodes (1),
 requests (2), events (4), retained diagnostic history (8), logs (16), and
-screenshot (32). The default is 15: nodes, requests, events, and history are
-cleared, while logs and screenshot are preserved unless explicitly selected.
+screenshot (32), and virtual clock state and pending work (64). The default is
+79: nodes, requests, events, history, and clock state are cleared, while logs
+and screenshot are preserved unless explicitly selected. Resetting the clock
+also advances its generation so language wrappers can discard old schedules.
 Bridge server, port, active WebSocket connections, and context configuration are
 never reset.
 
@@ -233,12 +235,17 @@ Commands are external automation requests.
 control the opt-in Gua virtual clock. Installation starts at `initialTimeMs` (zero
 by default) in the running state. `clock_run_for` is accepted only while paused,
 advances in `stepMs` slices (the installed default when omitted), and remains
-paused. Clock time is monotonic and context reset invalidates pending steps.
+paused. Clock time is monotonic, so installing an already installed clock is
+rejected with `invalid_state`; reset the context before starting a new timeline.
+Context reset also invalidates pending steps.
 
 Only work explicitly scheduled on GuaClock or subscribed to its tick stream is
 controlled. Engine time, physics, animations, audio, OS time, network time, and
-engine-native timers are outside this capability. Adapters must continue their
-unscaled bridge pump while the Gua clock is paused. Capability
+engine-native timers are outside this capability. `clock_install` activates the
+shared virtual clock but does not hook or replace those native time sources.
+Game and adapter code must explicitly use GuaClock as the time source for every
+subsystem that needs to be controlled. Adapters must continue their unscaled
+bridge pump while the Gua clock is paused. Capability
 `virtual_clock_v1` advertises support.
 
 Initial command types:

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -68,12 +68,22 @@ also advances its generation so language wrappers can discard old schedules.
 Bridge server, port, active WebSocket connections, and context configuration are
 never reset.
 
+The published C ABI constant `GUA_RESET_DEFAULT` retains its original value 15.
+Current native callers use `GUA_RESET_DEFAULT_V2` (79) and set
+`gua_reset_options_t.flags_version` to `GUA_RESET_FLAGS_VERSION_CURRENT`.
+For binary compatibility, the runtime recognizes an older reset-options struct
+or legacy flags version and upgrades the exact legacy Default (15) and All (63)
+masks to include the clock. Current-version explicit masks are never upgraded.
+
 Strict reset checks selected request/event queues before mutation. If pending,
 in-flight, or unconsumed state exists, it returns `dirty` with counts and a
 redacted first-item summary and changes nothing. Non-strict reset reports how
 many selected items it discarded. Every successful reset increments
 `sessionEpoch`; local callers may pass zero to use the current epoch, but remote
-`reset_context` commands must provide `expectedSessionEpoch`. A stale remote
+`reset_context` commands must provide `expectedSessionEpoch`. Current clients
+that provide `flags` also send `flagsVersion: 1`; omitted flags still resolve to
+the current default 79. A missing `flagsVersion` marks an older client, so exact
+legacy Default (15) and All (63) masks are upgraded to include the clock. A stale remote
 epoch is rejected without mutation. Multiple clients of one runtime observe the
 same reset because the isolation boundary is the shared runtime context, not a
 WebSocket connection. Runtime-owned on-demand screenshot requests, in-flight

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -254,7 +254,9 @@ queued. Consumers wait for both `pendingMs` to reach zero and a semantic frame
 whose sequence is greater than that correlated boundary, because consuming the
 final core step precedes adapter callbacks, tick delivery, and frame publication.
 An explicitly supplied `stepMs` must be positive; only an absent field selects
-the installed default. A remote `clock_pause` is acknowledged only after any
+the installed default. A positive duration or step that cannot advance the
+clock's finite-precision timeline is rejected with `invalid_duration` rather
+than consuming work without changing `nowMs`. A remote `clock_pause` is acknowledged only after any
 already queued running advance has been consumed and its host frame published;
 the lower-level C ABI reports `invalid_state` if pause is attempted while such
 work is still pending.

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -245,8 +245,12 @@ engine-native timers are outside this capability. `clock_install` activates the
 shared virtual clock but does not hook or replace those native time sources.
 Game and adapter code must explicitly use GuaClock as the time source for every
 subsystem that needs to be controlled. Adapters must continue their unscaled
-bridge pump while the Gua clock is paused. Capability
-`virtual_clock_v1` advertises support.
+bridge pump while the Gua clock is paused. An adapter must opt in to capability
+`virtual_clock_v1` only after it implements that pump and consumes every clock
+step; a bare runtime bridge does not advertise the capability. Remote
+`clock_run_for` consumers wait for both `pendingMs` to reach zero and a semantic
+frame published after the command response, because consuming the final core
+step precedes adapter callbacks, tick delivery, and frame publication.
 
 Initial command types:
 

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -227,6 +227,20 @@ recording v1 redaction rule.
 
 Commands are external automation requests.
 
+### Virtual clock (v1)
+
+`clock_install`, `clock_pause`, `clock_run_for`, `clock_resume`, and `get_clock`
+control the opt-in Gua virtual clock. Installation starts at `initialTimeMs` (zero
+by default) in the running state. `clock_run_for` is accepted only while paused,
+advances in `stepMs` slices (the installed default when omitted), and remains
+paused. Clock time is monotonic and context reset invalidates pending steps.
+
+Only work explicitly scheduled on GuaClock or subscribed to its tick stream is
+controlled. Engine time, physics, animations, audio, OS time, network time, and
+engine-native timers are outside this capability. Adapters must continue their
+unscaled bridge pump while the Gua clock is paused. Capability
+`virtual_clock_v1` advertises support.
+
 Initial command types:
 
 - `get_ui_tree`

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -248,9 +248,16 @@ subsystem that needs to be controlled. Adapters must continue their unscaled
 bridge pump while the Gua clock is paused. An adapter must opt in to capability
 `virtual_clock_v1` only after it implements that pump and consumes every clock
 step; a bare runtime bridge does not advertise the capability. Remote
-`clock_run_for` consumers wait for both `pendingMs` to reach zero and a semantic
-frame published after the command response, because consuming the final core
-step precedes adapter callbacks, tick delivery, and frame publication.
+`clock_run_for` responses include `completionSessionEpoch` and
+`completionAfterFrameSequence`, captured atomically when the operation is
+queued. Consumers wait for both `pendingMs` to reach zero and a semantic frame
+whose sequence is greater than that correlated boundary, because consuming the
+final core step precedes adapter callbacks, tick delivery, and frame publication.
+An explicitly supplied `stepMs` must be positive; only an absent field selects
+the installed default. A remote `clock_pause` is acknowledged only after any
+already queued running advance has been consumed and its host frame published;
+the lower-level C ABI reports `invalid_state` if pause is attempted while such
+work is still pending.
 
 Initial command types:
 

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -248,11 +248,13 @@ subsystem that needs to be controlled. Adapters must continue their unscaled
 bridge pump while the Gua clock is paused. An adapter must opt in to capability
 `virtual_clock_v1` only after it implements that pump and consumes every clock
 step; a bare runtime bridge does not advertise the capability. Remote
-`clock_run_for` responses include `completionSessionEpoch` and
-`completionAfterFrameSequence`, captured atomically when the operation is
-queued. Consumers wait for both `pendingMs` to reach zero and a semantic frame
-whose sequence is greater than that correlated boundary, because consuming the
-final core step precedes adapter callbacks, tick delivery, and frame publication.
+`clock_run_for` responses include `operationSequence`, `completionSessionEpoch`,
+and `completionAfterFrameSequence`, captured atomically when the operation is
+queued. After consuming the final step, the core acknowledges that operation
+sequence on the adapter's next successfully published semantic frame. Consumers
+wait for `completedOperationSequence` to reach their own operation sequence and
+for the semantic frame to pass the correlated boundary. They do not use global
+`pendingMs` as completion evidence because it may belong to a later client run.
 An explicitly supplied `stepMs` must be positive; only an absent field selects
 the installed default. A positive duration or step that cannot advance the
 clock's finite-precision timeline is rejected with `invalid_duration` rather


### PR DESCRIPTION
## Summary

- Add an opt-in deterministic virtual clock to the native C ABI and C++ wrapper
- Expose clock install, pause, run-for, resume, status, and step consumption APIs to .NET, Godot, Unity, MCP, and Inspector consumers
- Add clock scheduling and tick support to testing contexts and the Godot adapter
- Reset clock state with the default context reset and document usage in English and Japanese READMEs

## Testing

- Extended native state model tests to cover clock lifecycle, stepped execution, status reporting, and reset behavior
- Not run (not requested)