### PR TITLE
UnityリリーススモークテストのCI失敗を修正

### DIFF
--- a/.github/workflows/gua-release.yml
+++ b/.github/workflows/gua-release.yml
@@ -669,6 +669,11 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
+      - name: Prepare Unity Hub compatibility path
+        if: matrix.kind == 'linux'
+        shell: bash
+        run: |
+          sudo ln -sfn /usr/lib/unityhub /opt/unityhub
       - name: Install Unity Editor for this runner
         id: unity-setup
         uses: buildalon/unity-setup@v2
@@ -718,14 +723,16 @@ jobs:
         shell: pwsh
         env:
           UNITY_EXECUTABLE: ${{ steps.unity-setup.outputs.unity-editor-path }}
-          GUA_UNITY_SCENE: examples/unity-smoke/Assets/Scenes/GuaUnityFixture.unity
+          GUA_UNITY_PROJECT: ${{ github.workspace }}/examples/unity-smoke
+          GUA_UNITY_SCENE: Assets/Scenes/GuaUnityFixture.unity
         run: dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release --filter RenderedEditorPlayMode_ReflectsFixture
       - name: Run Editor Play Mode external smoke with Xvfb
         if: matrix.kind == 'linux'
         shell: bash
         env:
           UNITY_EXECUTABLE: ${{ steps.unity-setup.outputs.unity-editor-path }}
-          GUA_UNITY_SCENE: examples/unity-smoke/Assets/Scenes/GuaUnityFixture.unity
+          GUA_UNITY_PROJECT: ${{ github.workspace }}/examples/unity-smoke
+          GUA_UNITY_SCENE: Assets/Scenes/GuaUnityFixture.unity
         run: xvfb-run --auto-servernum dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release --filter RenderedEditorPlayMode_ReflectsFixture
 
   unity-player-smoke:
@@ -770,10 +777,6 @@ jobs:
             default { Get-ChildItem $root -Recurse -Filter GuaUnitySmoke.app -Directory | Select-Object -First 1 }
           }
           if ($null -eq $player) { throw 'Unity Player artifact was not found.' }
-          if ('${{ matrix.kind }}' -ne 'windows') {
-            $exe = if ('${{ matrix.kind }}' -eq 'linux') { $player.FullName } else { Join-Path $player.FullName 'Contents/MacOS/GuaUnitySmoke' }
-            chmod +x $exe
-          }
           "path=$($player.FullName)" | Out-File $env:GITHUB_OUTPUT -Append
       - name: Run rendered Player integration tests
         if: matrix.kind != 'linux'

--- a/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
@@ -28,6 +28,7 @@ public sealed class UnityIntegrationTests
         using var host = UnitySceneTestHost.LoadEditor(scene!, new UnitySceneTestHostOptions
         {
             UnityExecutablePath = Environment.GetEnvironmentVariable("UNITY_EXECUTABLE"),
+            ProjectPath = Environment.GetEnvironmentVariable("GUA_UNITY_PROJECT"),
             ConnectTimeout = TimeSpan.FromSeconds(60),
             SceneTimeout = TimeSpan.FromSeconds(15),
         });
@@ -48,6 +49,7 @@ public sealed class UnityIntegrationTests
             ConnectTimeout = TimeSpan.FromSeconds(30),
             SceneTimeout = TimeSpan.FromSeconds(15),
             EnvironmentVariables = new Dictionary<string, string> { ["GUA_UNITY_COVERAGE"] = "1", ["GUA_UNITY_HOST_CLICK"] = "1" },
+            AdditionalArguments = ["-screen-width", "1280", "-screen-height", "720", "-screen-fullscreen", "0"],
         });
 
         var version = host.RemoteContext.GetVersion();


### PR DESCRIPTION
## 概要

Gua Release workflow の Unity Editor / Player スモークテスト失敗を修正します。

## 変更内容

- Linux の Unity Hub 3.21 配置を buildalon/unity-setup v2 が期待する旧配置へ互換リンク
- Editor スモークテストへ Unity project と scene を明示
- macOS Player の実行ファイル名の決め打ちを廃止し、既存の汎用 resolver に解決を委譲
- Player を 1280 x 720 で起動し、16:9 のスケーリング検証を安定化

## 対象の失敗

- Smoke Unity Editor / linux-x64
- Smoke Unity Editor / osx-arm64
- Smoke Unity osx-x64 Player
- Smoke Unity osx-arm64 Player
- Smoke Unity win-x64 Player

対象 run: https://github.com/link1345/gua/actions/runs/33456931130

## 検証

- bun run check
- dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release --no-restore
  - 外部 Unity 環境を必要とする3件は環境変数未指定のためスキップ
- git diff --check
- gua_auditor 最終監査: actionable defect なし

修正後のタグ release workflow の実環境再実行は未実施です。