### PR TITLE
累積差分を対象とするローカルPR監査を追加

### DIFF
--- a/.codex/agents/gua-auditor.toml
+++ b/.codex/agents/gua-auditor.toml
@@ -1,7 +1,7 @@
 name = "gua_auditor"
-description = "Read-only Gua change auditor that reports only reproducible defects across the relevant protocol boundaries."
-model = "gpt-5.6-terra"
-model_reasoning_effort = "high"
+description = "Read-only Gua cumulative-diff auditor that reports only reproducible defects across the relevant protocol boundaries."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "max"
 # This is the default for a directly spawned custom agent. A live permission
 # override inherited from the parent session can take precedence, so the
 # non-editing boundary is also stated explicitly below and in AGENTS.md.
@@ -10,10 +10,10 @@ sandbox_mode = "read-only"
 developer_instructions = """
 Act only as an independent defect investigator for the Gua repository.
 
-Use the project-local $gua-bug-hunt skill. Audit only the task scope and change
-set provided by the parent, including relevant untracked additions. Select the
-smallest relevant set of lanes from the skill's audit matrix; do not perform an
-unbounded repository-wide scan.
+Use the project-local $gua-bug-hunt skill. Audit the task scope and the complete
+cumulative branch diff against the base supplied by the parent, including
+relevant untracked additions. Select every lane touched by that diff, while
+keeping unchanged repository surfaces out of scope.
 
 Do not modify files. Do not spawn another auditor or implementation agent.
 Prefer a small number of reproducible, high-confidence findings over speculative

--- a/.codex/skills/gua-bug-hunt/references/audit-matrix.md
+++ b/.codex/skills/gua-bug-hunt/references/audit-matrix.md
@@ -14,6 +14,7 @@ Select only lanes touched by the requested component or diff.
 | MCP | `packages/mcp` | tool/schema mismatch, unsupported command claims, timeouts, lost bridge errors |
 | Inspector | `packages/inspector` | stale push/poll ordering, incorrect node state rendering, reconnect state leaks |
 | Visual/recording | `Gua.Testing.Visual`, screenshot and recording schemas | implicit resize, mask denominator errors, secret retention, nondeterministic replay |
+| Game input | game-input schemas, core/runtime queues, engine input adapters, MCP, Inspector, recording | owner cleanup gaps, lease escape, consume/complete races, device-index drift, unsupported advertised codes, confirmation bypass |
 
 ## Cross-boundary invariants
 
@@ -27,6 +28,15 @@ Select only lanes touched by the requested component or diff.
 - Adapter-owned reflection follows the host UI rather than manual semantic
   restatement.
 - MCP and Inspector do not own runtime state.
+- Game input is owner-bound and lease-bounded; disconnect, dispose, reset, and
+  expiry neutralize held state without destroying already-consumed requests'
+  correlated completion path.
+- Common metadata, current policy, confirmation, capability, and Action Map
+  authorization are checked at consumption or dispatch, including specialized
+  game-input paths.
+- Advertised W3C keyboard codes, pointer controls, gamepad controls, and device
+  indexes have one consistent contract across schemas, validators, adapters,
+  Inspector, MCP, and recording.
 
 ## Bounded verification menu
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,16 +42,42 @@ bot, or full UI framework.
   skill. Keep bug-hunting subagents read-only and require reproducible evidence;
   fixes are a separate task unless the user explicitly requests them.
 
+## Code Review Rules
+
+- Review the cumulative branch diff against its merge base, not only the most
+  recent task or commit. A fix can expose a defect in an older part of the same
+  pull request.
+- For cross-boundary changes, trace the affected contract from `protocol/`
+  through the C ABI, managed bindings, engine adapters, bridge, MCP, Inspector,
+  recording, and tests. Do not assume that matching type names prove matching
+  behavior.
+- Reauthorize owner-, session-, visibility-, capability-, and confirmation-bound
+  operations at the point where the host consumes them. Enqueue-time validation
+  is not sufficient across disconnect, reset, policy, or Action Map changes.
+- Owner cleanup must neutralize held input on disconnect, dispose, reset, and
+  lease expiry. A consumed request must retain a completion path even if its
+  owner disconnects before the host reports completion.
+- Validate common request metadata before dispatching to command-specific paths;
+  an early return must not bypass epoch, timing, cancellation, or correlation
+  checks.
+- Publicly advertised keyboard, pointer, gamepad, action, and capability values
+  must be accepted consistently or rejected consistently at every boundary.
+- Preserve request correlation and one-shot bounded result retention. Never let
+  cleanup, polling, or one client consume another request's completion.
+- Keep sensitive input out of logs, diagnostics, errors, recordings, and review
+  artifacts while preserving safe replay references.
+
 ## Automatic Audit Gate
 
 - After changing repository content, including adding an untracked file,
   complete the initial focused validation, then spawn exactly one `gua_auditor`
   subagent before the final handoff.
-- Give the auditor only the current task scope and change set. Include
-  `git status --short`, tracked and staged diffs, and the contents of relevant
-  untracked files so additions cannot escape review. Require the auditor to use
-  `$gua-bug-hunt`, select only the relevant audit-matrix lanes, and return
-  reproducible findings with file references and verification evidence.
+- Give the auditor the current task scope plus the cumulative branch diff against
+  the intended base branch. Include `git status --short`, tracked and staged
+  diffs, and the contents of relevant untracked files so additions cannot escape
+  review. Require the auditor to use `$gua-bug-hunt`, select every audit-matrix
+  lane touched by that cumulative diff, and return reproducible findings with
+  file references and verification evidence.
 - Treat the auditor as behaviorally read-only: its custom-agent sandbox defaults
   to read-only, but a live parent permission override may take precedence.
   Explicitly prohibit edits in every audit prompt, reject any audit-authored
@@ -65,4 +91,11 @@ bot, or full UI framework.
   the final pass reports no actionable finding. This bounds the automatic gate
   to at most two audit passes per task.
 - Skip the automatic audit only when no repository file changed, when the task
-  is itself a read-only audit, or when the user explicitly asks to skip it.
+  is itself a read-only audit, when running as the fix phase inside
+  `scripts/run-local-pr-audit.ps1` (the outer loop owns re-audit), or when the
+  user explicitly asks to skip it.
+
+For a deliberate pull-request-wide gate, run
+`scripts/run-local-pr-audit.ps1 -Base origin/main`. Add `-Fix` to let a parent
+Codex validate findings, apply only supported fixes, run focused checks, and
+repeat the full review for at most four passes.

--- a/docs/bug-hunting-subagent.md
+++ b/docs/bug-hunting-subagent.md
@@ -17,3 +17,33 @@ Good delegation scopes are one changed diff, one protocol path, or one adapter.
 For cross-language work, divide by independent boundary (for example core ABI,
 WebSocket/MCP, and Godot) and let the parent agent deduplicate findings. The
 subagent must not edit product files; fixes remain a separate, explicit task.
+
+## Pull-request-wide local audit
+
+The bounded subagent gate runs after ordinary repository edits. Before handing
+off a large pull request, use the dedicated cumulative-diff harness from the PR
+branch or its worktree:
+
+```powershell
+git fetch origin main
+./scripts/run-local-pr-audit.ps1 -Base origin/main
+```
+
+This runs one dedicated cumulative `codex review` plus three independent,
+read-only Gua boundary reviews covering protocol/core, engine adapters, and
+protocol consumers. If the worktree is dirty, the dedicated reviewer also runs
+the uncommitted-change preset so staged, unstaged, and untracked fixes are not
+lost between passes. Reports are written under the system temporary directory
+rather than the repository.
+
+To validate findings, apply supported fixes, run focused verification, and
+repeat the complete audit until no files change or four passes finish:
+
+```powershell
+./scripts/run-local-pr-audit.ps1 -Base origin/main -Fix
+```
+
+Use `-Sequential` if the host cannot sustain four concurrent Codex sessions.
+The harness never commits, pushes, or posts review comments. Exact parity with
+the GitHub Connector is not guaranteed because its private prompt and runtime
+configuration are not available locally.

--- a/scripts/run-local-pr-audit.ps1
+++ b/scripts/run-local-pr-audit.ps1
@@ -1,0 +1,324 @@
+[CmdletBinding()]
+param(
+    [string]$Base = "origin/main",
+    [ValidateRange(1, 4)]
+    [int]$MaxPasses = 4,
+    [string]$Model = "gpt-5.6-sol",
+    [ValidateSet("high", "xhigh", "max", "ultra")]
+    [string]$ReasoningEffort = "max",
+    [switch]$Fix,
+    [switch]$Sequential
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Invoke-Git {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+
+    $output = & git @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed:`n$($output -join [Environment]::NewLine)"
+    }
+    return $output
+}
+
+function Get-WorkspaceFingerprint {
+    $status = @(Invoke-Git status --porcelain=v1 --untracked-files=all)
+    $untracked = @(Invoke-Git ls-files --others --exclude-standard)
+    $payload = [System.Collections.Generic.List[string]]::new()
+    $payload.AddRange([string[]]$status)
+    $payload.AddRange([string[]]@(Invoke-Git diff --binary HEAD))
+    $payload.AddRange([string[]]@(Invoke-Git diff --binary --cached HEAD))
+
+    foreach ($path in $untracked) {
+        $payload.Add("untracked:$path")
+        $payload.AddRange([string[]]@(Invoke-Git hash-object -- $path))
+    }
+
+    $bytes = [Text.Encoding]::UTF8.GetBytes(($payload -join "`n"))
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    try {
+        $hash = $sha256.ComputeHash($bytes)
+    }
+    finally {
+        $sha256.Dispose()
+    }
+    return ([BitConverter]::ToString($hash)).Replace("-", "")
+}
+
+function Invoke-Reviewer {
+    param(
+        [hashtable]$Reviewer,
+        [string]$OutputPath
+    )
+
+    if ($Reviewer.Kind -eq "Dedicated") {
+        $head = (Invoke-Git rev-parse HEAD | Select-Object -First 1).Trim()
+        $mergeBase = (Invoke-Git merge-base HEAD $Base | Select-Object -First 1).Trim()
+        $output = @()
+        $exitCode = 0
+        if ($head -ne $mergeBase) {
+            $arguments = @(
+                "review", "--base", $Base,
+                "-c", "model=`"$Model`"",
+                "-c", "model_reasoning_effort=`"$ReasoningEffort`"",
+                "-c", 'sandbox_mode="read-only"'
+            )
+            $output += @(& $script:CodexCommand @arguments 2>&1)
+            $exitCode = $LASTEXITCODE
+        }
+        if ($exitCode -eq 0 -and @(Invoke-Git status --porcelain=v1 --untracked-files=all).Count -gt 0) {
+            $output += "`n===== dedicated uncommitted review ====="
+            $arguments = @(
+                "review", "--uncommitted",
+                "-c", "model=`"$Model`"",
+                "-c", "model_reasoning_effort=`"$ReasoningEffort`"",
+                "-c", 'sandbox_mode="read-only"'
+            )
+            $output += @(& $script:CodexCommand @arguments 2>&1)
+            $exitCode = $LASTEXITCODE
+        }
+    }
+    else {
+        $arguments = @(
+            "-a", "never",
+            "-s", "read-only",
+            "-C", $script:RepositoryRoot,
+            "exec",
+            "-m", $Model,
+            "-c", "model_reasoning_effort=`"$ReasoningEffort`"",
+            "--ephemeral",
+            $Reviewer.Prompt
+        )
+        $output = @(& $script:CodexCommand @arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    $output | Set-Content -LiteralPath $OutputPath -Encoding utf8
+
+    if ($exitCode -ne 0) {
+        throw "Reviewer '$($Reviewer.Name)' failed with exit code $exitCode. See $OutputPath"
+    }
+}
+
+function Invoke-ReviewPass {
+    param(
+        [int]$Pass,
+        [string]$PassDirectory
+    )
+
+    $common = @"
+Use the project-local gua-bug-hunt skill. Review the entire cumulative diff
+against $Base, not merely the latest commit. Inspect committed changes with
+git diff $Base...HEAD, staged and unstaged changes with git diff --cached and
+git diff, and every path from git ls-files --others --exclude-standard. Remain
+read-only. Report only
+reproducible, actionable defects with tight file and line references, trigger,
+expected versus actual behavior, violated contract, and verification evidence.
+Ignore style, speculation, duplicate findings, and unchanged out-of-scope code.
+"@
+
+    $reviewers = @(
+        @{
+            Name = "general"
+            Kind = "Dedicated"
+        },
+        @{
+            Name = "protocol-core"
+            Kind = "Lane"
+            Prompt = "$common`nFocus on protocol/schema, native C ABI, runtime/bridge, ownership, queues, leases, epochs, request correlation, concurrency, cleanup, and consumed-request completion."
+        },
+        @{
+            Name = "engine-adapters"
+            Kind = "Lane"
+            Prompt = "$common`nFocus on Unity, Godot, and ImGui host mappings, lifecycle teardown, capability and enum translation, device isolation, Action Map reauthorization, and exceptional cleanup."
+        },
+        @{
+            Name = "consumers"
+            Kind = "Lane"
+            Prompt = "$common`nFocus on MCP, Inspector, WebMCP, recording/replay, shared metadata validation, confirmation gates, sensitive-value handling, timing, cancellation, and schema drift."
+        }
+    )
+
+    Write-Host "Starting cumulative review pass $Pass against $Base..."
+    if ($Sequential) {
+        foreach ($reviewer in $reviewers) {
+            $path = Join-Path $PassDirectory "$($reviewer.Name).txt"
+            Invoke-Reviewer -Reviewer $reviewer -OutputPath $path
+            Write-Host "  completed $($reviewer.Name)"
+        }
+    }
+    else {
+        $jobs = foreach ($reviewer in $reviewers) {
+            $path = Join-Path $PassDirectory "$($reviewer.Name).txt"
+            Start-Job -Name $reviewer.Name -ArgumentList @(
+                $script:RepositoryRoot,
+                $script:CodexCommand,
+                $Base,
+                $Model,
+                $ReasoningEffort,
+                $reviewer,
+                $path
+            ) -ScriptBlock {
+                param($RepositoryRoot, $CodexCommand, $Base, $Model, $ReasoningEffort, $Reviewer, $OutputPath)
+                Set-Location -LiteralPath $RepositoryRoot
+                if ($Reviewer.Kind -eq "Dedicated") {
+                    $head = (& git rev-parse HEAD | Select-Object -First 1).Trim()
+                    $mergeBase = (& git merge-base HEAD $Base | Select-Object -First 1).Trim()
+                    $output = @()
+                    $exitCode = 0
+                    if ($head -ne $mergeBase) {
+                        $arguments = @(
+                            "review", "--base", $Base,
+                            "-c", "model=`"$Model`"",
+                            "-c", "model_reasoning_effort=`"$ReasoningEffort`"",
+                            "-c", 'sandbox_mode="read-only"'
+                        )
+                        $output += @(& $CodexCommand @arguments 2>&1)
+                        $exitCode = $LASTEXITCODE
+                    }
+                    $dirty = @(& git status --porcelain=v1 --untracked-files=all).Count -gt 0
+                    if ($exitCode -eq 0 -and $dirty) {
+                        $output += "`n===== dedicated uncommitted review ====="
+                        $arguments = @(
+                            "review", "--uncommitted",
+                            "-c", "model=`"$Model`"",
+                            "-c", "model_reasoning_effort=`"$ReasoningEffort`"",
+                            "-c", 'sandbox_mode="read-only"'
+                        )
+                        $output += @(& $CodexCommand @arguments 2>&1)
+                        $exitCode = $LASTEXITCODE
+                    }
+                }
+                else {
+                    $arguments = @(
+                        "-a", "never",
+                        "-s", "read-only",
+                        "-C", $RepositoryRoot,
+                        "exec",
+                        "-m", $Model,
+                        "-c", "model_reasoning_effort=`"$ReasoningEffort`"",
+                        "--ephemeral",
+                        $Reviewer.Prompt
+                    )
+                    $output = @(& $CodexCommand @arguments 2>&1)
+                    $exitCode = $LASTEXITCODE
+                }
+                $output | Set-Content -LiteralPath $OutputPath -Encoding utf8
+                if ($exitCode -ne 0) {
+                    throw "Reviewer '$($Reviewer.Name)' failed with exit code $exitCode. See $OutputPath"
+                }
+                [pscustomobject]@{ Name = $Reviewer.Name; OutputPath = $OutputPath }
+            }
+        }
+
+        try {
+            $jobs | Wait-Job | Out-Null
+            $failures = @($jobs | Where-Object State -eq "Failed")
+            foreach ($job in $jobs) {
+                Receive-Job -Job $job | Out-Null
+            }
+            if ($failures.Count -gt 0) {
+                throw "Reviewers failed: $($failures.Name -join ', ')"
+            }
+        }
+        finally {
+            $jobs | Remove-Job -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    return @($reviewers | ForEach-Object { Join-Path $PassDirectory "$($_.Name).txt" })
+}
+
+function Invoke-Fixer {
+    param(
+        [int]$Pass,
+        [string[]]$ReportPaths,
+        [string]$PassDirectory
+    )
+
+    $reportList = $ReportPaths | ForEach-Object { "- $_" }
+    $prompt = @"
+This is pass $Pass of the Gua local pull-request audit fix phase.
+
+Read AGENTS.md and use the project-local gua-bug-hunt skill. Independently
+validate every finding in these read-only reviewer reports:
+$($reportList -join "`n")
+
+Reject speculative, duplicate, style-only, unsupported, and out-of-scope
+findings. Fix only reproducible findings that are within the cumulative branch
+diff against $Base. Preserve unrelated user changes. Run the narrowest relevant
+verification plus git diff --check. Do not commit, push, post GitHub comments,
+run scripts/run-local-pr-audit.ps1, or spawn another reviewer; the outer script
+owns the next audit pass. If no supported finding remains, make no repository
+change and say so explicitly.
+"@
+
+    $outputPath = Join-Path $PassDirectory "fixer.txt"
+    $arguments = @(
+        "-a", "never",
+        "-s", "workspace-write",
+        "-C", $script:RepositoryRoot,
+        "exec",
+        "-m", $Model,
+        "-c", "model_reasoning_effort=`"$ReasoningEffort`"",
+        "--ephemeral",
+        "-o", $outputPath,
+        $prompt
+    )
+    & $script:CodexCommand @arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Fixer failed with exit code $LASTEXITCODE. See $outputPath"
+    }
+}
+
+$script:RepositoryRoot = (Invoke-Git rev-parse --show-toplevel | Select-Object -First 1).Trim()
+Set-Location -LiteralPath $script:RepositoryRoot
+$null = Invoke-Git rev-parse --verify "$Base^{commit}"
+$script:CodexCommand = (Get-Command codex -ErrorAction Stop).Source
+
+$branch = (Invoke-Git branch --show-current | Select-Object -First 1).Trim()
+$mergeBase = (Invoke-Git merge-base HEAD $Base | Select-Object -First 1).Trim()
+$head = (Invoke-Git rev-parse HEAD | Select-Object -First 1).Trim()
+$hasLocalChanges = @(Invoke-Git status --porcelain=v1 --untracked-files=all).Count -gt 0
+if ($mergeBase -eq $head -and -not $hasLocalChanges) {
+    throw "There is no branch or working-tree diff against $Base. Run this from the pull-request branch or its worktree."
+}
+
+$runStamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$reportRoot = Join-Path ([IO.Path]::GetTempPath()) "gua-local-pr-audit\$runStamp"
+$null = New-Item -ItemType Directory -Path $reportRoot -Force
+
+Write-Host "Repository: $script:RepositoryRoot"
+Write-Host "Branch:     $branch"
+Write-Host "Base:       $Base"
+Write-Host "Reports:    $reportRoot"
+
+for ($pass = 1; $pass -le $(if ($Fix) { $MaxPasses } else { 1 }); $pass++) {
+    $passDirectory = Join-Path $reportRoot "pass-$pass"
+    $null = New-Item -ItemType Directory -Path $passDirectory -Force
+    $reports = Invoke-ReviewPass -Pass $pass -PassDirectory $passDirectory
+
+    foreach ($report in $reports) {
+        Write-Host "`n===== $([IO.Path]::GetFileNameWithoutExtension($report)) ====="
+        Get-Content -LiteralPath $report
+    }
+
+    if (-not $Fix) {
+        break
+    }
+
+    $before = Get-WorkspaceFingerprint
+    Invoke-Fixer -Pass $pass -ReportPaths $reports -PassDirectory $passDirectory
+    $after = Get-WorkspaceFingerprint
+    if ($before -eq $after) {
+        Write-Host "No repository changes were made; the audit loop is clean or findings were unsupported."
+        break
+    }
+
+    if ($pass -eq $MaxPasses) {
+        Write-Warning "The repository changed on the final allowed pass. Review the final reports and rerun after validation."
+    }
+}
+
+Write-Host "Local PR audit finished. Reports: $reportRoot"


### PR DESCRIPTION
## 概要

- 累積ブランチ差分を対象にした読み取り専用監査の規約を追加
- ゲーム入力を含む監査マトリクスと境界不変条件を拡充
- protocol/core、エンジンアダプター、コンシューマーを監査するローカルPR監査スクリプトを追加
- 任意で検出結果の検証・修正・再監査を最大4パスまで実行可能に整理
- 未コミット変更や未追跡ファイルを含む監査手順をドキュメント化

## テスト

Not run (not requested)