### PR TITLE
Windows版Godot GDExtensionのDebug/Release構成とCI検証を追加

### DIFF
--- a/.github/workflows/gua-release.yml
+++ b/.github/workflows/gua-release.yml
@@ -45,24 +45,37 @@ jobs:
       - name: Build Tauri inspector
         run: bun run --filter @gua/inspector tauri:build
 
-      - name: Configure native build
+      - name: Configure Debug native build
         run: cmake --preset windows-msvc-debug "-DGUA_VERSION=${{ steps.version.outputs.version }}" "-DGUA_GODOT_PLUGIN_VERSION=${{ steps.version.outputs.version }}" "-DGUA_BUILD_ID=${{ github.sha }}"
 
-      - name: Verify injected release metadata
+      - name: Configure Release native build
+        run: cmake --preset windows-msvc-release "-DGUA_VERSION=${{ steps.version.outputs.version }}" "-DGUA_GODOT_PLUGIN_VERSION=${{ steps.version.outputs.version }}" "-DGUA_BUILD_ID=${{ github.sha }}"
+
+      - name: Verify injected release metadata and Godot configurations
         shell: pwsh
         run: |
-          $cache = Get-Content build/windows-msvc-debug/CMakeCache.txt -Raw
-          if ($cache -notmatch 'GUA_VERSION:STRING=${{ steps.version.outputs.version }}' -or
-              $cache -notmatch 'GUA_GODOT_PLUGIN_VERSION:STRING=${{ steps.version.outputs.version }}' -or
-              $cache -notmatch 'GUA_BUILD_ID:STRING=${{ github.sha }}') {
-            throw 'Configured Gua version/build ID does not match the release tag and commit.'
+          $expected = @{
+            'build/windows-msvc-debug/CMakeCache.txt' = 'Debug'
+            'build/windows-msvc-release/CMakeCache.txt' = 'Release'
+          }
+          foreach ($entry in $expected.GetEnumerator()) {
+            $cache = Get-Content $entry.Key -Raw
+            if ($cache -notmatch 'GUA_VERSION:STRING=${{ steps.version.outputs.version }}' -or
+                $cache -notmatch 'GUA_GODOT_PLUGIN_VERSION:STRING=${{ steps.version.outputs.version }}' -or
+                $cache -notmatch 'GUA_BUILD_ID:STRING=${{ github.sha }}' -or
+                $cache -notmatch "GUA_GODOT_CONFIGURATION:STRING=$($entry.Value)") {
+              throw "Configured Gua metadata or Godot configuration is invalid: $($entry.Key)"
+            }
           }
 
-      - name: Build Godot GDExtension
-        run: cmake --build --preset windows-msvc-debug --target gua-godot
+      - name: Build Debug and Release Godot GDExtensions
+        run: |
+          cmake --build --preset windows-msvc-debug --target gua-godot
+          cmake --build --preset windows-msvc-release --target gua-godot
 
-      - name: Configure Unity native plugins
-        run: cmake --preset windows-msvc-release "-DGUA_VERSION=${{ steps.version.outputs.version }}" "-DGUA_BUILD_ID=${{ github.sha }}"
+      - name: Verify Windows Godot addon contract
+        shell: pwsh
+        run: scripts/verify-godot-windows-addon.ps1 -RequireBinaries
 
       - name: Build Unity native plugins
         run: cmake --build --preset windows-msvc-release --target gua gua-runtime --config Release
@@ -88,7 +101,7 @@ jobs:
           Copy-Item "examples/godot-gdscript/addons/gua/plugin.gd.uid" $godotTarget
           Copy-Item "examples/godot-gdscript/addons/gua/bin/*.dll" (Join-Path $godotTarget "bin")
 
-          Compress-Archive -Path (Join-Path $godotRoot "addons") -DestinationPath (Join-Path $assets "gua-godot-plugin-windows-debug-v$version.zip") -CompressionLevel Optimal
+          Compress-Archive -Path (Join-Path $godotRoot "addons") -DestinationPath (Join-Path $assets "gua-godot-plugin-windows-v$version.zip") -CompressionLevel Optimal
 
           Copy-Item "packages/inspector/src-tauri/target/release/bundle" (Join-Path $assets "inspector") -Recurse
           "assets=$assets" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -7,6 +7,59 @@ on:
       - main
 
 jobs:
+  godot-windows-addon-contract:
+    name: Godot Windows Debug / Release
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Configure Debug and Release native builds
+        run: |
+          cmake --preset windows-msvc-debug
+          cmake --preset windows-msvc-release
+
+      - name: Build Debug and Release Godot GDExtensions
+        run: |
+          cmake --build --preset windows-msvc-debug --target gua-godot
+          cmake --build --preset windows-msvc-release --target gua-godot
+
+      - name: Verify Windows addon contract
+        shell: pwsh
+        run: scripts/verify-godot-windows-addon.ps1 -RequireBinaries
+
+      - name: Install Godot 4.7 editor and export templates
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://github.com/godotengine/godot-builds/releases/download/4.7-stable/Godot_v4.7-stable_win64.exe.zip -OutFile godot.zip
+          Invoke-WebRequest https://github.com/godotengine/godot-builds/releases/download/4.7-stable/Godot_v4.7-stable_export_templates.tpz -OutFile templates.zip
+          Expand-Archive godot.zip -DestinationPath .godot-editor
+          Expand-Archive templates.zip -DestinationPath .godot-export-templates
+          $templateDirectory = Join-Path $env:APPDATA "Godot/export_templates/4.7.stable"
+          New-Item -ItemType Directory -Force $templateDirectory | Out-Null
+          Copy-Item ".godot-export-templates/templates/*" $templateDirectory -Recurse
+
+      - name: Export Windows Release player
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force artifacts/godot-windows-release | Out-Null
+          $godot = (Resolve-Path ".godot-editor/Godot_v4.7-stable_win64.exe").Path
+          $output = Join-Path $env:GITHUB_WORKSPACE "artifacts/godot-windows-release/GuaGodotSample.exe"
+          & $godot --headless --path examples/godot-gdscript --export-release "Windows Desktop" $output
+          if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $output -PathType Leaf)) {
+            throw "Godot Windows Release export failed."
+          }
+
+      - name: Run external-control smoke against Windows Release
+        run: bun scripts/verify-godot-windows-release.ts artifacts/godot-windows-release/GuaGodotSample.exe
+
   godot-web-addon-contract:
     name: Godot Web Debug / Release
     runs-on: ubuntu-latest

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -50,7 +50,7 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force artifacts/godot-windows-release | Out-Null
-          $godot = (Resolve-Path ".godot-editor/Godot_v4.7-stable_win64.exe").Path
+          $godot = (Resolve-Path ".godot-editor/Godot_v4.7-stable_win64_console.exe").Path
           $output = Join-Path $env:GITHUB_WORKSPACE "artifacts/godot-windows-release/GuaGodotSample.exe"
           & $godot --headless --path examples/godot-gdscript --export-release "Windows Desktop" $output
           if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $output -PathType Leaf)) {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,6 +13,9 @@
       "generator": "Visual Studio 18 2026",
       "architecture": "x64",
       "binaryDir": "${sourceDir}/build/windows-msvc-debug",
+      "cacheVariables": {
+        "GUA_GODOT_CONFIGURATION": "Debug"
+      },
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -26,6 +29,9 @@
       "generator": "Visual Studio 18 2026",
       "architecture": "x64",
       "binaryDir": "${sourceDir}/build/windows-msvc-release",
+      "cacheVariables": {
+        "GUA_GODOT_CONFIGURATION": "Release"
+      },
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",

--- a/README.ja.md
+++ b/README.ja.md
@@ -466,15 +466,25 @@ GuaAssertions.GetByRole(host.Context, "button", "Create").ToBeVisible();
 これはGDScriptプロジェクトと.NET対応プロジェクトの両方に推奨するGodot統合です。
 標準Control向けアダプターは、現在Guaが文書化しているGodot機能一式を実装しています。
 
-`native/gua-godot`は、共有`native/gua-runtime`上に構築された薄いGDExtension
-アダプターです。GDScript側でランタイムコアを再実装しません。
+`native/gua-godot`は、`native/gua-runtime`上に構築された薄いGDExtension
+アダプターです。Windowsではランタイム実装をGDExtensionへ静的に組み込み、
+Debug・Release両方のアドオンバイナリが、構成を区別できない共通の
+`gua_runtime.dll`へ依存しないようにしています。GDScript側でランタイムコアを
+再実装しません。
 
-Windowsデバッグ版GDExtensionをビルドします。
+WindowsのDebug版とRelease版GDExtensionは、別々の構成済みビルドツリーで
+ビルドします。
 
 ```powershell
 cmake --preset windows-msvc-debug
 cmake --build --preset windows-msvc-debug --target gua-godot
+cmake --preset windows-msvc-release
+cmake --build --preset windows-msvc-release --target gua-godot
 ```
+
+構成別のDLLは`examples/godot-gdscript/addons/gua/bin`へ出力されます。Godotは
+エディターとDebug ExportではDebug DLL、最適化したWindows Exportでは
+Release DLLを読み込みます。
 
 ゲームスクリプトでは、自動収集アダプターを明示的にプリロードします。
 
@@ -504,8 +514,9 @@ Gua.Inspector_<inspector-version>_x64-setup.exe
 Gua.Inspector_<inspector-version>_x64_en-US.msi
 ```
 
-`gua-godot-addon-v1.0.0.zip`には、Windows用GDExtension DLLとDebug・Release
-両方のWeb用GDExtension WASMを含む単一の`addons/gua`ツリーが入ります。
+`gua-godot-addon-v1.0.0.zip`には、Debug・Release両方のWindows用GDExtension
+DLLと、Debug・Release両方のWeb用GDExtension WASMを含む単一の
+`addons/gua`ツリーが入ります。
 アドオン内の各ファイル、Unity WebGL用静的ライブラリ、ImGui ZIPはGitHub
 Releaseへ個別公開しません。静的ライブラリはUnity Package Managerアーカイブに
 収録されます。

--- a/README.md
+++ b/README.md
@@ -658,8 +658,8 @@ Gua.Inspector_<inspector-version>_x64-setup.exe
 Gua.Inspector_<inspector-version>_x64_en-US.msi
 ```
 
-`gua-godot-addon-v1.0.0.zip` contains one `addons/gua` tree with the Windows
-GDExtension DLL and both Debug and Release Web GDExtension WASM files. Files
+`gua-godot-addon-v1.0.0.zip` contains one `addons/gua` tree with both Debug and
+Release Windows GDExtension DLLs and both Debug and Release Web GDExtension WASM files. Files
 inside that addon, Unity WebGL static libraries, and an ImGui ZIP are not
 published as separate GitHub Release assets; the static libraries are already
 included in the Unity Package Manager archive.
@@ -702,8 +702,10 @@ This is the recommended Godot integration for both GDScript projects and
 Godot feature set currently documented by Gua.
 
 The GDScript-facing adapter lives in `native/gua-godot` and builds a thin
-GDExtension wrapper over `native/gua-runtime`. It exposes `GuaContext` to
-GDScript without reimplementing the runtime core or the Inspector bridge:
+GDExtension wrapper over `native/gua-runtime`. On Windows the GDExtension embeds
+that runtime implementation so Debug and Release addon binaries do not depend
+on a shared, configuration-ambiguous `gua_runtime.dll`. It exposes `GuaContext`
+to GDScript without reimplementing the runtime core or the Inspector bridge:
 
 ```gdscript
 var ui := GuaContext.new()
@@ -719,14 +721,18 @@ while true:
         break
 ```
 
-Build the Windows debug GDExtension:
+Build the Windows Debug and Release GDExtensions in separate configured build trees:
 
 ```powershell
 cmake --preset windows-msvc-debug
 cmake --build --preset windows-msvc-debug --target gua-godot
+cmake --preset windows-msvc-release
+cmake --build --preset windows-msvc-release --target gua-godot
 ```
 
-The build writes the debug DLL into `examples/godot-gdscript/addons/gua/bin`.
+The builds write configuration-specific DLLs into
+`examples/godot-gdscript/addons/gua/bin`. Godot loads the Debug DLL in the
+editor and Debug exports, and the Release DLL in optimized Windows exports.
 Open `examples/godot-gdscript` with Godot 4.7 and run the project. The running
 game process starts an Inspector bridge on `ws://127.0.0.1:8765`, which Gua
 Inspector can connect to while the game is open. The addon includes `plugin.cfg`

--- a/examples/godot-gdscript/addons/gua/gua.gdextension
+++ b/examples/godot-gdscript/addons/gua/gua.gdextension
@@ -6,5 +6,6 @@ compatibility_minimum = "4.7"
 [libraries]
 
 windows.debug.x86_64 = "res://addons/gua/bin/gua_godot.windows.debug.x86_64.dll"
+windows.release.x86_64 = "res://addons/gua/bin/gua_godot.windows.release.x86_64.dll"
 web.wasm32.single.debug = "res://addons/gua/bin/gua_godot.web.debug.wasm32.wasm"
 web.wasm32.single.release = "res://addons/gua/bin/gua_godot.web.release.wasm32.wasm"

--- a/examples/godot-gdscript/export_presets.cfg
+++ b/examples/godot-gdscript/export_presets.cfg
@@ -39,3 +39,30 @@ progressive_web_app/icon_144x144=""
 progressive_web_app/icon_180x180=""
 progressive_web_app/icon_512x512=""
 progressive_web_app/background_color=Color(0, 0, 0, 1)
+
+[preset.1]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=false
+advanced_options=false
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="build/windows/GuaGodotSample.exe"
+encryption_include_filters=""
+encryption_exclude_filters=""
+encrypt_pck=false
+encrypt_directory=false
+script_export_mode=2
+
+[preset.1.options]
+
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=1
+binary_format/embed_pck=false
+texture_format/s3tc_bptc=true
+texture_format/etc2_astc=false

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -216,8 +216,8 @@ func _run() -> void:
 	web_input_bridge.adapter_ref = weakref(ui)
 	var released_owner_id: int = ui.create_game_input_owner()
 	web_input_bridge.game_input_owner_id = released_owner_id
-	if web_input_bridge._release_game_input_owner(["1"]) != 1 \
-			or web_input_bridge.game_input_owner_id == 0 \
+	web_input_bridge._release_game_input_owner([null, "1"])
+	if web_input_bridge.game_input_owner_id == 0 \
 			or web_input_bridge.game_input_owner_id == released_owner_id:
 		_fail("Gua WebMCP did not replace a released page-local game input owner.")
 		return

--- a/native/gua-godot/CMakeLists.txt
+++ b/native/gua-godot/CMakeLists.txt
@@ -4,11 +4,7 @@ set(GODOTCPP_API_VERSION "4.7" CACHE STRING "Godot API version for the Gua GDExt
 set(GUA_GODOT_CONFIGURATION "Debug" CACHE STRING "Build configuration for the Gua GDExtension (Debug or Release).")
 set_property(CACHE GUA_GODOT_CONFIGURATION PROPERTY STRINGS Debug Release)
 string(TOLOWER "${GUA_GODOT_CONFIGURATION}" GUA_GODOT_CONFIGURATION_LOWER)
-if(NOT EMSCRIPTEN)
-    # The existing Windows addon remains a Debug GDExtension. Web is the first
-    # platform distributed in both configurations.
-    set(GODOTCPP_TARGET "template_debug" CACHE STRING "Godot build target for the Gua GDExtension." FORCE)
-elseif(GUA_GODOT_CONFIGURATION_LOWER STREQUAL "debug")
+if(GUA_GODOT_CONFIGURATION_LOWER STREQUAL "debug")
     set(GODOTCPP_TARGET "template_debug" CACHE STRING "Godot build target for the Gua GDExtension." FORCE)
 elseif(GUA_GODOT_CONFIGURATION_LOWER STREQUAL "release")
     set(GODOTCPP_TARGET "template_release" CACHE STRING "Godot build target for the Gua GDExtension." FORCE)
@@ -44,18 +40,20 @@ target_include_directories(gua-godot
         include
 )
 
-target_link_libraries(gua-godot
-    PRIVATE
-        gua::runtime
-        godot::cpp
-)
+if(WIN32)
+    set(GUA_GODOT_RUNTIME_TARGET gua::runtime-godot)
+else()
+    set(GUA_GODOT_RUNTIME_TARGET gua::runtime)
+endif()
+
+target_link_libraries(gua-godot PRIVATE ${GUA_GODOT_RUNTIME_TARGET} godot::cpp)
 
 target_compile_features(gua-godot PRIVATE cxx_std_20)
 
 if(EMSCRIPTEN)
     set(GUA_GODOT_OUTPUT_NAME "gua_godot.web.${GUA_GODOT_CONFIGURATION_LOWER}.wasm32")
 else()
-    set(GUA_GODOT_OUTPUT_NAME "gua_godot.windows.debug.x86_64")
+    set(GUA_GODOT_OUTPUT_NAME "gua_godot.windows.${GUA_GODOT_CONFIGURATION_LOWER}.x86_64")
 endif()
 
 set_target_properties(gua-godot

--- a/native/gua-godot/README.md
+++ b/native/gua-godot/README.md
@@ -3,21 +3,25 @@
 This target exposes the shared Gua native runtime bridge to Godot 4.7 as a small
 GDExtension class usable from GDScript.
 
-Build the adapter:
+Build both Windows configurations in separate configured build trees:
 
 ```powershell
 cmake --preset windows-msvc-debug
 cmake --build --preset windows-msvc-debug --target gua-godot
+cmake --preset windows-msvc-release
+cmake --build --preset windows-msvc-release --target gua-godot
 ```
 
-The debug Windows DLL is emitted into:
+The Debug and Release Windows DLLs are emitted into:
 
 ```text
 examples/godot-gdscript/addons/gua/bin/
 ```
 
-On Windows, the adapter links `gua-runtime`, which owns both the core Gua context
-and the shared WebSocket bridge. A GDScript runtime can call
+On Windows, the adapter statically embeds the `gua-runtime` implementation,
+which owns both the core Gua context and the WebSocket bridge. This lets the
+Debug and Release GDExtensions coexist in one addon without a shared
+configuration-specific runtime DLL. A GDScript runtime can call
 `start_inspector_bridge(8765)` on `GuaContext` so Gua Inspector can connect to
 the running Godot game at `ws://127.0.0.1:8765`.
 

--- a/native/gua-runtime/CMakeLists.txt
+++ b/native/gua-runtime/CMakeLists.txt
@@ -10,6 +10,16 @@ add_library(gua-runtime ${GUA_RUNTIME_LIBRARY_TYPE}
 
 add_library(gua::runtime ALIAS gua-runtime)
 
+if(WIN32 AND GUA_BUILD_GODOT)
+    # A distributed Godot addon contains Debug and Release GDExtensions side by
+    # side. Embed the runtime so they do not compete for one configuration-
+    # ambiguous gua_runtime.dll next to the addon binaries.
+    add_library(gua-runtime-godot STATIC
+        src/runtime.cpp
+    )
+    add_library(gua::runtime-godot ALIAS gua-runtime-godot)
+endif()
+
 target_include_directories(gua-runtime
     PUBLIC
         include
@@ -28,6 +38,18 @@ else()
 endif()
 
 target_compile_features(gua-runtime PUBLIC cxx_std_20)
+
+if(TARGET gua-runtime-godot)
+    target_include_directories(gua-runtime-godot PUBLIC include)
+    target_link_libraries(gua-runtime-godot PUBLIC gua::core)
+    if(TARGET gua-ws-bridge)
+        target_link_libraries(gua-runtime-godot PUBLIC gua::ws-bridge)
+        target_compile_definitions(gua-runtime-godot PRIVATE GUA_RUNTIME_WITH_WS=1)
+    else()
+        target_compile_definitions(gua-runtime-godot PRIVATE GUA_RUNTIME_WITH_WS=0)
+    endif()
+    target_compile_features(gua-runtime-godot PUBLIC cxx_std_20)
+endif()
 
 set_target_properties(gua-runtime
     PROPERTIES
@@ -49,6 +71,15 @@ if(MSVC)
             /Zc:__cplusplus
             /utf-8
     )
+    if(TARGET gua-runtime-godot)
+        target_compile_options(gua-runtime-godot
+            PRIVATE
+                /W4
+                /permissive-
+                /Zc:__cplusplus
+                /utf-8
+        )
+    endif()
 else()
     target_compile_options(gua-runtime
         PRIVATE
@@ -70,12 +101,8 @@ if(WIN32)
     add_custom_command(TARGET gua-runtime POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory
             "${CMAKE_SOURCE_DIR}/examples/dotnet-godot/addons/gua/bin"
-            "${CMAKE_SOURCE_DIR}/examples/godot-gdscript/addons/gua/bin"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
             "$<TARGET_FILE:gua-runtime>"
             "${CMAKE_SOURCE_DIR}/examples/dotnet-godot/addons/gua/bin/$<TARGET_FILE_NAME:gua-runtime>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "$<TARGET_FILE:gua-runtime>"
-            "${CMAKE_SOURCE_DIR}/examples/godot-gdscript/addons/gua/bin/$<TARGET_FILE_NAME:gua-runtime>"
     )
 endif()

--- a/scripts/package-github-release-assets.ps1
+++ b/scripts/package-github-release-assets.ps1
@@ -34,7 +34,7 @@ if (Test-Path -LiteralPath $OutputDirectory) {
     New-Item -ItemType Directory -Force $OutputDirectory | Out-Null
 }
 
-$windowsAddonArchive = Require-File (Join-Path $WindowsAssetsDirectory "gua-godot-plugin-windows-debug-v$Version.zip")
+$windowsAddonArchive = Require-File (Join-Path $WindowsAssetsDirectory "gua-godot-plugin-windows-v$Version.zip")
 $webAddonArchive = Require-File (Join-Path $WebNativeDirectory "gua-godot-plugin-web-v$Version.zip")
 $unityArchive = Require-File (Join-Path $UnityPackageDirectory "com.link1345.gua-$Version.tgz")
 
@@ -73,7 +73,7 @@ try {
     Copy-Item -LiteralPath (Join-Path $webBin "gua_godot.web.debug.wasm32.wasm") -Destination $windowsBin
     Copy-Item -LiteralPath (Join-Path $webBin "gua_godot.web.release.wasm32.wasm") -Destination $windowsBin
 
-    Require-File (Join-Path $windowsBin "gua_godot.windows.debug.x86_64.dll") | Out-Null
+    & (Join-Path $root "scripts/verify-godot-windows-addon.ps1") -AddonDirectory $windowsAddon -RequireBinaries
     & (Join-Path $root "scripts/verify-godot-web-addon.ps1") -AddonDirectory $windowsAddon -RequireBinaries
 
     $godotArchive = Join-Path $OutputDirectory "gua-godot-addon-v$Version.zip"

--- a/scripts/verify-godot-windows-addon.ps1
+++ b/scripts/verify-godot-windows-addon.ps1
@@ -1,0 +1,47 @@
+param(
+    [string]$AddonDirectory = "examples/godot-gdscript/addons/gua",
+    [switch]$RequireBinaries
+)
+
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $PSScriptRoot
+$addon = if ([System.IO.Path]::IsPathRooted($AddonDirectory)) {
+    $AddonDirectory
+} else {
+    Join-Path $root $AddonDirectory
+}
+$descriptorPath = Join-Path $addon "gua.gdextension"
+$descriptor = Get-Content -LiteralPath $descriptorPath -Raw
+
+$expectedLibraries = [ordered]@{
+    "windows.debug.x86_64" = "res://addons/gua/bin/gua_godot.windows.debug.x86_64.dll"
+    "windows.release.x86_64" = "res://addons/gua/bin/gua_godot.windows.release.x86_64.dll"
+}
+
+foreach ($mapping in $expectedLibraries.GetEnumerator()) {
+    $escapedKey = [regex]::Escape($mapping.Key)
+    $escapedValue = [regex]::Escape($mapping.Value)
+    if ($descriptor -notmatch "(?m)^$escapedKey\s*=\s*`"$escapedValue`"\s*$") {
+        throw "Missing or incorrect Godot Windows library mapping: $($mapping.Key) -> $($mapping.Value)"
+    }
+
+    if ($RequireBinaries) {
+        $fileName = Split-Path -Leaf $mapping.Value
+        $binaryPath = Join-Path $addon "bin/$fileName"
+        if (-not (Test-Path -LiteralPath $binaryPath -PathType Leaf)) {
+            throw "Godot Windows addon binary is missing: $binaryPath"
+        }
+        if ((Get-Item -LiteralPath $binaryPath).Length -eq 0) {
+            throw "Godot Windows addon binary is empty: $binaryPath"
+        }
+    }
+}
+
+if ($RequireBinaries) {
+    $ambiguousRuntime = Join-Path $addon "bin/gua_runtime.dll"
+    if (Test-Path -LiteralPath $ambiguousRuntime -PathType Leaf) {
+        throw "Godot Windows addon must embed its runtime instead of shipping a configuration-ambiguous DLL: $ambiguousRuntime"
+    }
+}
+
+Write-Host "Godot Windows addon Debug/Release contract verified."

--- a/scripts/verify-godot-windows-release.ts
+++ b/scripts/verify-godot-windows-release.ts
@@ -1,0 +1,162 @@
+import { resolve } from "node:path";
+import { createServer } from "node:net";
+import { GuaBridgeClient } from "../packages/mcp/src/index";
+
+const executable = resolve(
+  process.argv[2] ?? "artifacts/godot-windows-release/GuaGodotSample.exe",
+);
+if (!(await Bun.file(executable).exists())) {
+  throw new Error(`Godot Windows Release export is missing: ${executable}`);
+}
+
+const port = await findAvailablePort();
+const gameProcess = Bun.spawn([executable, "--headless"], {
+  env: { ...Bun.env, GUA_BRIDGE_PORT: String(port) },
+  stdout: "pipe",
+  stderr: "pipe",
+});
+let stdout = "";
+let stderr = "";
+const stdoutTask = captureOutput(
+  gameProcess.stdout,
+  (chunk) => (stdout += chunk),
+);
+const stderrTask = captureOutput(
+  gameProcess.stderr,
+  (chunk) => (stderr += chunk),
+);
+
+let client: GuaBridgeClient | undefined;
+try {
+  const deadline = performance.now() + 20_000;
+  const listeningMessage = `Gua Inspector bridge listening on ws://127.0.0.1:${port}`;
+  while (!stdout.includes(listeningMessage)) {
+    if (stderr.includes("Failed to start Gua Inspector bridge")) {
+      throw new Error(
+        `Spawned Godot Release failed to start its Bridge on port ${port}.`,
+      );
+    }
+    if (gameProcess.exitCode !== null) {
+      throw new Error(
+        `Godot Release exited before starting its Bridge (${gameProcess.exitCode}).`,
+      );
+    }
+    if (performance.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for the spawned Godot Release Bridge on port ${port}.`,
+      );
+    }
+    await Bun.sleep(25);
+  }
+
+  let initial;
+  while (performance.now() < deadline) {
+    client?.close();
+    client = new GuaBridgeClient(`ws://127.0.0.1:${port}`, 1_000);
+    try {
+      initial = await client.getUiTree();
+      if (initial.screen === "title") break;
+    } catch {
+      if (gameProcess.exitCode !== null)
+        throw new Error(
+          `Godot Release exited before accepting an external connection (${gameProcess.exitCode}).`,
+        );
+    }
+    await Bun.sleep(100);
+  }
+
+  if (
+    initial?.screen !== "title" ||
+    !initial.nodes.some(
+      (node) => node.id === "start" && node.actions.includes("click"),
+    )
+  ) {
+    throw new Error(
+      `Godot Windows Release did not expose the allowed start action: ${JSON.stringify(initial)}`,
+    );
+  }
+
+  const receipt = await client.performAction({
+    action: "click",
+    nodeId: "start",
+  });
+  if (
+    receipt === null ||
+    !Number.isSafeInteger(receipt.requestId) ||
+    receipt.requestId <= 0
+  ) {
+    throw new Error(
+      `Godot Windows Release did not accept the external click: ${JSON.stringify(receipt)}`,
+    );
+  }
+  const completion = await client.waitForAction(receipt.requestId, 5_000);
+  if (!completion.succeeded) {
+    throw new Error(
+      `Godot Windows Release rejected the external click: ${JSON.stringify(completion)}`,
+    );
+  }
+
+  let finalTree;
+  while (performance.now() < deadline) {
+    finalTree = await client.getUiTree();
+    if (finalTree.screen === "loading") break;
+    await Bun.sleep(25);
+  }
+  if (finalTree?.screen !== "loading") {
+    throw new Error(
+      `Godot Windows Release click did not publish the loading screen: ${JSON.stringify(finalTree)}`,
+    );
+  }
+  console.log(
+    `Godot Windows Release external-control smoke passed (requestId=${receipt.requestId}).`,
+  );
+} finally {
+  client?.close();
+  gameProcess.kill();
+  await gameProcess.exited.catch(() => undefined);
+  await Promise.allSettled([stdoutTask, stderrTask]);
+  if (stdout.trim().length > 0) console.log(stdout.trim());
+  if (stderr.trim().length > 0) console.error(stderr.trim());
+}
+
+function findAvailablePort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        server.close();
+        reject(
+          new Error(
+            "Could not allocate a loopback port for the Godot Release smoke test.",
+          ),
+        );
+        return;
+      }
+      server.close((error) => {
+        if (error) reject(error);
+        else resolvePort(address.port);
+      });
+    });
+  });
+}
+
+async function captureOutput(
+  stream: ReadableStream<Uint8Array>,
+  append: (chunk: string) => void,
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) break;
+      append(decoder.decode(result.value, { stream: true }));
+    }
+    append(decoder.decode());
+  } finally {
+    reader.releaseLock();
+  }
+}


### PR DESCRIPTION
## 概要

- Windows向けGodot GDExtensionのDebug・Release DLLを個別にビルド・同梱
- 構成ごとのランタイムを静的組み込みし、曖昧な共有 `gua_runtime.dll` への依存を解消
- Godotアドオンのライブラリ構成とバイナリを検証するスクリプトを追加
- Windows Release exportと外部操作を検証するCI smoke testを追加
- リリース成果物のファイル名、パッケージング、READMEを更新

## テスト

- Windows Debug/Release GDExtensionのビルドとアドオン契約検証をCIに追加
- Godot 4.7 Windows Release exportおよびInspector bridge経由の外部クリック操作を検証
- Web版の既存Debug/Releaseアドオン契約検証を維持