### PR TITLE
WindowsリリースCIのdumpbin検出をVS 2026対応にする

### DIFF
--- a/.github/workflows/gua-release.yml
+++ b/.github/workflows/gua-release.yml
@@ -77,11 +77,13 @@ jobs:
         shell: pwsh
         run: |
           scripts/verify-godot-windows-addon.ps1 -RequireBinaries
-          $dumpbin = Get-ChildItem "${env:ProgramFiles}\Microsoft Visual Studio\2022" -Recurse -Filter dumpbin.exe -File | Select-Object -First 1
-          if ($null -eq $dumpbin) { throw 'dumpbin.exe was not found.' }
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path -LiteralPath $vswhere -PathType Leaf)) { throw 'vswhere.exe was not found.' }
+          $dumpbin = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find 'VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe' | Select-Object -First 1
+          if ([string]::IsNullOrWhiteSpace($dumpbin)) { throw 'dumpbin.exe was not found.' }
           foreach ($configuration in 'debug', 'release') {
             $binary = "examples/godot-gdscript/addons/gua/bin/gua_godot.windows.$configuration.x86_64.dll"
-            $dependencies = (& $dumpbin.FullName /dependents $binary) -join "`n"
+            $dependencies = (& $dumpbin /dependents $binary) -join "`n"
             if ($LASTEXITCODE -ne 0 -or $dependencies -match '(?i)gua_runtime\.dll') {
               throw "Godot $configuration GDExtension must embed gua-runtime."
             }


### PR DESCRIPTION
## 概要

Windows release asset の検証で利用する dumpbin.exe を、Visual Studio 2022 固定パスではなく vswhere.exe から検出するように変更します。

## 原因

GitHub Actions の windows-latest runner が windows-2025-vs2026 に更新された一方、workflow は Program Files 配下の Visual Studio 2022 のみを再帰検索していました。そのため Godot Debug/Release GDExtension のビルド成功後、dumpbin.exe was not found. で失敗していました。

失敗した run: https://github.com/link1345/gua/actions/runs/33382202676/job/99456882276

## 変更内容

- runner 同梱の vswhere.exe を使用
- VC.Tools.x86.x64 component を持つ最新の Visual Studio instance から Hostx64/x64/dumpbin.exe を取得
- Debug/Release GDExtension が gua_runtime.dll に依存していないことを確認する既存検査は維持

## 検証

- Bun 内蔵 YAML parser による gua-release.yml の parse
- bun run check
- git diff --check origin/main...HEAD
- ローカル Visual Studio 18 環境で同じ vswhere 式による dumpbin.exe の解決
- gua_auditor による累積差分監査: actionable finding なし

実際の Gua Release workflow はタグ push 時のみ実行されるため、runner 上での最終確認は次回のタグ実行で行います。