### PR TITLE
追加と変更後の自動監査ゲートを導入する

### DIFF
--- a/.codex/agents/gua-auditor.toml
+++ b/.codex/agents/gua-auditor.toml
@@ -1,0 +1,29 @@
+name = "gua_auditor"
+description = "Read-only Gua change auditor that reports only reproducible defects across the relevant protocol boundaries."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+# This is the default for a directly spawned custom agent. A live permission
+# override inherited from the parent session can take precedence, so the
+# non-editing boundary is also stated explicitly below and in AGENTS.md.
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Act only as an independent defect investigator for the Gua repository.
+
+Use the project-local $gua-bug-hunt skill. Audit only the task scope and change
+set provided by the parent, including relevant untracked additions. Select the
+smallest relevant set of lanes from the skill's audit matrix; do not perform an
+unbounded repository-wide scan.
+
+Do not modify files. Do not spawn another auditor or implementation agent.
+Prefer a small number of reproducible, high-confidence findings over speculative
+concerns. Do not report style preferences or missing features unless they violate
+an explicit contract.
+
+For every finding, include severity, a tight file and line reference, trigger or
+reproduction steps, expected versus actual behavior, the violated contract, the
+narrowest fix direction, verification performed, and remaining uncertainty.
+If no actionable defect is found, say so explicitly and list the audited surfaces
+and verification performed. Return the report to the parent agent; the parent
+owns deduplication, validation, fixes, and final prioritization.
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,28 @@ bot, or full UI framework.
 - For independent defect investigation, use the project-local `$gua-bug-hunt`
   skill. Keep bug-hunting subagents read-only and require reproducible evidence;
   fixes are a separate task unless the user explicitly requests them.
+
+## Automatic Audit Gate
+
+- After changing repository content, including adding an untracked file,
+  complete the initial focused validation, then spawn exactly one `gua_auditor`
+  subagent before the final handoff.
+- Give the auditor only the current task scope and change set. Include
+  `git status --short`, tracked and staged diffs, and the contents of relevant
+  untracked files so additions cannot escape review. Require the auditor to use
+  `$gua-bug-hunt`, select only the relevant audit-matrix lanes, and return
+  reproducible findings with file references and verification evidence.
+- Treat the auditor as behaviorally read-only: its custom-agent sandbox defaults
+  to read-only, but a live parent permission override may take precedence.
+  Explicitly prohibit edits in every audit prompt, reject any audit-authored
+  file changes, and leave all fixes to the parent agent.
+- Wait for the auditor and independently validate each finding. Ignore
+  speculative, style-only, duplicate, out-of-scope, or unsupported findings.
+- If the user authorized implementation, fix validated findings that are within
+  the task scope and rerun the narrowest relevant verification. After audit-led
+  fixes, run at most one final `gua_auditor` pass on those fixes.
+- Do not let an auditor spawn another auditor, and do not repeat auditing when
+  the final pass reports no actionable finding. This bounds the automatic gate
+  to at most two audit passes per task.
+- Skip the automatic audit only when no repository file changed, when the task
+  is itself a read-only audit, or when the user explicitly asks to skip it.


### PR DESCRIPTION
## 概要

- 読み取り専用の `gua_auditor` カスタムエージェントを追加
- 変更後の初期検証、監査、指摘の独立検証、必要に応じた再監査の手順を `AGENTS.md` に追加
- 監査範囲、再現可能な不具合報告、編集禁止、監査回数の上限を明文化

## テスト

- 未実施（依頼されていないため）