### PR TITLE
GitHub Release向け公開アセットを整理して単一アーカイブ化する

### DIFF
--- a/.github/workflows/gua-release.yml
+++ b/.github/workflows/gua-release.yml
@@ -74,11 +74,10 @@ jobs:
           $assets = Join-Path $env:RUNNER_TEMP "gua-release-assets"
           $godotRoot = Join-Path $env:RUNNER_TEMP "gua-godot-plugin"
           $godotTarget = Join-Path $godotRoot "addons/gua"
-          $imguiRoot = Join-Path $env:RUNNER_TEMP "gua-imgui-plugin"
           $version = '${{ steps.version.outputs.version }}'
 
-          Remove-Item -Recurse -Force $assets, $godotRoot, $imguiRoot -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Force $assets, $godotTarget, (Join-Path $godotTarget "bin"), $imguiRoot | Out-Null
+          Remove-Item -Recurse -Force $assets, $godotRoot -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force $assets, $godotTarget, (Join-Path $godotTarget "bin") | Out-Null
 
           Copy-Item "examples/godot-gdscript/addons/gua/gua.gdextension" $godotTarget
           Copy-Item "examples/godot-gdscript/addons/gua/gua.gdextension.uid" $godotTarget
@@ -89,15 +88,7 @@ jobs:
           Copy-Item "examples/godot-gdscript/addons/gua/plugin.gd.uid" $godotTarget
           Copy-Item "examples/godot-gdscript/addons/gua/bin/*.dll" (Join-Path $godotTarget "bin")
 
-          $imguiNativeRoot = Join-Path $imguiRoot "native"
-          New-Item -ItemType Directory -Force $imguiNativeRoot | Out-Null
-          Copy-Item "native/gua-imgui" $imguiNativeRoot -Recurse
-          New-Item -ItemType Directory -Force (Join-Path $imguiNativeRoot "gua-core") | Out-Null
-          Copy-Item "native/gua-core/include" (Join-Path $imguiNativeRoot "gua-core") -Recurse
-          Copy-Item "LICENSE" $imguiRoot
-
           Compress-Archive -Path (Join-Path $godotRoot "addons") -DestinationPath (Join-Path $assets "gua-godot-plugin-windows-debug-v$version.zip") -CompressionLevel Optimal
-          Compress-Archive -Path (Join-Path $imguiRoot "*") -DestinationPath (Join-Path $assets "gua-imgui-plugin-v$version.zip") -CompressionLevel Optimal
 
           Copy-Item "packages/inspector/src-tauri/target/release/bundle" (Join-Path $assets "inspector") -Recurse
           "assets=$assets" >> $env:GITHUB_OUTPUT
@@ -248,6 +239,9 @@ jobs:
       - web-native
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Download Windows release assets
         uses: actions/download-artifact@v4
         with:
@@ -266,6 +260,16 @@ jobs:
           name: gua-web-native-v${{ needs.windows-assets.outputs.version }}
           path: release-assets/web
 
+      - name: Package public GitHub Release assets
+        shell: pwsh
+        run: |
+          scripts/package-github-release-assets.ps1 `
+            -Version '${{ needs.windows-assets.outputs.version }}' `
+            -WindowsAssetsDirectory release-assets `
+            -WebNativeDirectory release-assets/web `
+            -UnityPackageDirectory release-assets/unity `
+            -OutputDirectory publish-assets
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
@@ -274,6 +278,6 @@ jobs:
           body: |
             Automated Gua release build from `${{ github.sha }}`.
 
-            This release contains the Windows Inspector bundles, Godot native and Web GDExtension addons, ImGui adapter headers, and the Unity Package Manager archive for Unity 6000.5+ with Windows x64 Mono and experimental WebGL native runtimes.
-          files: release-assets/**/*
+            This release contains the Windows Inspector installers, one Godot addon archive with Windows and Web GDExtensions, and the Unity Package Manager archive for Unity 6000.5+ with Windows x64 Mono and experimental WebGL native runtimes.
+          files: publish-assets/*
           fail_on_unmatched_files: true

--- a/README.ja.md
+++ b/README.ja.md
@@ -489,9 +489,26 @@ var ui := GuaAutoAdapterScript.new()
 ## リリース自動化
 
 手動で作成した`gua-vX.Y.Z`タグをpushすると、リリースワークフローが実行されます。
-Inspector・Godotプラグイン・ImGuiプラグインはまとめてビルドされ、対応する
+Inspector・Godotアドオン・Unityパッケージはまとめてビルドされ、対応する
 GitHub Releaseへ添付されます。MCPと.NETパッケージも同じバージョンでnpm・
-NuGetへ公開されます。`main`への変更だけではパッケージは公開されません。
+NuGetへ公開されます。`main`への変更だけではパッケージは公開されません。ImGui
+アダプターは引き続きリポジトリ内のソースとして利用できますが、正式なRelease
+ファイルとしては公開しません。
+
+公開されるGitHub Releaseのファイルは、`1.0.0`を例にすると次の構成です。
+
+```text
+gua-godot-addon-v1.0.0.zip
+com.link1345.gua-1.0.0.tgz
+Gua.Inspector_<inspector-version>_x64-setup.exe
+Gua.Inspector_<inspector-version>_x64_en-US.msi
+```
+
+`gua-godot-addon-v1.0.0.zip`には、Windows用GDExtension DLLとDebug・Release
+両方のWeb用GDExtension WASMを含む単一の`addons/gua`ツリーが入ります。
+アドオン内の各ファイル、Unity WebGL用静的ライブラリ、ImGui ZIPはGitHub
+Releaseへ個別公開しません。静的ライブラリはUnity Package Managerアーカイブに
+収録されます。
 
 ## リポジトリ構成
 

--- a/README.md
+++ b/README.md
@@ -642,9 +642,27 @@ completion when the connected bridge supports it.
 ## Release automation
 
 Pushing a manually created `gua-vX.Y.Z` tag runs the release workflows. The
-Inspector, Godot plugin, and ImGui plugin are built together and attached to the
+Inspector, Godot addon, and Unity package are built together and attached to the
 matching GitHub Release, while the MCP and .NET packages publish the same
 version to npm and NuGet. Changes pushed to `main` do not publish packages.
+The ImGui adapter remains available as source in this repository but is not a
+public release asset.
+
+The public GitHub Release contains these versioned assets (using `1.0.0` as an
+example):
+
+```text
+gua-godot-addon-v1.0.0.zip
+com.link1345.gua-1.0.0.tgz
+Gua.Inspector_<inspector-version>_x64-setup.exe
+Gua.Inspector_<inspector-version>_x64_en-US.msi
+```
+
+`gua-godot-addon-v1.0.0.zip` contains one `addons/gua` tree with the Windows
+GDExtension DLL and both Debug and Release Web GDExtension WASM files. Files
+inside that addon, Unity WebGL static libraries, and an ImGui ZIP are not
+published as separate GitHub Release assets; the static libraries are already
+included in the Unity Package Manager archive.
 
 The MCP workflow uses npm trusted publishing through GitHub Actions OIDC. The
 `gui-mcp` package must be configured on npm with this repository, the

--- a/scripts/package-github-release-assets.ps1
+++ b/scripts/package-github-release-assets.ps1
@@ -1,0 +1,106 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WindowsAssetsDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WebNativeDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string]$UnityPackageDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputDirectory
+)
+
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $PSScriptRoot
+
+function Require-File([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Required release asset is missing: $Path"
+    }
+    return (Resolve-Path -LiteralPath $Path).Path
+}
+
+if (Test-Path -LiteralPath $OutputDirectory) {
+    $existingOutput = @(Get-ChildItem -LiteralPath $OutputDirectory -Force)
+    if ($existingOutput.Count -gt 0) {
+        throw "Release output directory must be empty: $OutputDirectory"
+    }
+} else {
+    New-Item -ItemType Directory -Force $OutputDirectory | Out-Null
+}
+
+$windowsAddonArchive = Require-File (Join-Path $WindowsAssetsDirectory "gua-godot-plugin-windows-debug-v$Version.zip")
+$webAddonArchive = Require-File (Join-Path $WebNativeDirectory "gua-godot-plugin-web-v$Version.zip")
+$unityArchive = Require-File (Join-Path $UnityPackageDirectory "com.link1345.gua-$Version.tgz")
+
+$staging = Join-Path $OutputDirectory ".godot-addon-staging"
+$windowsAddonRoot = Join-Path $staging "windows"
+$webAddonRoot = Join-Path $staging "web"
+
+try {
+    New-Item -ItemType Directory -Force $windowsAddonRoot, $webAddonRoot | Out-Null
+    Expand-Archive -LiteralPath $windowsAddonArchive -DestinationPath $windowsAddonRoot
+    Expand-Archive -LiteralPath $webAddonArchive -DestinationPath $webAddonRoot
+
+    $windowsAddon = Join-Path $windowsAddonRoot "addons/gua"
+    $webAddon = Join-Path $webAddonRoot "addons/gua"
+    if (-not (Test-Path -LiteralPath $windowsAddon -PathType Container)) {
+        throw "Windows Godot archive does not contain addons/gua: $windowsAddonArchive"
+    }
+    if (-not (Test-Path -LiteralPath $webAddon -PathType Container)) {
+        throw "Web Godot archive does not contain addons/gua: $webAddonArchive"
+    }
+
+    foreach ($webMetadata in Get-ChildItem -LiteralPath $webAddon -File) {
+        $windowsMetadata = Join-Path $windowsAddon $webMetadata.Name
+        if (-not (Test-Path -LiteralPath $windowsMetadata -PathType Leaf)) {
+            throw "Godot addon metadata is missing from the Windows archive: $($webMetadata.Name)"
+        }
+        $webContent = [System.IO.File]::ReadAllText($webMetadata.FullName).Replace("`r`n", "`n").Replace("`r", "`n")
+        $windowsContent = [System.IO.File]::ReadAllText($windowsMetadata).Replace("`r`n", "`n").Replace("`r", "`n")
+        if (-not [string]::Equals($webContent, $windowsContent, [System.StringComparison]::Ordinal)) {
+            throw "Godot addon metadata differs between Windows and Web archives beyond line endings: $($webMetadata.Name)"
+        }
+    }
+
+    $windowsBin = Join-Path $windowsAddon "bin"
+    $webBin = Join-Path $webAddon "bin"
+    Copy-Item -LiteralPath (Join-Path $webBin "gua_godot.web.debug.wasm32.wasm") -Destination $windowsBin
+    Copy-Item -LiteralPath (Join-Path $webBin "gua_godot.web.release.wasm32.wasm") -Destination $windowsBin
+
+    Require-File (Join-Path $windowsBin "gua_godot.windows.debug.x86_64.dll") | Out-Null
+    & (Join-Path $root "scripts/verify-godot-web-addon.ps1") -AddonDirectory $windowsAddon -RequireBinaries
+
+    $godotArchive = Join-Path $OutputDirectory "gua-godot-addon-v$Version.zip"
+    Compress-Archive -Path (Join-Path $windowsAddonRoot "addons") -DestinationPath $godotArchive -CompressionLevel Optimal
+
+    Copy-Item -LiteralPath $unityArchive -Destination $OutputDirectory
+
+    $inspectorFiles = @(
+        Get-ChildItem -LiteralPath (Join-Path $WindowsAssetsDirectory "inspector") -Recurse -File |
+            Where-Object { $_.Extension -in ".exe", ".msi" }
+    )
+    if ($inspectorFiles.Count -eq 0) {
+        throw "No Inspector installer was found below $WindowsAssetsDirectory"
+    }
+    foreach ($inspectorFile in $inspectorFiles) {
+        $destination = Join-Path $OutputDirectory $inspectorFile.Name
+        if (Test-Path -LiteralPath $destination) {
+            throw "Inspector installer names must be unique: $($inspectorFile.Name)"
+        }
+        Copy-Item -LiteralPath $inspectorFile.FullName -Destination $destination
+    }
+} finally {
+    if (Test-Path -LiteralPath $staging) {
+        Remove-Item -LiteralPath $staging -Recurse -Force
+    }
+}
+
+$publishedFiles = @(Get-ChildItem -LiteralPath $OutputDirectory -File | Sort-Object Name)
+Write-Host "GitHub Release assets:"
+$publishedFiles | ForEach-Object { Write-Host "- $($_.Name)" }

--- a/scripts/verify-godot-web-addon.ps1
+++ b/scripts/verify-godot-web-addon.ps1
@@ -5,7 +5,11 @@ param(
 
 $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent $PSScriptRoot
-$addon = Join-Path $root $AddonDirectory
+$addon = if ([System.IO.Path]::IsPathRooted($AddonDirectory)) {
+    $AddonDirectory
+} else {
+    Join-Path $root $AddonDirectory
+}
 $descriptorPath = Join-Path $addon "gua.gdextension"
 $descriptor = Get-Content -LiteralPath $descriptorPath -Raw
 


### PR DESCRIPTION
## 概要

- GitHub Releaseで公開するアセットを専用スクリプトでパッケージ化
- GodotのWindows用・Web用アセットを統合し、単一のアドオンZIPとして公開
- ImGui ZIPや個別の内部ファイルを公開対象から除外
- InspectorインストーラーとUnity Package Managerアーカイブを公開
- README（英日）に公開アセット構成と収録内容を追記
- Godot Webアドオン検証スクリプトが絶対パスにも対応

## Testing

- 未実施（依頼されていないため）