### PR TITLE
Unity Editorスモークのライセンス認証を修正

### DIFF
--- a/.github/workflows/gua-release.yml
+++ b/.github/workflows/gua-release.yml
@@ -4,9 +4,12 @@ on:
   push:
     tags:
       - "gua-v[0-9]*"
+  pull_request:
+    paths:
+      - ".github/workflows/gua-release.yml"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: gua-release-${{ github.ref }}
@@ -28,7 +31,14 @@ jobs:
       - name: Determine release version
         id: version
         shell: pwsh
-        run: .github/scripts/release-version-from-tag.ps1
+        run: |
+          if ('${{ github.event_name }}' -eq 'pull_request') {
+            $version = '0.0.0-pr.${{ github.event.pull_request.number }}'
+            "version=$version" >> $env:GITHUB_OUTPUT
+            "tag=" >> $env:GITHUB_OUTPUT
+          } else {
+            .github/scripts/release-version-from-tag.ps1
+          }
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -685,26 +695,12 @@ jobs:
           # unity-setup@v2 omits the editor architecture from its macOS cache key,
           # so an arm64 editor can otherwise be restored on the Intel runner.
           cache-installation: ${{ matrix.kind != 'macos' }}
-      - name: Install Unity license
-        shell: pwsh
-        env:
-          UNITY_LICENSE_VALUE: ${{ secrets.UNITY_LICENSE }}
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:UNITY_LICENSE_VALUE)) { throw 'UNITY_LICENSE is required.' }
-          if ('${{ matrix.kind }}' -eq 'windows') {
-            $directory = Join-Path $env:ProgramData 'Unity'
-            New-Item -ItemType Directory -Force $directory | Out-Null
-            Set-Content -LiteralPath (Join-Path $directory 'Unity_lic.ulf') -Value $env:UNITY_LICENSE_VALUE -Encoding utf8NoBOM
-          } elseif ('${{ matrix.kind }}' -eq 'macos') {
-            $temporary = Join-Path $env:RUNNER_TEMP 'Unity_lic.ulf'
-            Set-Content -LiteralPath $temporary -Value $env:UNITY_LICENSE_VALUE -Encoding utf8NoBOM
-            sudo mkdir -p '/Library/Application Support/Unity'
-            sudo cp $temporary '/Library/Application Support/Unity/Unity_lic.ulf'
-          } else {
-            $directory = Join-Path $HOME '.local/share/unity3d/Unity'
-            New-Item -ItemType Directory -Force $directory | Out-Null
-            Set-Content -LiteralPath (Join-Path $directory 'Unity_lic.ulf') -Value $env:UNITY_LICENSE_VALUE -Encoding utf8NoBOM
-          }
+      - name: Activate Unity license
+        uses: buildalon/activate-unity-license@v2
+        with:
+          license: Personal
+          username: ${{ secrets.UNITY_EMAIL }}
+          password: ${{ secrets.UNITY_PASSWORD }}
       - uses: actions/download-artifact@v4
         with:
           name: gua-unity-upm-v${{ needs.windows-assets.outputs.version }}
@@ -797,6 +793,7 @@ jobs:
 
   publish:
     name: Publish Gua release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/gua-v')
     needs:
       - windows-assets
       - portable-native
@@ -806,6 +803,8 @@ jobs:
       - unity-editor-smoke
       - godot-addon
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/gua-release.yml
+++ b/.github/workflows/gua-release.yml
@@ -4,12 +4,9 @@ on:
   push:
     tags:
       - "gua-v[0-9]*"
-  pull_request:
-    paths:
-      - ".github/workflows/gua-release.yml"
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: gua-release-${{ github.ref }}
@@ -31,14 +28,7 @@ jobs:
       - name: Determine release version
         id: version
         shell: pwsh
-        run: |
-          if ('${{ github.event_name }}' -eq 'pull_request') {
-            $version = '0.0.0-pr.${{ github.event.pull_request.number }}'
-            "version=$version" >> $env:GITHUB_OUTPUT
-            "tag=" >> $env:GITHUB_OUTPUT
-          } else {
-            .github/scripts/release-version-from-tag.ps1
-          }
+        run: .github/scripts/release-version-from-tag.ps1
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -793,7 +783,6 @@ jobs:
 
   publish:
     name: Publish Gua release
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/gua-v')
     needs:
       - windows-assets
       - portable-native
@@ -803,8 +792,6 @@ jobs:
       - unity-editor-smoke
       - godot-addon
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## 概要

Gua ReleaseのUnity Editorスモークが全4環境で失敗していたライセンス認証経路を修正します。

対象Actions実行: https://github.com/link1345/gua/actions/runs/33469789866

## 原因

固定のUnity_lic.ulfを各ランナーへコピーしていましたが、Unity 6000.5.3f1がそのライセンスを無効と判定し、EditorがGua bridgeの起動前に終了していました。

## 変更内容

- 手動のUnity_lic.ulf配置をbuildalon/activate-unity-license@v2へ置換
- release環境のUNITY_EMAILとUNITY_PASSWORDを使い、ランナーごとにPersonalライセンスを認証
- gua-vタグpush専用のリリーストリガーと既存のbuild・smoke・publish構成は維持
- PRイベントからリリースワークフローを実行する変更は含めない

## 検証

- actionlint 1.7.12: 成功
- git diff --check: 成功
- gua_auditorによる累積差分監査: アクショナブルな指摘なし

実際のUnityオンライン認証を含む最終確認は、マージ後のタグ実行で行います。