### PR TITLE
Gua.Testing.Unityのnet8.0パッケージ作成を修正

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -127,6 +127,7 @@ jobs:
           dotnet build bindings/dotnet/src/Gua.Runtime/Gua.Runtime.csproj --configuration Release --framework net10.0 --no-restore -p:Version=${{ steps.version.outputs.version }}
           dotnet build bindings/dotnet/src/Gua.Runtime/Gua.Runtime.csproj --configuration Release --framework netstandard2.1 --no-restore -p:Version=${{ steps.version.outputs.version }}
           dotnet build bindings/dotnet/src/Gua.Testing.Unity/Gua.Testing.Unity.csproj --configuration Release --framework net10.0 --no-restore -p:Version=${{ steps.version.outputs.version }}
+          dotnet build bindings/dotnet/src/Gua.Testing.Unity/Gua.Testing.Unity.csproj --configuration Release --framework net8.0 --no-restore -p:Version=${{ steps.version.outputs.version }}
           dotnet build bindings/dotnet/src/Gua.Testing.Unity/Gua.Testing.Unity.csproj --configuration Release --framework netstandard2.1 --no-restore -p:Version=${{ steps.version.outputs.version }}
 
       - name: Build Visual and Recording target frameworks

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -372,6 +372,7 @@ jobs:
           dotnet build bindings/dotnet/src/Gua.Runtime/Gua.Runtime.csproj --configuration Release --framework net10.0 --no-restore
           dotnet build bindings/dotnet/src/Gua.Runtime/Gua.Runtime.csproj --configuration Release --framework netstandard2.1 --no-restore
           dotnet build bindings/dotnet/src/Gua.Testing.Unity/Gua.Testing.Unity.csproj --configuration Release --framework net10.0 --no-restore
+          dotnet build bindings/dotnet/src/Gua.Testing.Unity/Gua.Testing.Unity.csproj --configuration Release --framework net8.0 --no-restore
           dotnet build bindings/dotnet/src/Gua.Testing.Unity/Gua.Testing.Unity.csproj --configuration Release --framework netstandard2.1 --no-restore
 
       - name: Build WebGL static-link managed assemblies


### PR DESCRIPTION
## 概要

Gua.Testing.Unity の NuGet パッケージ作成時に、net8.0 の成果物が存在せず NU5026 で失敗する問題を修正します。

## 原因

Gua.Testing.Unity は net10.0、net8.0、netstandard2.1 を対象にしていますが、NuGet Publish workflow では net10.0 と netstandard2.1 だけを事前ビルドしていました。そのため、--no-build を指定した pack が net8.0 の DLL を見つけられませんでした。

## 変更内容

- NuGet Publish workflow で Gua.Testing.Unity の net8.0 を事前ビルド
- 通常の Syntax Check workflow にも同じビルドを追加し、リリース前に検出可能にする

## 検証

- net10.0、net8.0、netstandard2.1 の Release build 成功
- --no-build を指定した Gua.Testing.Unity の pack 成功
- 生成した nupkg に3つの対象フレームワークの DLL と依存関係が含まれることを確認
- git diff --check 成功
- 読み取り専用の累積差分監査でアクショナブルな指摘なし