### PR TITLE
Unity EditorスモークのCanvas fake null失敗を修正する

### DIFF
--- a/bindings/unity/Runtime/GuaUnityRuntime.cs
+++ b/bindings/unity/Runtime/GuaUnityRuntime.cs
@@ -662,7 +662,8 @@ public sealed partial class GuaUnityRuntime : MonoBehaviour
     private void CollectTransform(Transform transform, string? parentId, Canvas canvas, HashSet<Transform> visited, string? ancestorSelectableLabel, bool parentVisible)
     {
         if (!visited.Add(transform)) return;
-        var localCanvas = transform.GetComponent<Canvas>() ?? canvas;
+        var attachedCanvas = transform.GetComponent<Canvas>();
+        var localCanvas = attachedCanvas != null ? attachedCanvas : canvas;
         var id = FitNodeId(ExplicitOrObjectId(transform.gameObject, transform.GetSiblingIndex().ToString(CultureInfo.InvariantCulture)));
         var selectable = transform.GetComponent<Selectable>();
         var text = transform.GetComponent<Text>();


### PR DESCRIPTION
## 概要

Release Run 33477895948で、4 OSすべてのUnity Editor Play Modeスモークが失敗する問題を修正します。

## 原因

`CollectTransform` が `transform.GetComponent<Canvas>() ?? canvas` でCanvasを選択していました。Unityの破棄済みComponentは通常のC#参照としてはnullではない一方、Unityのoverloaded null判定ではnullになるため、`??` がfake-null Canvasを採用していました。

その結果、Canvasを持たない `Background` の境界計算で `MissingComponentException` が毎フレーム発生し、Semantic UI Treeを完成できませんでした。OSごとの初回インポート時間差により、CI上はブリッジ接続タイムアウトまたは `Start Game` 未観測として現れていました。

失敗Run: https://github.com/link1345/gua/actions/runs/33477895948

## 変更

- 取得したCanvasをUnityの `!= null` 判定で検証
- fake-nullの場合は有効な親Canvasへフォールバック

## 検証

- 修正前のRun生成UPM artifactを冷状態のWindows Unity 6000.5.3f1プロジェクトで再現
  - `MissingComponentException` を確認
  - Editor smoke失敗を確認
- 修正後source packageのEditor Play Mode外部スモーク: 成功
- 修正版 `Gua.Unity.dll` をRun生成UPM artifactへ差し替えた冷状態Editorスモーク: 成功
- `dotnet build bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release`: 0 warning / 0 error
- `git diff --check origin/main...HEAD`: 問題なし
- `$gua-bug-hunt` による読み取り専用監査: 追加のactionable defectなし

修正を含むGitHub Actionsの4 OS実走は、このPRのマージ後に新しいRelease Runで確認します。