### PR TITLE
macOSのUnity Editor smokeでAssembly Updaterを無効化

### DIFF
--- a/.github/workflows/gua-release.yml
+++ b/.github/workflows/gua-release.yml
@@ -714,6 +714,10 @@ jobs:
           GUA_UNITY_PROJECT: ${{ github.workspace }}/examples/unity-smoke
           GUA_UNITY_SCENE: Assets/Scenes/GuaUnityFixture.unity
           GUA_UNITY_EDITOR_BATCH_MODE: '1'
+          # The packaged assemblies are built by this workflow with the same Unity
+          # version. On a cold macOS import, the API Updater can run before uGUI's
+          # UnityEngine.UI assembly reaches its search path and block play mode.
+          GUA_UNITY_EDITOR_DISABLE_ASSEMBLY_UPDATER: ${{ matrix.kind == 'macos' && '1' || '0' }}
         run: dotnet test bindings/dotnet/tests/Gua.Unity.Integration.Tests/Gua.Unity.Integration.Tests.csproj -c Release --filter RenderedEditorPlayMode_ReflectsFixture
       - name: Run Editor Play Mode external smoke with Xvfb
         if: matrix.kind == 'linux'

--- a/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
@@ -26,18 +26,28 @@ public sealed class UnityIntegrationTests
         var scene = Environment.GetEnvironmentVariable("GUA_UNITY_SCENE");
         if (string.IsNullOrWhiteSpace(scene)) Assert.Ignore("Set GUA_UNITY_SCENE to run the Unity Editor integration fixture.");
         var batchMode = string.Equals(Environment.GetEnvironmentVariable("GUA_UNITY_EDITOR_BATCH_MODE"), "1", StringComparison.Ordinal);
+        var disableAssemblyUpdater = string.Equals(Environment.GetEnvironmentVariable("GUA_UNITY_EDITOR_DISABLE_ASSEMBLY_UPDATER"), "1", StringComparison.Ordinal);
         using var host = UnitySceneTestHost.LoadEditor(scene!, new UnitySceneTestHostOptions
         {
             UnityExecutablePath = Environment.GetEnvironmentVariable("UNITY_EXECUTABLE"),
             ProjectPath = Environment.GetEnvironmentVariable("GUA_UNITY_PROJECT"),
             ConnectTimeout = TimeSpan.FromSeconds(60),
             SceneTimeout = TimeSpan.FromSeconds(15),
-            AdditionalArguments = batchMode ? ["-batchmode"] : [],
+            AdditionalArguments = EditorAdditionalArguments(batchMode, disableAssemblyUpdater),
         });
         Assert.That(WaitForText(host, "Start Game"), Is.True);
         Assert.That(WaitForText(host, "Gua Unity Sample"), Is.True);
         Assert.That(WaitForScreen(host, "title"), Is.True);
         Assert.That(host.RemoteContext.GetVersion().AdapterVersions, Contains.Key("unity"));
+    }
+
+    [Test]
+    public void EditorStartupArguments_CanDisableUpdaterAfterBatchMode()
+    {
+        Assert.That(EditorAdditionalArguments(batchMode: true, disableAssemblyUpdater: true),
+            Is.EqualTo(new[] { "-batchmode", "-disable-assembly-updater" }));
+        Assert.That(EditorAdditionalArguments(batchMode: true, disableAssemblyUpdater: false),
+            Is.EqualTo(new[] { "-batchmode" }));
     }
 
     [Test]
@@ -267,6 +277,14 @@ public sealed class UnityIntegrationTests
     private static bool WaitForAction(UnitySceneTestHost host, ulong requestId)
     {
         return WaitForActionEvent(host, requestId, out var action) && action.Succeeded;
+    }
+
+    private static IReadOnlyList<string> EditorAdditionalArguments(bool batchMode, bool disableAssemblyUpdater)
+    {
+        var arguments = new List<string>();
+        if (batchMode) arguments.Add("-batchmode");
+        if (disableAssemblyUpdater) arguments.Add("-disable-assembly-updater");
+        return arguments;
     }
 
     private static bool WaitForActionEvent(UnitySceneTestHost host, ulong requestId, out GuaActionEvent result)


### PR DESCRIPTION
## 概要

- macOSのUnity Editor smoke実行時にAssembly Updaterを無効化
- 起動引数の組み立てを共通化し、batch modeとの順序を保証
- Assembly Updater無効化引数のユニットテストを追加

## テスト

- `EditorStartupArguments_CanDisableUpdaterAfterBatchMode` のユニットテストを追加