### PR TITLE
UnityリリーススモークのCI失敗を修正

### DIFF
--- a/.github/workflows/gua-release.yml
+++ b/.github/workflows/gua-release.yml
@@ -682,7 +682,9 @@ jobs:
           unity-version: 6000.5.3f1
           architecture: ${{ matrix.architecture }}
           build-targets: ${{ matrix.target }}
-          cache-installation: true
+          # unity-setup@v2 omits the editor architecture from its macOS cache key,
+          # so an arm64 editor can otherwise be restored on the Intel runner.
+          cache-installation: ${{ matrix.kind != 'macos' }}
       - name: Install Unity license
         shell: pwsh
         env:
@@ -725,6 +727,7 @@ jobs:
           UNITY_EXECUTABLE: ${{ steps.unity-setup.outputs.unity-editor-path }}
           GUA_UNITY_PROJECT: ${{ github.workspace }}/examples/unity-smoke
           GUA_UNITY_SCENE: Assets/Scenes/GuaUnityFixture.unity
+          GUA_UNITY_EDITOR_BATCH_MODE: '1'
         run: dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release --filter RenderedEditorPlayMode_ReflectsFixture
       - name: Run Editor Play Mode external smoke with Xvfb
         if: matrix.kind == 'linux'
@@ -733,6 +736,7 @@ jobs:
           UNITY_EXECUTABLE: ${{ steps.unity-setup.outputs.unity-editor-path }}
           GUA_UNITY_PROJECT: ${{ github.workspace }}/examples/unity-smoke
           GUA_UNITY_SCENE: Assets/Scenes/GuaUnityFixture.unity
+          GUA_UNITY_EDITOR_BATCH_MODE: '1'
         run: xvfb-run --auto-servernum dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release --filter RenderedEditorPlayMode_ReflectsFixture
 
   unity-player-smoke:
@@ -783,15 +787,13 @@ jobs:
         shell: pwsh
         env:
           GUA_UNITY_PLAYER: ${{ steps.player.outputs.path }}
-          GUA_UNITY_ARTIFACT_PLAYER: ${{ steps.player.outputs.path }}
-        run: dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release
+        run: dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release --filter RenderedPlayer_ReflectsUiAndDispatchesButtonListener
       - name: Run rendered Player integration tests with Xvfb
         if: matrix.kind == 'linux'
         shell: bash
         env:
           GUA_UNITY_PLAYER: ${{ steps.player.outputs.path }}
-          GUA_UNITY_ARTIFACT_PLAYER: ${{ steps.player.outputs.path }}
-        run: xvfb-run --auto-servernum dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release
+        run: xvfb-run --auto-servernum dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release --filter RenderedPlayer_ReflectsUiAndDispatchesButtonListener
 
   publish:
     name: Publish Gua release

--- a/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
@@ -25,12 +25,14 @@ public sealed class UnityIntegrationTests
     {
         var scene = Environment.GetEnvironmentVariable("GUA_UNITY_SCENE");
         if (string.IsNullOrWhiteSpace(scene)) Assert.Ignore("Set GUA_UNITY_SCENE to run the Unity Editor integration fixture.");
+        var batchMode = string.Equals(Environment.GetEnvironmentVariable("GUA_UNITY_EDITOR_BATCH_MODE"), "1", StringComparison.Ordinal);
         using var host = UnitySceneTestHost.LoadEditor(scene!, new UnitySceneTestHostOptions
         {
             UnityExecutablePath = Environment.GetEnvironmentVariable("UNITY_EXECUTABLE"),
             ProjectPath = Environment.GetEnvironmentVariable("GUA_UNITY_PROJECT"),
             ConnectTimeout = TimeSpan.FromSeconds(60),
             SceneTimeout = TimeSpan.FromSeconds(15),
+            AdditionalArguments = batchMode ? ["-batchmode"] : [],
         });
         Assert.That(WaitForText(host, "Start Game"), Is.True);
         Assert.That(WaitForText(host, "Gua Unity Sample"), Is.True);
@@ -48,8 +50,13 @@ public sealed class UnityIntegrationTests
         {
             ConnectTimeout = TimeSpan.FromSeconds(30),
             SceneTimeout = TimeSpan.FromSeconds(15),
-            EnvironmentVariables = new Dictionary<string, string> { ["GUA_UNITY_COVERAGE"] = "1", ["GUA_UNITY_HOST_CLICK"] = "1" },
-            AdditionalArguments = ["-screen-width", "1280", "-screen-height", "720", "-screen-fullscreen", "0"],
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                ["GUA_UNITY_COVERAGE"] = "1",
+                ["GUA_UNITY_HOST_CLICK"] = "1",
+                ["GUA_UNITY_FIXTURE_RESOLUTION"] = "960x540",
+            },
+            AdditionalArguments = ["-screen-width", "960", "-screen-height", "540", "-screen-fullscreen", "0"],
         });
 
         var version = host.RemoteContext.GetVersion();

--- a/examples/unity-smoke/Assets/GuaUnityFixture.cs
+++ b/examples/unity-smoke/Assets/GuaUnityFixture.cs
@@ -23,7 +23,17 @@ public static class GuaUnityFixture
         GuaUnityAdapterRegistry.Register(new GuaUnityThrowingAdapter());
         Application.runInBackground = true;
         Application.targetFrameRate = 60;
-        Screen.SetResolution(1280, 720, FullScreenMode.Windowed);
+        var fixtureWidth = 1280;
+        var fixtureHeight = 720;
+        var fixtureResolution = Environment.GetEnvironmentVariable("GUA_UNITY_FIXTURE_RESOLUTION");
+        if (!string.IsNullOrWhiteSpace(fixtureResolution))
+        {
+            var parts = fixtureResolution.Split('x');
+            if (parts.Length != 2 || !int.TryParse(parts[0], out fixtureWidth) || !int.TryParse(parts[1], out fixtureHeight) ||
+                fixtureWidth <= 0 || fixtureHeight <= 0)
+                throw new ArgumentException("GUA_UNITY_FIXTURE_RESOLUTION must use a positive WIDTHxHEIGHT value.");
+        }
+        Screen.SetResolution(fixtureWidth, fixtureHeight, FullScreenMode.Windowed);
         legacyFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
 
         var inputMapObject = new GameObject("GuaGameInputFixture");


### PR DESCRIPTION
## 概要

Gua Release run [33464208768](https://github.com/link1345/gua/actions/runs/33464208768) で失敗したUnity Editor / Playerスモークを修正します。

## 原因と対応

- `buildalon/unity-setup@v2` のmacOSキャッシュキーにEditorアーキテクチャが含まれず、Intel runnerへarm64 Editorが復元されていたため、macOSではEditor installation cacheを無効化
- Windows / Linux / macOS arm64のEditorがGUI用entitlementを取得できずbridgeを開始できなかったため、CIのEditor Play Mode smokeを `-batchmode` で起動
- Windows runnerで1280x720のPlayerウィンドウが1024x720へclampされていたため、CI fixtureを960x540へ変更
- fixture自身の `Screen.SetResolution(1280, 720)` が起動引数を上書きしていたため、`GUA_UNITY_FIXTURE_RESOLUTION` でCI解像度を伝播
- Player smokeが重複したartifactテストも実行していたため、対象のrendered Playerテスト1件へfilterを限定

## 検証

- `dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release --no-restore`
  - ビルド成功
  - 実Player / Editor環境変数未指定の3件はskip
- `bun run check`
- `git diff --check origin/main`
- 自動監査で解像度上書きを検出・修正後、追加のactionable findingなし

## リモート確認

GitHub hosted runner上のUnity entitlement、macOS Editor installation、Windowsの実ウィンドウサイズは、このPRのCIで最終確認します。