### PR TITLE
npm公開ワークフローのバージョン整合性とTrusted Publishingを強化する

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -10,7 +10,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: mcp-publish-${{ github.ref }}
+  group: mcp-publish
+  queue: max
   cancel-in-progress: false
 
 jobs:
@@ -38,22 +39,58 @@ jobs:
           node-version: 24.15.0
           registry-url: https://registry.npmjs.org
 
-      - name: Read WebMCP package version
-        id: webmcp_version
+      - name: Refuse stale release promotion
         shell: bash
-        run: echo "version=$(node -p \"require('./packages/webmcp/package.json').version\")" >> "${GITHUB_OUTPUT}"
+        run: |
+          PACKAGE_VERSION="${{ steps.version.outputs.version }}" node <<'NODE'
+          const packages = ["gua-world-tools", "gua-webmcp", "gui-mcp"];
+          const releaseVersion = process.env.PACKAGE_VERSION;
 
-      - name: Read World Tools package version
-        id: world_tools_version
-        shell: bash
-        run: echo "version=$(node -p \"require('./packages/world-tools/package.json').version\")" >> "${GITHUB_OUTPUT}"
+          function parseStableVersion(value) {
+            const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(value);
+            if (!match) throw new Error(`Expected a stable semantic version, received: ${value}`);
+            return match.slice(1).map(BigInt);
+          }
+
+          function compareVersions(left, right) {
+            const leftParts = parseStableVersion(left);
+            const rightParts = parseStableVersion(right);
+            for (let index = 0; index < leftParts.length; index += 1) {
+              if (leftParts[index] > rightParts[index]) return 1;
+              if (leftParts[index] < rightParts[index]) return -1;
+            }
+            return 0;
+          }
+
+          async function main() {
+            for (const packageName of packages) {
+              const response = await fetch(`https://registry.npmjs.org/${packageName}/latest`);
+              if (response.status === 404) continue;
+              if (!response.ok) {
+                throw new Error(`Unexpected npm registry response for ${packageName}@latest: HTTP ${response.status}`);
+              }
+
+              const currentVersion = (await response.json()).version;
+              if (compareVersions(currentVersion, releaseVersion) > 0) {
+                throw new Error(
+                  `Refusing to publish stale release ${releaseVersion}: ${packageName}@latest is ${currentVersion}.`,
+                );
+              }
+            }
+          }
+
+          main().catch((error) => {
+            console.error(error.message);
+            process.exitCode = 1;
+          });
+          NODE
 
       - name: Check whether World Tools version is already published
         id: world_tools_npm_version
         shell: bash
         run: |
           package_name="gua-world-tools"
-          package_version="${{ steps.world_tools_version.outputs.version }}"
+          package_version="${{ steps.version.outputs.version }}"
           status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
             "https://registry.npmjs.org/${package_name}/${package_version}")"
 
@@ -76,7 +113,7 @@ jobs:
         shell: bash
         run: |
           package_name="gua-webmcp"
-          package_version="${{ steps.webmcp_version.outputs.version }}"
+          package_version="${{ steps.version.outputs.version }}"
           status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
             "https://registry.npmjs.org/${package_name}/${package_version}")"
 
@@ -135,23 +172,95 @@ jobs:
           bun run --filter gua-webmcp build
           bun run --filter gui-mcp build
 
+      - name: Prepare World Tools publish package
+        id: prepare_world_tools
+        shell: bash
+        run: |
+          package_version="${{ steps.version.outputs.version }}"
+          publish_dir="${RUNNER_TEMP}/gua-world-tools-package"
+
+          rm -rf "${publish_dir}"
+          mkdir -p "${publish_dir}/dist" "${publish_dir}/src"
+          cp packages/world-tools/README.md "${publish_dir}/README.md"
+          cp -R packages/world-tools/dist/. "${publish_dir}/dist/"
+          cp -R packages/world-tools/src/. "${publish_dir}/src/"
+
+          PACKAGE_VERSION="${package_version}" PUBLISH_DIR="${publish_dir}" node <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          const packageJson = JSON.parse(fs.readFileSync("packages/world-tools/package.json", "utf8"));
+          packageJson.version = process.env.PACKAGE_VERSION;
+          delete packageJson.scripts;
+          delete packageJson.devDependencies;
+
+          fs.writeFileSync(
+            path.join(process.env.PUBLISH_DIR, "package.json"),
+            `${JSON.stringify(packageJson, null, 2)}\n`,
+          );
+          NODE
+
+          echo "publish_dir=${publish_dir}" >> "${GITHUB_OUTPUT}"
+
       - name: Verify World Tools package contents
-        working-directory: packages/world-tools
-        run: npm pack --dry-run
+        run: |
+          cd "${{ steps.prepare_world_tools.outputs.publish_dir }}"
+          npm pack --dry-run
 
       - name: Publish World Tools to npm
         if: steps.world_tools_npm_version.outputs.published != 'true'
-        working-directory: packages/world-tools
-        run: npm publish --access public --tag latest
+        run: |
+          cd "${{ steps.prepare_world_tools.outputs.publish_dir }}"
+          npm publish --access public --tag latest
+
+      - name: Prepare WebMCP publish package
+        id: prepare_webmcp
+        shell: bash
+        run: |
+          package_version="${{ steps.version.outputs.version }}"
+          publish_dir="${RUNNER_TEMP}/gua-webmcp-package"
+
+          rm -rf "${publish_dir}"
+          mkdir -p "${publish_dir}/dist" "${publish_dir}/src"
+          cp packages/webmcp/README.md "${publish_dir}/README.md"
+          cp -R packages/webmcp/dist/. "${publish_dir}/dist/"
+          cp -R packages/webmcp/src/. "${publish_dir}/src/"
+
+          PACKAGE_VERSION="${package_version}" PUBLISH_DIR="${publish_dir}" node <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          const packageJson = JSON.parse(fs.readFileSync("packages/webmcp/package.json", "utf8"));
+          packageJson.version = process.env.PACKAGE_VERSION;
+          packageJson.dependencies["gua-world-tools"] = `^${process.env.PACKAGE_VERSION}`;
+          delete packageJson.scripts;
+          delete packageJson.devDependencies;
+          for (const section of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+            for (const [name, version] of Object.entries(packageJson[section] ?? {})) {
+              if (String(version).startsWith("workspace:")) {
+                throw new Error(`Published gua-webmcp manifest retains workspace dependency ${name}@${version}`);
+              }
+            }
+          }
+
+          fs.writeFileSync(
+            path.join(process.env.PUBLISH_DIR, "package.json"),
+            `${JSON.stringify(packageJson, null, 2)}\n`,
+          );
+          NODE
+
+          echo "publish_dir=${publish_dir}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify WebMCP package contents
-        working-directory: packages/webmcp
-        run: npm pack --dry-run
+        run: |
+          cd "${{ steps.prepare_webmcp.outputs.publish_dir }}"
+          npm pack --dry-run
 
       - name: Publish WebMCP to npm
         if: steps.webmcp_npm_version.outputs.published != 'true'
-        working-directory: packages/webmcp
-        run: npm publish --access public --tag latest
+        run: |
+          cd "${{ steps.prepare_webmcp.outputs.publish_dir }}"
+          npm publish --access public --tag latest
 
       - name: Prepare publish package
         id: prepare

--- a/README.ja.md
+++ b/README.ja.md
@@ -486,8 +486,15 @@ var ui := GuaAutoAdapterScript.new()
 
 手動で作成した`gua-vX.Y.Z`タグをpushすると、リリースワークフローが実行されます。
 Inspector・Godotプラグイン・ImGuiプラグインはまとめてビルドされ、対応する
-GitHub Releaseへ添付されます。MCPと.NETパッケージも同じバージョンでnpm・
-NuGetへ公開されます。`main`への変更だけではパッケージは公開されません。
+GitHub Releaseへ添付されます。`gua-world-tools`・`gua-webmcp`・`gui-mcp`と
+.NETパッケージも、タグから決定した同じバージョンでnpm・NuGetへ公開されます。
+`main`への変更だけではパッケージは公開されません。
+
+MCPワークフローはGitHub Actions OIDCによるnpm Trusted Publishingを使用します。
+`gua-world-tools`・`gua-webmcp`・`gui-mcp`の各パッケージには、npm側でこの
+リポジトリ、`.github/workflows/mcp-publish.yml`、`release`環境を設定する必要があります。
+npmリリースはタグをまたいで直列実行され、いずれかのパッケージの`latest`が新しい場合、
+古いタグの再実行は公開前に拒否されます。
 
 ## リポジトリ構成
 

--- a/README.md
+++ b/README.md
@@ -639,12 +639,16 @@ completion when the connected bridge supports it.
 
 Pushing a manually created `gua-vX.Y.Z` tag runs the release workflows. The
 Inspector, Godot plugin, and ImGui plugin are built together and attached to the
-matching GitHub Release, while the MCP and .NET packages publish the same
-version to npm and NuGet. Changes pushed to `main` do not publish packages.
+matching GitHub Release. `gua-world-tools`, `gua-webmcp`, `gui-mcp`, and the
+.NET packages publish the same tag-derived version to npm and NuGet. Changes
+pushed to `main` do not publish packages.
 
 The MCP workflow uses npm trusted publishing through GitHub Actions OIDC. The
-`gui-mcp` package must be configured on npm with this repository, the
-`.github/workflows/mcp-publish.yml` workflow, and the `release` environment.
+`gua-world-tools`, `gua-webmcp`, and `gui-mcp` packages must each be configured
+on npm with this repository, the `.github/workflows/mcp-publish.yml` workflow,
+and the `release` environment. npm releases are serialized across tags, and a
+rerun of an older tag is rejected before publication when any package already
+has a newer `latest` version.
 
 ## Godot 4.7 C# Sample
 

--- a/bun.lock
+++ b/bun.lock
@@ -45,16 +45,16 @@
       "devDependencies": {
         "@types/pngjs": "^6.0.5",
         "bun-types": "^1.3.0",
-        "gua-webmcp": "^0.19.1",
-        "gua-world-tools": "^0.19.2",
+        "gua-webmcp": "workspace:*",
+        "gua-world-tools": "workspace:*",
         "typescript": "^5.5.0",
       },
     },
     "packages/webmcp": {
       "name": "gua-webmcp",
-      "version": "0.19.2",
+      "version": "0.0.0",
       "dependencies": {
-        "gua-world-tools": "^0.19.2",
+        "gua-world-tools": "workspace:*",
       },
       "devDependencies": {
         "bun-types": "^1.3.0",
@@ -63,7 +63,7 @@
     },
     "packages/world-tools": {
       "name": "gua-world-tools",
-      "version": "0.19.2",
+      "version": "0.0.0",
       "devDependencies": {
         "typescript": "^5.5.0",
       },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,10 +25,10 @@
     "prepack": "bun run build"
   },
   "devDependencies": {
-    "gua-world-tools": "^0.19.2",
+    "gua-world-tools": "workspace:*",
     "@types/pngjs": "^6.0.5",
     "bun-types": "^1.3.0",
-    "gua-webmcp": "^0.19.2",
+    "gua-webmcp": "workspace:*",
     "typescript": "^5.5.0"
   },
   "dependencies": { "pngjs": "^7.0.0" }

--- a/packages/mcp/test/automation.test.ts
+++ b/packages/mcp/test/automation.test.ts
@@ -44,7 +44,8 @@ describe("GuaAutomationManager", () => {
   test("keeps bundled workspace packages out of published dependencies", async () => {
     const manifest = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
     expect(Object.values(manifest.dependencies ?? {}).some((version) => String(version).startsWith("workspace:"))).toBe(false);
-    expect(manifest.devDependencies["gua-world-tools"]).toBe("^0.19.2");
+    expect(manifest.devDependencies["gua-world-tools"]).toBe("workspace:*");
+    expect(manifest.devDependencies["gua-webmcp"]).toBe("workspace:*");
   });
 
   test("rejects clock_run_for without its required duration", () => {

--- a/packages/webmcp/package.json
+++ b/packages/webmcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gua-webmcp",
-  "version": "0.19.2",
+  "version": "0.0.0",
   "description": "Browser-native WebMCP adapter for Gua game UI automation.",
   "type": "module",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "prepack": "bun run build"
   },
   "dependencies": {
-    "gua-world-tools": "^0.19.2"
+    "gua-world-tools": "workspace:*"
   },
   "devDependencies": {
     "bun-types": "^1.3.0",

--- a/packages/world-tools/package.json
+++ b/packages/world-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gua-world-tools",
-  "version": "0.19.2",
+  "version": "0.0.0",
   "description": "Shared World Object Tree types and observation tools for Gua MCP and WebMCP consumers.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## 概要

- npm公開をタグ由来の共通バージョンで統一
- `gua-world-tools` と `gua-webmcp` の公開用パッケージを生成し、workspace依存を除去
- npmのlatestより古いタグの再公開を拒否
- タグをまたぐnpm公開を直列化
- Trusted Publishingに必要なnpm設定をREADMEへ追記
- テスト用依存関係をworkspace参照へ更新

## テスト

- MCPパッケージの既存テストを更新
- npm公開用パッケージの内容を`npm pack --dry-run`で検証