### PR TITLE
Godot Linux Releaseエクスポート後のCI判定を修正

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -96,8 +96,18 @@ jobs:
           $godot = (Resolve-Path '.godot-editor/${{ matrix.executable }}').Path
           $output = Join-Path $env:GITHUB_WORKSPACE '${{ matrix.output }}'
           & $godot --headless --path examples/godot-gdscript --export-release '${{ matrix.preset }}' $output
-          if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $output)) {
-            throw 'Godot ${{ matrix.rid }} Release export failed.'
+          $exportExitCode = $LASTEXITCODE
+          $outputExists = Test-Path -LiteralPath $output
+          Write-Host "Godot export exit code: $exportExitCode; output exists: $outputExists"
+          if (-not $outputExists) {
+            throw "Godot ${{ matrix.rid }} Release export did not create $output (exit code $exportExitCode)."
+          }
+          if ($exportExitCode -ne 0) {
+            if ('${{ matrix.rid }}' -ne 'linux-x64') {
+              throw "Godot ${{ matrix.rid }} Release export exited with code $exportExitCode."
+            }
+            Write-Warning "Godot linux-x64 editor exited with code $exportExitCode after creating the Release player; continuing to the external-control smoke."
+            $global:LASTEXITCODE = 0
           }
 
       - name: Run external-control smoke against desktop Release


### PR DESCRIPTION
## 概要

Godot desktop / linux-x64 のRelease exportが、成果物生成後にeditorの終了コードで失敗し、後続の外部制御smokeへ進めない問題を修正します。

## 原因

- LinuxジョブではGodotのsavepack完了後に固定エラーだけが表示され、終了コードと成果物の状態を区別できませんでした。
- Release playerが生成されていても、非0のLASTEXITCODEがGitHub ActionsのPowerShellステップ終了処理に引き継がれ、後続smokeがスキップされていました。

## 変更内容

- Godot exportの終了コードと成果物の有無をログへ出力します。
- 成果物が存在しない場合は全プラットフォームで失敗させます。
- Windows/macOSの非0終了は従来どおり失敗させます。
- linux-x64のみ、成果物生成済みなら警告を出し、終了状態を明示的に成功へ戻して外部制御smokeへ進めます。
- 後続smokeではRelease playerを実際に起動し、bridge起動、UI tree取得、相関付きクリック完了、loading画面への遷移まで検証します。

## 検証

- Godot 4.7 Linux Debug/Release GDExtension build
- Godot 4.7 Linux Release exportと生成物確認
- GitHub Actions PowerShell終了処理のローカルエミュレーション
- workflow YAML解析
- bun run check
- git diff --check
- gua_auditorによる累積差分監査（残存するactionable defectなし）

## 関連ジョブ

- https://github.com/link1345/gua/actions/runs/33477733257/job/99760418187
- https://github.com/link1345/gua/actions/runs/33477733257/job/99766460136