### PR TITLE
READMEのWebMCPリンクとリリースワークフローを修正

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -41,12 +41,12 @@ jobs:
       - name: Read WebMCP package version
         id: webmcp_version
         shell: bash
-        run: echo "version=$(node -p \"require('./packages/webmcp/package.json').version\")" >> "${GITHUB_OUTPUT}"
+        run: node -e "console.log('version=' + require('./packages/webmcp/package.json').version)" >> "${GITHUB_OUTPUT}"
 
       - name: Read World Tools package version
         id: world_tools_version
         shell: bash
-        run: echo "version=$(node -p \"require('./packages/world-tools/package.json').version\")" >> "${GITHUB_OUTPUT}"
+        run: node -e "console.log('version=' + require('./packages/world-tools/package.json').version)" >> "${GITHUB_OUTPUT}"
 
       - name: Check whether World Tools version is already published
         id: world_tools_npm_version

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Test Visual and Recording packages
         run: dotnet test bindings/dotnet/tests/Gua.Visual.Tests/Gua.Visual.Tests.csproj --configuration Release --no-restore -p:Version=${{ steps.version.outputs.version }}
+        env:
+          GUA_NATIVE_DIR: ${{ github.workspace }}\build\windows-msvc-release\native\gua-core\Release
 
       - name: Pack Gua.Core
         run: dotnet pack bindings/dotnet/src/Gua.Core/Gua.Core.csproj --configuration Release --no-build -p:PackageVersion=${{ steps.version.outputs.version }}

--- a/README.ja.md
+++ b/README.ja.md
@@ -64,7 +64,7 @@ GuaはAIコーディングエージェントを補完します。AIがゲーム�
 
 Godot Web ExportとUnity WebGLのページは、実行中の同じSemantic UI Treeを実験的な
 ブラウザ`document.modelContext` APIから公開できます。
-[`gua-webmcp`パッケージ](https://www.npmjs.com/package/gua-webmcp)は、エンジンが
+`gua-webmcp`パッケージは、エンジンが
 所有する同一ページ内ブリッジに対して`get_ui_tree`、Semantic action、wait、read-onlyの
 World Object Tree観測ツール、capabilityで制御されたSemantic Game Action / Raw Input、
 任意のscreenshotツールを登録します。world型とselector
@@ -225,6 +225,9 @@ adapterはinput pumpとcleanup経路が初期化済みのcapabilityだけを公�
 既存のSemantic UI用`press_key`は変更せず、Raw Keyboard gestureには
 `press_physical_key`を使います。
 
+- **gua-webmcp:** [![NPM Version](https://img.shields.io/npm/v/gua-webmcp)](https://www.npmjs.com/package/gua-webmcp) ![NPM Downloads](https://img.shields.io/npm/dw/gua-webmcp)<br>
+  ページのWebMCP APIを通じて、GuaのSemantic UI、World Object Tree、
+  ゲーム入力ツールを登録するブラウザネイティブadapterです。
 - **gui-mcp:** [![NPM Version](https://img.shields.io/npm/v/gui-mcp)](https://www.npmjs.com/package/gui-mcp) ![NPM Downloads](https://img.shields.io/npm/dw/gui-mcp)<br>
   Inspectorと同じWebSocketブリッジを通じて、Guaのランタイム操作を
   AIエージェントへ公開する薄いMCPサーバーです。

--- a/README.ja.md
+++ b/README.ja.md
@@ -63,7 +63,8 @@ GuaはAIコーディングエージェントを補完します。AIがゲーム�
 ### ブラウザネイティブWebMCP（実験的）
 
 Godot Web ExportとUnity WebGLのページは、実行中の同じSemantic UI Treeを実験的な
-ブラウザ`document.modelContext` APIから公開できます。`gua-webmcp`は、エンジンが
+ブラウザ`document.modelContext` APIから公開できます。
+[`gua-webmcp`パッケージ](https://www.npmjs.com/package/gua-webmcp)は、エンジンが
 所有する同一ページ内ブリッジに対して`get_ui_tree`、Semantic action、wait、read-onlyの
 World Object Tree観測ツール、capabilityで制御されたSemantic Game Action / Raw Input、
 任意のscreenshotツールを登録します。world型とselector

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ recognition.
 
 Godot Web Export and Unity WebGL pages can expose the same live Semantic UI Tree
 through the experimental browser `document.modelContext` API. The
-`gua-webmcp` package registers `get_ui_tree`, semantic actions, waits, the
+[`gua-webmcp` package](https://www.npmjs.com/package/gua-webmcp) registers
+`get_ui_tree`, semantic actions, waits, the
 read-only World Object Tree observation tools, capability-gated Semantic Game
 Action / Raw Input tools, and an optional screenshot tool
 against an engine-owned same-page bridge. Shared world types and selector

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ recognition.
 
 Godot Web Export and Unity WebGL pages can expose the same live Semantic UI Tree
 through the experimental browser `document.modelContext` API. The
-[`gua-webmcp` package](https://www.npmjs.com/package/gua-webmcp) registers
+`gua-webmcp` package registers
 `get_ui_tree`, semantic actions, waits, the
 read-only World Object Tree observation tools, capability-gated Semantic Game
 Action / Raw Input tools, and an optional screenshot tool
@@ -188,6 +188,9 @@ Adapters advertise each input capability only after its pump and cleanup path
 are initialized. The existing semantic UI `press_key` API remains unchanged;
 raw keyboard gestures use `press_physical_key`.
 
+- **gua-webmcp:** [![NPM Version](https://img.shields.io/npm/v/gua-webmcp)](https://www.npmjs.com/package/gua-webmcp) ![NPM Downloads](https://img.shields.io/npm/dw/gua-webmcp)<br>
+  A browser-native adapter that registers Gua semantic UI, World Object Tree,
+  and game-input tools through the page's WebMCP API.
 - **gui-mcp:** [![NPM Version](https://img.shields.io/npm/v/gui-mcp)](https://www.npmjs.com/package/gui-mcp) ![NPM Downloads](https://img.shields.io/npm/dw/gui-mcp)<br>
   A thin MCP server that exposes Gua runtime actions to AI agents through the
   same WebSocket bridge used by the Inspector.


### PR DESCRIPTION
## 概要

- 英語版・日本語版READMEに`gua-webmcp`のnpm Version／Downloadsバッジを追加し、Versionバッジからnpmページへリンク
- MCP npm公開workflowのパッケージバージョン取得で壊れていたBashの引用符を修正
- NuGet公開workflowのVisual/RecordingテストへRelease版`gua.dll`の場所を渡すよう修正

## 背景

- MCP公開ジョブは`require(...)`がBash構文として解釈され、パッケージバージョン取得時に失敗していました。
- NuGet公開ジョブはnative runtimeをビルド済みでしたが、テストへ`GUA_NATIVE_DIR`を渡しておらず、clockテストが`gua.dll`を読み込めませんでした。

## 検証

- `bun run check`
- `gua-world-tools`: 6件成功
- `gua-webmcp`: 67件成功
- `gui-mcp`: 15件成功
- `Gua.Visual.Tests`: 13件成功（Release版native runtimeを指定）
- `git diff --check`
- read-onlyの累積差分監査: アクショナブルな指摘なし