### PR TITLE
ゲーム入力と仮想時計の契約を統一する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -238,6 +238,15 @@ bridge、MCP、Inspectorでも`get_clock`、`clock_install`、`clock_pause`、
 
 ### Semantic Game ActionとRaw Input
 
+大規模なAction Mapではdescriptorに`category`、`tags`、人向けの`aliases`を追加し、
+固定API `find_game_input_actions`で現在のMapを検索できます。条件はAND、複数tagは
+全件一致、結果はAction IDのordinal昇順です。paginationはなく既定20件、最大100件で、
+`truncated`が真なら条件を絞ります。Player投影では`agentExposure: "private"`を件数・
+打ち切り判定より前に除外し、公開Action・公開metadata・contextが変わったときだけ
+Player revisionを進めます。検索結果は実行権限ではなく、enqueue時とhost consume直前に
+最新descriptorを再認可します。ID、description、category、tags、aliasesには、Debug toolや
+recordingに残って困る秘密情報を入れないでください。
+
 ホストはUI Treeと独立したGame Action Mapを明示登録し、button、axis、vector、
 textを`press_game_input_action`、`set_game_input_action`、
 `release_game_input_action`で操作できます。明示opt-inのRaw toolはcommand schemaに
@@ -453,6 +462,7 @@ select
 scroll
 press_key
 get_game_input_actions
+find_game_input_actions
 press_game_input_action
 set_game_input_action
 release_game_input_action

--- a/README.md
+++ b/README.md
@@ -224,6 +224,18 @@ registration.
 Local C++ and .NET sessions poll the returned request ID for host completion;
 enqueue acceptance alone does not prove that the adapter injected the input.
 
+Large Action Maps can add `category`, `tags`, and human-facing `aliases` to each
+descriptor and discover the current map with the fixed
+`find_game_input_actions` API. Filters are combined with AND, tags require every
+requested value, and results are ordered by ordinal Action ID. The unpaged result
+defaults to 20 actions, accepts at most 100, and reports `truncated` so clients
+can narrow the query. Player projection omits descriptors marked
+`agentExposure: "private"` before counting or truncation; its revision changes
+only when public actions, public metadata, or the context changes. Search is a
+snapshot, not execution authority: enqueue and host consumption both revalidate
+the latest descriptor. Do not put secrets in IDs, descriptions, categories,
+tags, or aliases because Debug tools and recordings may preserve that metadata.
+
 Unity 6000.5 integration uses `com.unity.inputsystem@1.20.0` virtual devices;
 Godot injects main-thread `InputEvent` values through `Input.parse_input_event`.
 Adapters advertise each input capability only after its pump and cleanup path
@@ -680,6 +692,7 @@ select
 scroll
 press_key
 get_game_input_actions
+find_game_input_actions
 press_game_input_action
 set_game_input_action
 release_game_input_action

--- a/bindings/dotnet/src/Gua.Runtime/GuaGameInput.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaGameInput.cs
@@ -122,6 +122,10 @@ public sealed partial class GuaRuntime
             {
                 if (action.Minimum.HasValue != action.Maximum.HasValue)
                     throw new ArgumentException($"Action '{action.Id}' must specify both range bounds.");
+                if ((action.Category?.Contains('\0') ?? false) ||
+                    (action.Aliases?.Any(value => value.Contains('\0')) ?? false) ||
+                    (action.Tags?.Any(value => value.Contains('\0')) ?? false))
+                    throw new ArgumentException($"Action '{action.Id}' category, aliases, and tags must not contain embedded NUL characters.", nameof(actions));
                 var strings = new[] { action.Id, action.Description, JsonSerializer.Serialize(action.Bindings ?? []), action.Risk, action.Category };
                 var pointers = strings.Select(value => value is null ? 0 : (nint)Marshal.StringToCoTaskMemUTF8(value)).ToArray();
                 var aliases = AllocateStrings(action.Aliases ?? [], out var aliasArray);
@@ -253,6 +257,10 @@ public sealed partial class GuaRuntime
     {
         ThrowIfDisposed();
         if (selector is null) throw new ArgumentNullException(nameof(selector));
+        static bool ContainsNul(string? value) => value?.Contains('\0') == true;
+        if (ContainsNul(selector.Id) || ContainsNul(selector.Query) || ContainsNul(selector.Context) ||
+            ContainsNul(selector.Category) || (selector.Tags?.Any(ContainsNul) ?? false))
+            throw new ArgumentException("Game input selectors must not contain embedded NUL characters.", nameof(selector));
         var allocations = new List<nint>();
         nint Text(string? value) { if (string.IsNullOrEmpty(value)) return 0; var pointer = (nint)Marshal.StringToCoTaskMemUTF8(value); allocations.Add(pointer); return pointer; }
         var tagPointers = AllocateStrings(selector.Tags ?? [], out var tagArray);

--- a/bindings/dotnet/src/Gua.Runtime/GuaGameInput.cs
+++ b/bindings/dotnet/src/Gua.Runtime/GuaGameInput.cs
@@ -20,7 +20,41 @@ public enum GuaGameInputOperation { Press = 1, Set = 2, Release = 3, Down = 4, U
 public sealed record GuaGameInputActionDescriptor(
     string Id, string Description, GuaGameInputValueType ValueType,
     double? Minimum = null, double? Maximum = null, bool Holdable = false, bool Active = true,
-    IReadOnlyList<string>? Bindings = null, string Risk = "safe", bool RequiresConfirmation = false);
+    IReadOnlyList<string>? Bindings = null, string Risk = "safe", bool RequiresConfirmation = false,
+    string? Category = null, IReadOnlyList<string>? Aliases = null, IReadOnlyList<string>? Tags = null,
+    GuaAgentExposure AgentExposure = GuaAgentExposure.Auto);
+
+public sealed record GuaGameInputActionSelector(
+    string? Id = null, string? Query = null, GuaGameInputValueType? ValueType = null, bool? Active = null,
+    string? Context = null, string? Category = null, IReadOnlyList<string>? Tags = null, uint Limit = 20);
+
+public sealed record GuaGameInputAction(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("description")] string Description,
+    [property: JsonPropertyName("valueType")] string ValueType,
+    [property: JsonPropertyName("holdable")] bool Holdable,
+    [property: JsonPropertyName("active")] bool Active,
+    [property: JsonPropertyName("requiresConfirmation")] bool RequiresConfirmation,
+    [property: JsonPropertyName("range")] GuaGameInputActionRange? Range = null,
+    [property: JsonPropertyName("bindings")] IReadOnlyList<string>? Bindings = null,
+    [property: JsonPropertyName("risk")] string Risk = "safe",
+    [property: JsonPropertyName("category")] string? Category = null,
+    [property: JsonPropertyName("aliases")] IReadOnlyList<string>? Aliases = null,
+    [property: JsonPropertyName("tags")] IReadOnlyList<string>? Tags = null,
+    [property: JsonPropertyName("agentExposure")] string AgentExposure = "auto");
+
+public sealed record GuaGameInputActionRange(
+    [property: JsonPropertyName("minimum")] double Minimum,
+    [property: JsonPropertyName("maximum")] double Maximum);
+
+public sealed record GuaGameInputActionSearchResult(
+    [property: JsonPropertyName("schemaVersion")] int SchemaVersion,
+    [property: JsonPropertyName("sessionEpoch")] ulong SessionEpoch,
+    [property: JsonPropertyName("revision")] ulong Revision,
+    [property: JsonPropertyName("context")] string Context,
+    [property: JsonPropertyName("count")] int Count,
+    [property: JsonPropertyName("truncated")] bool Truncated,
+    [property: JsonPropertyName("actions")] IReadOnlyList<GuaGameInputAction> Actions);
 
 public sealed record GuaGameInputRequest(
     ulong RequestId, ulong OwnerId, GuaGameInputKind Kind, GuaGameInputOperation Operation,
@@ -88,21 +122,32 @@ public sealed partial class GuaRuntime
             {
                 if (action.Minimum.HasValue != action.Maximum.HasValue)
                     throw new ArgumentException($"Action '{action.Id}' must specify both range bounds.");
-                var strings = new[] { action.Id, action.Description, JsonSerializer.Serialize(action.Bindings ?? []), action.Risk };
-                var pointers = strings.Select(Marshal.StringToCoTaskMemUTF8).Select(pointer => (nint)pointer).ToArray();
+                var strings = new[] { action.Id, action.Description, JsonSerializer.Serialize(action.Bindings ?? []), action.Risk, action.Category };
+                var pointers = strings.Select(value => value is null ? 0 : (nint)Marshal.StringToCoTaskMemUTF8(value)).ToArray();
+                var aliases = AllocateStrings(action.Aliases ?? [], out var aliasArray);
+                var tags = AllocateStrings(action.Tags ?? [], out var tagArray);
                 try
                 {
-                    var native = new Native.GameInputAction
+                    var baseAction = new Native.GameInputAction
                     {
                         StructSize = (uint)Marshal.SizeOf<Native.GameInputAction>(), Id = pointers[0], Description = pointers[1],
                         ValueType = (int)action.ValueType, Minimum = action.Minimum ?? 0, Maximum = action.Maximum ?? 0,
                         HasRange = action.Minimum.HasValue ? 1 : 0, Holdable = action.Holdable ? 1 : 0, Active = action.Active ? 1 : 0,
                         BindingsJson = pointers[2], Risk = pointers[3], RequiresConfirmation = action.RequiresConfirmation ? 1 : 0,
                     };
-                    if (Native.gua_runtime_register_game_input_action_v1(_handle, in native) == 0)
+                    var native = new Native.GameInputActionV2 { StructSize = (uint)Marshal.SizeOf<Native.GameInputActionV2>(),
+                        Base = baseAction, Category = pointers[4], Aliases = aliasArray, AliasCount = (uint)aliases.Length,
+                        Tags = tagArray, TagCount = (uint)tags.Length, AgentExposure = (int)action.AgentExposure };
+                    if (Native.gua_runtime_register_game_input_action_v2(_handle, in native) == 0)
                         throw new ArgumentException($"Invalid game input action '{action.Id}'.", nameof(actions));
                 }
-                finally { foreach (var pointer in pointers) Marshal.FreeCoTaskMem(pointer); }
+                finally {
+                    foreach (var pointer in pointers) if (pointer != 0) Marshal.FreeCoTaskMem(pointer);
+                    foreach (var pointer in aliases) Marshal.FreeCoTaskMem(pointer);
+                    foreach (var pointer in tags) Marshal.FreeCoTaskMem(pointer);
+                    if (aliasArray != 0) Marshal.FreeCoTaskMem(aliasArray);
+                    if (tagArray != 0) Marshal.FreeCoTaskMem(tagArray);
+                }
             }
             if (Native.gua_runtime_end_game_input_frame(_handle) == 0)
                 throw new InvalidOperationException("Failed to commit the game input action frame.");
@@ -191,6 +236,39 @@ public sealed partial class GuaRuntime
     }
 
     public unsafe string GetGameInputActionsJson() => CopyGameInputJson(0, false);
+    public unsafe string GetPlayerGameInputActionsJson()
+    {
+        int Copy(byte* output, int size) => Native.gua_runtime_copy_player_game_input_actions_json(_handle, output, size);
+        return CopyGameInputJson(Copy);
+    }
+    public GuaGameInputActionSearchResult FindGameInputActions(GuaGameInputActionSelector selector,
+        GuaObservationProfile observationProfile = GuaObservationProfile.Debug)
+    {
+        var json = FindGameInputActionsJson(selector, observationProfile);
+        return JsonSerializer.Deserialize<GuaGameInputActionSearchResult>(json)
+            ?? throw new InvalidOperationException("Native game input search JSON is invalid.");
+    }
+    public unsafe string FindGameInputActionsJson(GuaGameInputActionSelector selector,
+        GuaObservationProfile observationProfile = GuaObservationProfile.Debug)
+    {
+        ThrowIfDisposed();
+        if (selector is null) throw new ArgumentNullException(nameof(selector));
+        var allocations = new List<nint>();
+        nint Text(string? value) { if (string.IsNullOrEmpty(value)) return 0; var pointer = (nint)Marshal.StringToCoTaskMemUTF8(value); allocations.Add(pointer); return pointer; }
+        var tagPointers = AllocateStrings(selector.Tags ?? [], out var tagArray);
+        try {
+            var native = new Native.GameInputActionSelector { StructSize = (uint)Marshal.SizeOf<Native.GameInputActionSelector>(),
+                Id = Text(selector.Id), Query = Text(selector.Query), ValueType = selector.ValueType.HasValue ? (int)selector.ValueType.Value : 0,
+                Active = selector.Active.HasValue ? (selector.Active.Value ? 2 : 1) : 0, Context = Text(selector.Context),
+                Category = Text(selector.Category), Tags = tagArray, TagCount = (uint)tagPointers.Length, Limit = selector.Limit };
+            int Copy(byte* output, int size) => Native.gua_runtime_query_game_input_actions_json(_handle, in native, (int)observationProfile, output, size);
+            return CopyGameInputJson(Copy);
+        } finally {
+            foreach (var pointer in allocations) Marshal.FreeCoTaskMem(pointer);
+            foreach (var pointer in tagPointers) Marshal.FreeCoTaskMem(pointer);
+            if (tagArray != 0) Marshal.FreeCoTaskMem(tagArray);
+        }
+    }
     internal unsafe string GetGameInputStateJson(ulong ownerId) => CopyGameInputJson(ownerId, true);
     internal unsafe GuaGameInputResult GetGameInputResult(ulong ownerId, ulong requestId)
     {
@@ -223,5 +301,13 @@ public sealed partial class GuaRuntime
                 required = actual;
             }
         }
+    }
+
+    private static nint[] AllocateStrings(IReadOnlyList<string> values, out nint array)
+    {
+        var pointers = values.Select(value => (nint)Marshal.StringToCoTaskMemUTF8(value)).ToArray();
+        array = 0;
+        if (pointers.Length != 0) { array = (nint)Marshal.AllocCoTaskMem(IntPtr.Size * pointers.Length); Marshal.Copy(pointers, 0, array, pointers.Length); }
+        return pointers;
     }
 }

--- a/bindings/dotnet/src/Gua.Runtime/Native.cs
+++ b/bindings/dotnet/src/Gua.Runtime/Native.cs
@@ -21,6 +21,8 @@ internal static unsafe class Native
     [StructLayout(LayoutKind.Sequential)] internal struct ClockStatus { internal uint StructSize; internal int Installed, Paused; internal double NowMs, DefaultStepMs, PendingMs; internal ulong Generation; }
     [StructLayout(LayoutKind.Sequential)] internal struct ClockStep { internal uint StructSize; internal double DeltaMs; internal int FinalStep; internal ulong Generation; }
     [StructLayout(LayoutKind.Sequential)] internal struct GameInputAction { internal uint StructSize; internal nint Id, Description; internal int ValueType; internal double Minimum, Maximum; internal int HasRange, Holdable, Active; internal nint BindingsJson, Risk; internal int RequiresConfirmation; }
+    [StructLayout(LayoutKind.Sequential)] internal struct GameInputActionV2 { internal uint StructSize; internal GameInputAction Base; internal nint Category, Aliases; internal uint AliasCount; internal nint Tags; internal uint TagCount; internal int AgentExposure; }
+    [StructLayout(LayoutKind.Sequential)] internal struct GameInputActionSelector { internal uint StructSize; internal nint Id, Query; internal int ValueType, Active; internal nint Context, Category, Tags; internal uint TagCount, Limit; }
     [StructLayout(LayoutKind.Sequential)] internal struct GameInputRequestDescriptor { internal uint StructSize; internal ulong OwnerId; internal int Kind, Operation; internal nint Target, ValueJson; internal double X, Y; internal uint LeaseMs; internal int DeviceIndex, Sensitive; }
     [StructLayout(LayoutKind.Sequential)] internal struct GameInputRequestDescriptorV2 { internal uint StructSize; internal ulong OwnerId; internal int Kind, Operation; internal nint Target, ValueJson; internal double X, Y; internal uint LeaseMs; internal int DeviceIndex, Sensitive, Confirmed; }
     [StructLayout(LayoutKind.Sequential)] internal unsafe struct GameInputRequest { internal uint StructSize; internal ulong RequestId, OwnerId; internal int Kind, Operation; internal fixed byte Target[128]; internal fixed byte ValueJson[512]; internal double X, Y; internal uint LeaseMs; internal int DeviceIndex, Sensitive; }
@@ -100,6 +102,7 @@ internal static unsafe class Native
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern uint gua_runtime_get_game_input_capabilities(nint runtime, int observationProfile);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_begin_game_input_frame(nint runtime, [MarshalAs(UnmanagedType.LPUTF8Str)] string inputContext);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_register_game_input_action_v1(nint runtime, in GameInputAction action);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_register_game_input_action_v2(nint runtime, in GameInputActionV2 action);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_end_game_input_frame(nint runtime);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_abort_game_input_frame(nint runtime);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern ulong gua_runtime_create_game_input_owner(nint runtime);
@@ -111,6 +114,8 @@ internal static unsafe class Native
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_complete_game_input_request(nint runtime, ulong requestId, int succeeded, int errorCode);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern int gua_runtime_tick_game_input_leases(nint runtime, double elapsedMs);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern unsafe int gua_runtime_copy_game_input_actions_json(nint runtime, byte* output, int size);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern unsafe int gua_runtime_copy_player_game_input_actions_json(nint runtime, byte* output, int size);
+    [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern unsafe int gua_runtime_query_game_input_actions_json(nint runtime, in GameInputActionSelector selector, int observationProfile, byte* output, int size);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern unsafe int gua_runtime_copy_game_input_state_json(nint runtime, ulong ownerId, byte* output, int size);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern unsafe int gua_runtime_copy_game_input_result_json(nint runtime, ulong ownerId, ulong requestId, byte* output, int size);
     [DllImport(Library, CallingConvention = CallingConvention.Cdecl)] internal static extern void gua_runtime_set_world_object_tree_enabled(nint runtime, int enabled);

--- a/bindings/dotnet/src/Gua.Runtime/README.md
+++ b/bindings/dotnet/src/Gua.Runtime/README.md
@@ -1,5 +1,10 @@
 # Gua.Runtime
 
+Semantic Game Action descriptor v2 exposes `Category`, `Aliases`, `Tags`, and
+`AgentExposure`. Use `FindGameInputActions` with a `GuaGameInputActionSelector`
+for bounded, profile-aware discovery; its result revision must be treated as a
+snapshot because execution is revalidated against the current Action Map.
+
 Managed `net10.0` and `netstandard2.1` wrapper over the stable Gua runtime C
 ABI. Engine adapters use it to publish semantic frames, consume actions,
 complete screenshot requests, expose adapter versions, and run the Inspector

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -1776,6 +1776,14 @@ public sealed class SelectorParityTests
         });
         var player = runtime.FindGameInputActions(new(Limit: 100), GuaObservationProfile.Player);
         Assert.That(player.Actions.Select(action => action.Id), Is.EqualTo(new[] { "open_inventory" }));
+        Assert.Throws<ArgumentException>(() => runtime.FindGameInputActions(new(Query: "before\0after")));
+        Assert.Throws<ArgumentException>(() => runtime.FindGameInputActions(new(Tags: ["inventory\0hidden"])));
+        Assert.Throws<ArgumentException>(() => runtime.PublishGameInputActions("invalid", [
+            new GuaGameInputActionDescriptor("invalid", "Invalid", GuaGameInputValueType.Button, Aliases: ["hop\0hidden"]),
+        ]));
+        Assert.Throws<ArgumentException>(() => runtime.PublishGameInputActions("invalid", [
+            new GuaGameInputActionDescriptor("invalid", "Invalid", GuaGameInputValueType.Button, Category: "movement\0hidden"),
+        ]));
         using var playerSession = runtime.CreateGameInputSession(GuaObservationProfile.Player);
         Assert.Throws<InvalidOperationException>(() => playerSession.Send(
             GuaGameInputKind.Semantic, GuaGameInputOperation.Press, "debug_cheat", true));

--- a/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
+++ b/bindings/dotnet/tests/Gua.Selector.Tests/SelectorParityTests.cs
@@ -1756,6 +1756,31 @@ public sealed class SelectorParityTests
         });
     }
 
+    [Test]
+    public void GameInputSearchUsesCoreMetadataAndPlayerProjection()
+    {
+        using var runtime = new GuaRuntime();
+        runtime.EnableGameInput(GuaGameInputCapabilities.Semantic, () => { }, GuaGameInputCapabilities.Semantic);
+        runtime.PublishGameInputActions("inventory", [
+            new GuaGameInputActionDescriptor("open_inventory", "Open inventory", GuaGameInputValueType.Button,
+                Category: "menu", Aliases: ["show items"], Tags: ["inventory", "ui"]),
+            new GuaGameInputActionDescriptor("debug_cheat", "Debug cheat", GuaGameInputValueType.Button,
+                Category: "debug", AgentExposure: GuaAgentExposure.Private),
+        ]);
+
+        var debug = runtime.FindGameInputActions(new(Query: "items", Category: "menu", Tags: ["inventory"]));
+        Assert.Multiple(() => {
+            Assert.That(debug.Count, Is.EqualTo(1));
+            Assert.That(debug.Actions.Single().Id, Is.EqualTo("open_inventory"));
+            Assert.That(debug.Context, Is.EqualTo("inventory"));
+        });
+        var player = runtime.FindGameInputActions(new(Limit: 100), GuaObservationProfile.Player);
+        Assert.That(player.Actions.Select(action => action.Id), Is.EqualTo(new[] { "open_inventory" }));
+        using var playerSession = runtime.CreateGameInputSession(GuaObservationProfile.Player);
+        Assert.Throws<InvalidOperationException>(() => playerSession.Send(
+            GuaGameInputKind.Semantic, GuaGameInputOperation.Press, "debug_cheat", true));
+    }
+
     private static int ScheduledCount(object clock)
     {
         var field = clock.GetType().GetField("scheduled", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)

--- a/bindings/unity/Documentation~/index.md
+++ b/bindings/unity/Documentation~/index.md
@@ -26,7 +26,10 @@ read-only `get_world_object_tree`, `find_world_objects`, and
 by `gua-world-tools`; WebMCP callers cannot elevate the runtime observation
 profile or invoke actions on world objects.
 When `GuaGameInputMap` initializes the input pump, the same page bridge exposes
-only the matching Semantic Game Action and Raw Input capabilities. Calls wait
+only the matching Semantic Game Action and Raw Input capabilities. The Action
+Map component exposes category, aliases, tags, and Player agent exposure;
+`find_game_input_actions` performs bounded discovery without generating dynamic
+tools. Keep secrets out of descriptor metadata. Calls wait
 for correlated host completion and use a page-owned session that is released on
 abort, timeout, bridge uninstall, or runtime destruction.
 

--- a/bindings/unity/Runtime/GuaGameInputMap.cs
+++ b/bindings/unity/Runtime/GuaGameInputMap.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Gua.Core;
 using Gua.Runtime;
 using UnityEngine;
 
@@ -21,10 +22,14 @@ public sealed class GuaGameInputAction
     public string[] Bindings = Array.Empty<string>();
     public string Risk = "safe";
     public bool RequiresConfirmation;
+    public string Category = "";
+    public string[] Aliases = Array.Empty<string>();
+    public string[] Tags = Array.Empty<string>();
+    public GuaAgentExposure AgentExposure;
 
     internal GuaGameInputActionDescriptor Descriptor() => new(
         Id, Description, ValueType, HasRange ? Minimum : null, HasRange ? Maximum : null,
-        Holdable, Active, Bindings, Risk, RequiresConfirmation);
+        Holdable, Active, Bindings, Risk, RequiresConfirmation, Category, Aliases, Tags, AgentExposure);
 }
 
 public sealed class GuaGameInputMap : MonoBehaviour

--- a/bindings/unity/Runtime/GuaUnityRuntime.cs
+++ b/bindings/unity/Runtime/GuaUnityRuntime.cs
@@ -154,6 +154,25 @@ public sealed partial class GuaUnityRuntime : MonoBehaviour
     public void HandleWebRequest(string json)
     {
         if (runtime == null) return;
+        int callId;
+        string commandType;
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            callId = document.RootElement.GetProperty("callId").GetInt32();
+            commandType = document.RootElement.GetProperty("command").GetProperty("type").GetString() ?? string.Empty;
+        }
+        catch (Exception error) { Debug.LogError("Invalid Gua WebGL request: " + error.Message); return; }
+        // Game input search uses a boolean `active` field, while the legacy world-query DTO below uses an integer
+        // tri-state field with the same name. Route search before JsonUtility attempts that incompatible conversion.
+        if (commandType == "find_game_input_actions")
+        {
+            if ((playerGameInputCapabilities & GuaGameInputCapabilities.Semantic) == 0) { ResolveWebError(callId, "engine_unsupported", "Unity Player game input is not authorized."); return; }
+            if (!TryGameInputSelector(json, out var selector, out var selectorError)) { ResolveWebError(callId, "invalid_request", selectorError); return; }
+            try { GuaUnityWebResolve(webOwnerId, callId, runtime.FindGameInputActionsJson(selector, GuaObservationProfile.Player), 0); }
+            catch (Exception error) { ResolveWebError(callId, "invalid_request", error.Message); }
+            return;
+        }
         WebEnvelope envelope;
         try { envelope = JsonUtility.FromJson<WebEnvelope>(json); }
         catch (Exception error) { Debug.LogError("Invalid Gua WebGL request: " + error.Message); return; }
@@ -187,14 +206,6 @@ public sealed partial class GuaUnityRuntime : MonoBehaviour
         {
             if ((playerGameInputCapabilities & GuaGameInputCapabilities.Semantic) == 0) { ResolveWebError(envelope.callId, "engine_unsupported", "Unity Player game input is not authorized."); return; }
             GuaUnityWebResolve(webOwnerId, envelope.callId, runtime.GetPlayerGameInputActionsJson(), 0);
-            return;
-        }
-        if (envelope.command.type == "find_game_input_actions")
-        {
-            if ((playerGameInputCapabilities & GuaGameInputCapabilities.Semantic) == 0) { ResolveWebError(envelope.callId, "engine_unsupported", "Unity Player game input is not authorized."); return; }
-            if (!TryGameInputSelector(json, out var selector, out var selectorError)) { ResolveWebError(envelope.callId, "invalid_request", selectorError); return; }
-            try { GuaUnityWebResolve(webOwnerId, envelope.callId, runtime.FindGameInputActionsJson(selector, GuaObservationProfile.Player), 0); }
-            catch (Exception error) { ResolveWebError(envelope.callId, "invalid_request", error.Message); }
             return;
         }
         if (envelope.command.type == "get_game_input_state")
@@ -503,12 +514,36 @@ public sealed partial class GuaUnityRuntime : MonoBehaviour
                     ? value.GetString() ?? string.Empty : throw new FormatException("tags must contain strings.")).ToArray()
                     : throw new FormatException("tags must be an array.") : Array.Empty<string>();
             var limit = command.TryGetProperty("limit", out var limitValue) ? limitValue.GetUInt32() : 20U;
-            if (limit is < 1 or > 100 || tags.Length > 16 || tags.Any(string.IsNullOrEmpty) || tags.Distinct(StringComparer.Ordinal).Count() != tags.Length)
+            var id = Text("id"); var query = Text("query"); var context = Text("context"); var category = Text("category");
+            if ((id != null && !ValidGameInputIdentifier(id)) || (category != null && !ValidGameInputIdentifier(category)) ||
+                (query != null && !ValidGameInputText(query, 128)) || (context != null && !ValidGameInputText(context, int.MaxValue)) ||
+                limit is < 1 or > 100 || tags.Length > 16 || tags.Any(tag => !ValidGameInputText(tag, 64)) ||
+                tags.Distinct(StringComparer.Ordinal).Count() != tags.Length)
                 throw new FormatException("Game input selector limits or tags are invalid.");
-            selector = new(Text("id"), Text("query"), valueType, active, Text("context"), Text("category"), tags, limit);
+            selector = new(id, query, valueType, active, context, category, tags, limit);
             error = string.Empty; return true;
         }
         catch (Exception parseError) { error = parseError.Message; return false; }
+    }
+
+    private static bool ValidGameInputIdentifier(string value) => value.Length is > 0 and < 128 && value[0] is >= 'a' and <= 'z' &&
+        value.All(character => character is >= 'a' and <= 'z' or >= '0' and <= '9' or '_' or '.' or '-');
+
+    private static bool ValidGameInputText(string value, int maximumCodePoints)
+    {
+        if (value.Length == 0) return false;
+        var codePoints = 0;
+        for (var index = 0; index < value.Length; index++)
+        {
+            var character = value[index];
+            if (character == '\0' || char.IsLowSurrogate(character)) return false;
+            if (char.IsHighSurrogate(character))
+            {
+                if (++index >= value.Length || !char.IsLowSurrogate(value[index])) return false;
+            }
+            if (++codePoints > maximumCodePoints) return false;
+        }
+        return true;
     }
 
     private readonly struct ParsedGameInput

--- a/bindings/unity/Runtime/GuaUnityRuntime.cs
+++ b/bindings/unity/Runtime/GuaUnityRuntime.cs
@@ -186,7 +186,15 @@ public sealed partial class GuaUnityRuntime : MonoBehaviour
         if (envelope.command.type == "get_game_input_actions")
         {
             if ((playerGameInputCapabilities & GuaGameInputCapabilities.Semantic) == 0) { ResolveWebError(envelope.callId, "engine_unsupported", "Unity Player game input is not authorized."); return; }
-            GuaUnityWebResolve(webOwnerId, envelope.callId, runtime.GetGameInputActionsJson(), 0);
+            GuaUnityWebResolve(webOwnerId, envelope.callId, runtime.GetPlayerGameInputActionsJson(), 0);
+            return;
+        }
+        if (envelope.command.type == "find_game_input_actions")
+        {
+            if ((playerGameInputCapabilities & GuaGameInputCapabilities.Semantic) == 0) { ResolveWebError(envelope.callId, "engine_unsupported", "Unity Player game input is not authorized."); return; }
+            if (!TryGameInputSelector(json, out var selector, out var selectorError)) { ResolveWebError(envelope.callId, "invalid_request", selectorError); return; }
+            try { GuaUnityWebResolve(webOwnerId, envelope.callId, runtime.FindGameInputActionsJson(selector, GuaObservationProfile.Player), 0); }
+            catch (Exception error) { ResolveWebError(envelope.callId, "invalid_request", error.Message); }
             return;
         }
         if (envelope.command.type == "get_game_input_state")
@@ -317,6 +325,7 @@ public sealed partial class GuaUnityRuntime : MonoBehaviour
     {
         var result = new List<string>();
         if ((playerGameInputCapabilities & GuaGameInputCapabilities.Semantic) != 0) result.Add("semantic_game_input_v1");
+        if ((playerGameInputCapabilities & GuaGameInputCapabilities.Semantic) != 0) result.Add("semantic_game_input_search_v1");
         if ((playerGameInputCapabilities & GuaGameInputCapabilities.Keyboard) != 0) result.Add("raw_keyboard_input_v1");
         if ((playerGameInputCapabilities & GuaGameInputCapabilities.Pointer) != 0) result.Add("raw_pointer_input_v1");
         if ((playerGameInputCapabilities & GuaGameInputCapabilities.Gamepad) != 0) result.Add("raw_gamepad_input_v1");
@@ -459,11 +468,47 @@ public sealed partial class GuaUnityRuntime : MonoBehaviour
     private bool WebGameInputRequiresConfirmation(string actionId)
     {
         if (runtime == null) return false;
-        using var document = JsonDocument.Parse(runtime.GetGameInputActionsJson());
+        using var document = JsonDocument.Parse(runtime.FindGameInputActionsJson(new GuaGameInputActionSelector(Id: actionId, Limit: 1), GuaObservationProfile.Player));
         foreach (var action in document.RootElement.GetProperty("actions").EnumerateArray())
             if (action.GetProperty("id").GetString() == actionId)
                 return action.TryGetProperty("requiresConfirmation", out var confirmation) && confirmation.ValueKind == JsonValueKind.True;
         return false;
+    }
+
+    private static bool TryGameInputSelector(string json, out GuaGameInputActionSelector selector, out string error)
+    {
+        selector = new(); error = "Invalid game input selector.";
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            var command = document.RootElement.GetProperty("command");
+            var allowed = new HashSet<string>(new[] { "type", "id", "query", "valueType", "active", "context", "category", "tags", "limit" }, StringComparer.Ordinal);
+            if (command.EnumerateObject().Any(property => !allowed.Contains(property.Name))) throw new FormatException("Unknown game input selector field.");
+            string? Text(string name)
+            {
+                if (!command.TryGetProperty(name, out var value)) return null;
+                if (value.ValueKind != JsonValueKind.String) throw new FormatException($"{name} must be a string.");
+                var text = value.GetString();
+                if (string.IsNullOrEmpty(text)) throw new FormatException($"{name} must not be empty.");
+                return text;
+            }
+            var valueTypeText = Text("valueType");
+            GuaGameInputValueType? valueType = valueTypeText switch { null => null, "button" => GuaGameInputValueType.Button,
+                "axis1d" => GuaGameInputValueType.Axis1D, "vector2" => GuaGameInputValueType.Vector2, "text" => GuaGameInputValueType.Text, _ => throw new FormatException("valueType is invalid.") };
+            bool? active = command.TryGetProperty("active", out var activeValue)
+                ? activeValue.ValueKind is JsonValueKind.True or JsonValueKind.False ? activeValue.GetBoolean() : throw new FormatException("active must be boolean.")
+                : null;
+            var tags = command.TryGetProperty("tags", out var tagValues)
+                ? tagValues.ValueKind == JsonValueKind.Array ? tagValues.EnumerateArray().Select(value => value.ValueKind == JsonValueKind.String
+                    ? value.GetString() ?? string.Empty : throw new FormatException("tags must contain strings.")).ToArray()
+                    : throw new FormatException("tags must be an array.") : Array.Empty<string>();
+            var limit = command.TryGetProperty("limit", out var limitValue) ? limitValue.GetUInt32() : 20U;
+            if (limit is < 1 or > 100 || tags.Length > 16 || tags.Any(string.IsNullOrEmpty) || tags.Distinct(StringComparer.Ordinal).Count() != tags.Length)
+                throw new FormatException("Game input selector limits or tags are invalid.");
+            selector = new(Text("id"), Text("query"), valueType, active, Text("context"), Text("category"), tags, limit);
+            error = string.Empty; return true;
+        }
+        catch (Exception parseError) { error = parseError.Message; return false; }
     }
 
     private readonly struct ParsedGameInput

--- a/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
+++ b/examples/godot-gdscript/addons/gua/gua_auto_adapter.gd
@@ -49,6 +49,8 @@ const REQUIRED_CONTEXT_METHODS := [
 	"enable_virtual_clock_adapter",
 	"publish_game_input_actions",
 	"get_game_input_actions_json",
+	"get_player_game_input_actions_json",
+	"find_game_input_actions_json",
 	"enable_game_input_adapter",
 	"get_game_input_capabilities",
 	"create_game_input_owner",
@@ -448,6 +450,14 @@ func get_game_input_actions_json() -> String:
 	if not _ensure_context():
 		return "{}"
 	return context.get_game_input_actions_json()
+
+
+func get_player_game_input_actions_json() -> String:
+	return context.get_player_game_input_actions_json() if _ensure_context() else "{}"
+
+
+func find_game_input_actions_json(selector: Dictionary, observation_profile := 0) -> String:
+	return context.find_game_input_actions_json(selector, observation_profile) if _ensure_context() else "{}"
 
 
 func create_game_input_owner() -> int:

--- a/examples/godot-gdscript/addons/gua/gua_webmcp_bridge.gd
+++ b/examples/godot-gdscript/addons/gua/gua_webmcp_bridge.gd
@@ -12,6 +12,7 @@ var poll_callback: JavaScriptObject
 var cancel_callback: JavaScriptObject
 var get_game_input_capabilities_callback: JavaScriptObject
 var get_game_input_actions_callback: JavaScriptObject
+var find_game_input_actions_callback: JavaScriptObject
 var get_game_input_state_callback: JavaScriptObject
 var enqueue_game_input_callback: JavaScriptObject
 var poll_game_input_callback: JavaScriptObject
@@ -37,6 +38,7 @@ func attach(gua_adapter: RefCounted) -> bool:
 	cancel_callback = JavaScriptBridge.create_callback(_cancel_action)
 	get_game_input_capabilities_callback = JavaScriptBridge.create_callback(_get_game_input_capabilities)
 	get_game_input_actions_callback = JavaScriptBridge.create_callback(_get_game_input_actions)
+	find_game_input_actions_callback = JavaScriptBridge.create_callback(_find_game_input_actions)
 	get_game_input_state_callback = JavaScriptBridge.create_callback(_get_game_input_state)
 	enqueue_game_input_callback = JavaScriptBridge.create_callback(_enqueue_game_input)
 	poll_game_input_callback = JavaScriptBridge.create_callback(_poll_game_input)
@@ -49,6 +51,7 @@ func attach(gua_adapter: RefCounted) -> bool:
 	window.__guaGodotCancelAction = cancel_callback
 	window.__guaGodotGetGameInputCapabilities = get_game_input_capabilities_callback
 	window.__guaGodotGetGameInputActions = get_game_input_actions_callback
+	window.__guaGodotFindGameInputActions = find_game_input_actions_callback
 	window.__guaGodotGetGameInputState = get_game_input_state_callback
 	window.__guaGodotEnqueueGameInput = enqueue_game_input_callback
 	window.__guaGodotPollGameInput = poll_game_input_callback
@@ -68,6 +71,7 @@ func attach(gua_adapter: RefCounted) -> bool:
   const cancelAction = globalThis.__guaGodotCancelAction;
   const getGameInputCapabilities = globalThis.__guaGodotGetGameInputCapabilities;
   const getGameInputActions = globalThis.__guaGodotGetGameInputActions;
+  const findGameInputActions = globalThis.__guaGodotFindGameInputActions;
   const getGameInputState = globalThis.__guaGodotGetGameInputState;
   const enqueueGameInput = globalThis.__guaGodotEnqueueGameInput;
   const pollGameInput = globalThis.__guaGodotPollGameInput;
@@ -125,6 +129,7 @@ func attach(gua_adapter: RefCounted) -> bool:
       }
       if (command.type === 'get_game_input_capabilities') return JSON.parse(callGodot(getGameInputCapabilities));
       if (command.type === 'get_game_input_actions') return JSON.parse(callGodot(getGameInputActions));
+      if (command.type === 'find_game_input_actions') return JSON.parse(callGodot(findGameInputActions, JSON.stringify(command)));
       if (command.type === 'get_game_input_state') return JSON.parse(callGodot(getGameInputState));
       if (command.type === 'perform_game_input') {
         const receipt = JSON.parse(callGodot(enqueueGameInput, JSON.stringify(command.request)));
@@ -258,6 +263,7 @@ func detach() -> void:
   delete globalThis.__guaGodotCancelAction;
   delete globalThis.__guaGodotGetGameInputCapabilities;
   delete globalThis.__guaGodotGetGameInputActions;
+  delete globalThis.__guaGodotFindGameInputActions;
   delete globalThis.__guaGodotGetGameInputState;
   delete globalThis.__guaGodotEnqueueGameInput;
   delete globalThis.__guaGodotPollGameInput;
@@ -274,6 +280,7 @@ func detach() -> void:
 	cancel_callback = null
 	get_game_input_capabilities_callback = null
 	get_game_input_actions_callback = null
+	find_game_input_actions_callback = null
 	get_game_input_state_callback = null
 	enqueue_game_input_callback = null
 	poll_game_input_callback = null
@@ -383,6 +390,7 @@ func _game_input_capabilities(adapter: RefCounted) -> Array:
 	var mask := int(adapter.get_game_input_capabilities(1))
 	var result: Array = []
 	if mask & 1: result.push_back("semantic_game_input_v1")
+	if mask & 1: result.push_back("semantic_game_input_search_v1")
 	if mask & 2: result.push_back("raw_keyboard_input_v1")
 	if mask & 4: result.push_back("raw_pointer_input_v1")
 	if mask & 8: result.push_back("raw_gamepad_input_v1")
@@ -401,7 +409,25 @@ func _get_game_input_actions(arguments: Array) -> void:
 	if adapter == null or not "semantic_game_input_v1" in _game_input_capabilities(adapter):
 		_respond(arguments, JSON.stringify({"code": "engine_unsupported", "message": "Semantic game input is unavailable."}))
 		return
-	_respond(arguments, adapter.get_game_input_actions_json())
+	_respond(arguments, adapter.get_player_game_input_actions_json())
+
+
+func _find_game_input_actions(arguments: Array) -> void:
+	var adapter := _adapter()
+	if adapter == null or not "semantic_game_input_search_v1" in _game_input_capabilities(adapter):
+		_respond(arguments, JSON.stringify({"code": "engine_unsupported", "message": "Semantic game input search is unavailable."}))
+		return
+	var source = JSON.parse_string(str(_request_argument(arguments)))
+	if not source is Dictionary:
+		_respond(arguments, JSON.stringify({"code": "invalid_request", "message": "Invalid game input selector."}))
+		return
+	var selector := {
+		"id": source.get("id", ""), "query": source.get("query", ""), "value_type": source.get("valueType", ""),
+		"active": source.get("active") if source.has("active") else null, "context": source.get("context", ""),
+		"category": source.get("category", ""), "tags": source.get("tags", []), "limit": source.get("limit", 20),
+	}
+	if selector.active == null: selector.erase("active")
+	_respond(arguments, adapter.find_game_input_actions_json(selector, 1))
 
 
 func _get_game_input_state(arguments: Array) -> void:
@@ -427,7 +453,8 @@ func _enqueue_game_input(arguments: Array) -> void:
 		return
 	var request: Dictionary = source
 	if request.get("type", "") in ["press_game_input_action", "set_game_input_action"]:
-		var action_map = JSON.parse_string(adapter.get_game_input_actions_json())
+		var action_map = JSON.parse_string(adapter.find_game_input_actions_json(
+			{"id": request.get("actionId", ""), "limit": 1}, 1))
 		if action_map is Dictionary:
 			for action in action_map.get("actions", []):
 				if action is Dictionary and action.get("id", "") == request.get("actionId", "") and action.get("requiresConfirmation", false) and not request.get("confirmed", false):

--- a/examples/godot-gdscript/scripts/gua_smoke.gd
+++ b/examples/godot-gdscript/scripts/gua_smoke.gd
@@ -191,10 +191,10 @@ func _run() -> void:
 		_fail("Gua Player game input must be denied before explicit host opt-in.")
 		return
 	if not ui.configure_game_input_actions("gameplay", [
-		{"id": "jump", "description": "Jump", "value_type": "button", "holdable": true, "bindings": ["Space"]},
+		{"id": "jump", "description": "Jump", "value_type": "button", "holdable": true, "bindings": ["Space"], "category": "movement", "aliases": ["hop"], "tags": ["gameplay", "air"]},
 		{"id": "throttle", "description": "Throttle", "value_type": "axis1d", "minimum": -1.0, "maximum": 1.0, "holdable": true},
 		{"id": "move", "description": "Move", "value_type": "vector2", "minimum": -1.0, "maximum": 1.0, "holdable": true},
-		{"id": "chat", "description": "Chat", "value_type": "text"},
+		{"id": "chat", "description": "Chat", "value_type": "text", "agent_exposure": "private"},
 	], true) or not ui.enable_raw_input(true):
 		_fail("Gua smoke failed to initialize game input capabilities.")
 		return
@@ -205,6 +205,28 @@ func _run() -> void:
 	var game_input_actions: String = ui.context.get_game_input_actions_json()
 	if not game_input_actions.contains("\"button\"") or not game_input_actions.contains("\"axis1d\"") or not game_input_actions.contains("\"vector2\"") or not game_input_actions.contains("\"text\""):
 		_fail("Gua smoke did not publish every game input action type: %s" % game_input_actions)
+		return
+	var player_actions: String = ui.context.get_player_game_input_actions_json()
+	var jump_search: String = ui.context.find_game_input_actions_json({"query": "hop", "category": "movement", "tags": ["gameplay"], "limit": 1}, 1)
+	if player_actions.contains("\"chat\"") or not jump_search.contains("\"jump\"") or not jump_search.contains("\"truncated\":false"):
+		_fail("Gua Player game-input projection/search did not enforce descriptor v2 metadata: %s / %s" % [player_actions, jump_search])
+		return
+	if not ui.configure_game_input_actions("menu", [
+		{"id": "jump", "description": "Jump", "value_type": "button", "holdable": true, "category": "movement", "aliases": ["hop"], "tags": ["menu"]},
+	], true):
+		_fail("Gua smoke could not republish the Action Map in another context.")
+		return
+	var menu_search: String = ui.context.find_game_input_actions_json({"id": "jump", "context": "menu"}, 1)
+	if not menu_search.contains("\"context\":\"menu\"") or not menu_search.contains("\"jump\""):
+		_fail("Gua smoke did not expose the republished Action Map context: %s" % menu_search)
+		return
+	if not ui.configure_game_input_actions("gameplay", [
+		{"id": "jump", "description": "Jump", "value_type": "button", "holdable": true, "bindings": ["Space"], "category": "movement", "aliases": ["hop"], "tags": ["gameplay", "air"]},
+		{"id": "throttle", "description": "Throttle", "value_type": "axis1d", "minimum": -1.0, "maximum": 1.0, "holdable": true},
+		{"id": "move", "description": "Move", "value_type": "vector2", "minimum": -1.0, "maximum": 1.0, "holdable": true},
+		{"id": "chat", "description": "Chat", "value_type": "text", "agent_exposure": "private"},
+	], true):
+		_fail("Gua smoke could not restore the gameplay Action Map after context search.")
 		return
 	var web_input_bridge = load("res://addons/gua/gua_webmcp_bridge.gd").new()
 	var wheel_request: Dictionary = web_input_bridge._native_game_input_request({

--- a/examples/unity-smoke/Assets/GuaUnityFixture.cs
+++ b/examples/unity-smoke/Assets/GuaUnityFixture.cs
@@ -42,10 +42,10 @@ public static class GuaUnityFixture
         inputMap.EnableRawInput = true;
         inputMap.AllowPlayerAgentSemanticInput = true;
         inputMap.AllowPlayerAgentRawInput = true;
-        inputMap.Actions.Add(new GuaGameInputAction { Id = "jump", Description = "Jump", ValueType = Gua.Runtime.GuaGameInputValueType.Button, Holdable = true, Bindings = new[] { "Space" } });
+        inputMap.Actions.Add(new GuaGameInputAction { Id = "jump", Description = "Jump", ValueType = Gua.Runtime.GuaGameInputValueType.Button, Holdable = true, Bindings = new[] { "Space" }, Category = "movement", Aliases = new[] { "hop" }, Tags = new[] { "gameplay", "air" }, AgentExposure = Gua.Core.GuaAgentExposure.Auto });
         inputMap.Actions.Add(new GuaGameInputAction { Id = "throttle", Description = "Throttle", ValueType = Gua.Runtime.GuaGameInputValueType.Axis1D, HasRange = true, Minimum = -1, Maximum = 1, Holdable = true });
         inputMap.Actions.Add(new GuaGameInputAction { Id = "move", Description = "Move", ValueType = Gua.Runtime.GuaGameInputValueType.Vector2, HasRange = true, Minimum = -1, Maximum = 1, Holdable = true });
-        inputMap.Actions.Add(new GuaGameInputAction { Id = "chat", Description = "Chat", ValueType = Gua.Runtime.GuaGameInputValueType.Text });
+        inputMap.Actions.Add(new GuaGameInputAction { Id = "chat", Description = "Chat", ValueType = Gua.Runtime.GuaGameInputValueType.Text, AgentExposure = Gua.Core.GuaAgentExposure.Private });
 
         if (Object.FindFirstObjectByType<EventSystem>() == null)
         {

--- a/native/gua-core/include/gua/gua.h
+++ b/native/gua-core/include/gua/gua.h
@@ -85,6 +85,30 @@ typedef struct gua_game_input_action_descriptor_v1_t {
     int requires_confirmation;
 } gua_game_input_action_descriptor_v1_t;
 
+typedef struct gua_game_input_action_descriptor_v2_t {
+    uint32_t struct_size;
+    gua_game_input_action_descriptor_v1_t base;
+    const char* category;
+    const char* const* aliases;
+    uint32_t alias_count;
+    const char* const* tags;
+    uint32_t tag_count;
+    int agent_exposure;
+} gua_game_input_action_descriptor_v2_t;
+
+typedef struct gua_game_input_action_selector_v1_t {
+    uint32_t struct_size;
+    const char* id;
+    const char* query;
+    int value_type;
+    int active;
+    const char* context;
+    const char* category;
+    const char* const* tags;
+    uint32_t tag_count;
+    uint32_t limit;
+} gua_game_input_action_selector_v1_t;
+
 typedef struct gua_game_input_request_descriptor_v1_t {
     uint32_t struct_size;
     uint64_t owner_id;
@@ -644,14 +668,20 @@ int gua_reset_context(gua_context_t* ctx, const gua_reset_options_t* options, gu
 /* Game input action-map publication is atomic and independent from the UI tree. */
 int gua_begin_game_input_frame(gua_context_t* ctx, const char* input_context);
 int gua_register_game_input_action_v1(gua_context_t* ctx, const gua_game_input_action_descriptor_v1_t* descriptor);
+int gua_register_game_input_action_v2(gua_context_t* ctx, const gua_game_input_action_descriptor_v2_t* descriptor);
 int gua_end_game_input_frame(gua_context_t* ctx);
 int gua_abort_game_input_frame(gua_context_t* ctx);
 int gua_copy_game_input_actions_json(gua_context_t* ctx, char* out_json, int out_json_size);
+int gua_copy_game_input_actions_json_for_profile(gua_context_t* ctx, int observation_profile, char* out_json, int out_json_size);
+int gua_query_game_input_actions_json(gua_context_t* ctx, const gua_game_input_action_selector_v1_t* selector,
+    int observation_profile, char* out_json, int out_json_size);
 /* Owners isolate held inputs. A zero owner is invalid. */
 uint64_t gua_create_game_input_owner(gua_context_t* ctx);
 int gua_release_game_input_owner(gua_context_t* ctx, uint64_t owner_id);
 int gua_enqueue_game_input(gua_context_t* ctx, const gua_game_input_request_descriptor_v1_t* descriptor, uint64_t* out_request_id);
 int gua_enqueue_game_input_v2(gua_context_t* ctx, const gua_game_input_request_descriptor_v2_t* descriptor, uint64_t* out_request_id);
+int gua_enqueue_game_input_for_profile_v2(gua_context_t* ctx, const gua_game_input_request_descriptor_v2_t* descriptor,
+    int observation_profile, uint64_t* out_request_id);
 int gua_consume_game_input_request(gua_context_t* ctx, gua_game_input_request_v1_t* out_request);
 int gua_complete_game_input_request(gua_context_t* ctx, uint64_t request_id, int succeeded, int error_code);
 /* Advance safety leases with unscaled host time, never GuaClock time. */

--- a/native/gua-core/include/gua/gua.hpp
+++ b/native/gua-core/include/gua/gua.hpp
@@ -113,6 +113,20 @@ struct GameInputAction {
     std::string bindings_json = "[]";
     std::string risk = "safe";
     bool requires_confirmation = false;
+    std::string category;
+    std::vector<std::string> aliases;
+    std::vector<std::string> tags;
+    int agent_exposure = GUA_AGENT_EXPOSURE_AUTO;
+};
+struct GameInputActionSelector {
+    std::string id, query, context, category;
+    std::optional<GameInputValueType> value_type;
+    std::optional<bool> active;
+    std::vector<std::string> tags;
+    std::uint32_t limit = 20;
+};
+struct GameInputActionSearchResult {
+    std::string json;
 };
 struct GameInputRequest {
     std::uint64_t request_id = 0, owner_id = 0;
@@ -490,11 +504,18 @@ public:
                 gua_abort_game_input_frame(context_);
                 throw std::invalid_argument("Game input range requires minimum and maximum");
             }
-            gua_game_input_action_descriptor_v1_t descriptor { sizeof(descriptor), action.id.c_str(), action.description.c_str(),
+            gua_game_input_action_descriptor_v1_t base { sizeof(base), action.id.c_str(), action.description.c_str(),
                 static_cast<int>(action.value_type), action.minimum.value_or(0), action.maximum.value_or(0), has_range ? 1 : 0,
                 action.holdable ? 1 : 0, action.active ? 1 : 0, action.bindings_json.c_str(), action.risk.c_str(),
                 action.requires_confirmation ? 1 : 0 };
-            if (!gua_register_game_input_action_v1(context_, &descriptor)) {
+            std::vector<const char*> aliases, tags;
+            for (const auto& alias : action.aliases) aliases.push_back(alias.c_str());
+            for (const auto& tag : action.tags) tags.push_back(tag.c_str());
+            gua_game_input_action_descriptor_v2_t descriptor { sizeof(descriptor), base,
+                action.category.empty() ? nullptr : action.category.c_str(), aliases.empty() ? nullptr : aliases.data(),
+                static_cast<std::uint32_t>(aliases.size()), tags.empty() ? nullptr : tags.data(),
+                static_cast<std::uint32_t>(tags.size()), action.agent_exposure };
+            if (!gua_register_game_input_action_v2(context_, &descriptor)) {
                 gua_abort_game_input_frame(context_);
                 throw std::invalid_argument("Invalid game input action: " + action.id);
             }
@@ -503,6 +524,26 @@ public:
     }
     [[nodiscard]] std::string game_input_actions_json() const
     { return copy_json([](auto* context, char* output, int size) { return gua_copy_game_input_actions_json(context, output, size); }); }
+    [[nodiscard]] std::string game_input_actions_json(int observation_profile) const
+    { return copy_json([observation_profile](auto* context, char* output, int size) { return gua_copy_game_input_actions_json_for_profile(context, observation_profile, output, size); }); }
+    [[nodiscard]] std::string find_game_input_actions_json(const GameInputActionSelector& selector,
+        int observation_profile = GUA_OBSERVATION_PROFILE_DEBUG) const
+    {
+        std::vector<const char*> tags;
+        for (const auto& tag : selector.tags) tags.push_back(tag.c_str());
+        gua_game_input_action_selector_v1_t native { sizeof(native), selector.id.empty() ? nullptr : selector.id.c_str(),
+            selector.query.empty() ? nullptr : selector.query.c_str(),
+            selector.value_type.has_value() ? static_cast<int>(*selector.value_type) : 0,
+            selector.active.has_value() ? (*selector.active ? GUA_FILTER_TRUE : GUA_FILTER_FALSE) : GUA_FILTER_ANY,
+            selector.context.empty() ? nullptr : selector.context.c_str(), selector.category.empty() ? nullptr : selector.category.c_str(),
+            tags.empty() ? nullptr : tags.data(), static_cast<std::uint32_t>(tags.size()), selector.limit };
+        return copy_json([&](auto* context, char* output, int size) {
+            return gua_query_game_input_actions_json(context, &native, observation_profile, output, size);
+        });
+    }
+    [[nodiscard]] GameInputActionSearchResult find_game_input_actions(const GameInputActionSelector& selector,
+        int observation_profile = GUA_OBSERVATION_PROFILE_DEBUG) const
+    { return { find_game_input_actions_json(selector, observation_profile) }; }
     [[nodiscard]] std::uint64_t create_game_input_owner() { return gua_create_game_input_owner(context_); }
     bool release_game_input_owner(std::uint64_t owner_id) { return gua_release_game_input_owner(context_, owner_id) != 0; }
     [[nodiscard]] std::string game_input_state_json(std::uint64_t owner_id) const

--- a/native/gua-core/include/gua/gua.hpp
+++ b/native/gua-core/include/gua/gua.hpp
@@ -2,6 +2,7 @@
 
 #include "gua/gua.h"
 
+#include <algorithm>
 #include <stdexcept>
 #include <cstdint>
 #include <optional>
@@ -499,6 +500,13 @@ public:
         std::string context(input_context);
         if (!gua_begin_game_input_frame(context_, context.c_str())) throw std::runtime_error("Failed to begin game input frame");
         for (const auto& action : actions) {
+            const auto contains_nul = [](const std::string& value) { return value.find('\0') != std::string::npos; };
+            if (contains_nul(action.category) ||
+                std::any_of(action.aliases.begin(), action.aliases.end(), contains_nul) ||
+                std::any_of(action.tags.begin(), action.tags.end(), contains_nul)) {
+                gua_abort_game_input_frame(context_);
+                throw std::invalid_argument("Game input category, aliases, and tags must not contain embedded NUL characters");
+            }
             const bool has_range = action.minimum.has_value() || action.maximum.has_value();
             if (has_range && (!action.minimum.has_value() || !action.maximum.has_value())) {
                 gua_abort_game_input_frame(context_);
@@ -529,6 +537,10 @@ public:
     [[nodiscard]] std::string find_game_input_actions_json(const GameInputActionSelector& selector,
         int observation_profile = GUA_OBSERVATION_PROFILE_DEBUG) const
     {
+        const auto contains_nul = [](const std::string& value) { return value.find('\0') != std::string::npos; };
+        if (contains_nul(selector.id) || contains_nul(selector.query) || contains_nul(selector.context) ||
+            contains_nul(selector.category) || std::any_of(selector.tags.begin(), selector.tags.end(), contains_nul))
+            throw std::invalid_argument("Game input selectors must not contain embedded NUL characters");
         std::vector<const char*> tags;
         for (const auto& tag : selector.tags) tags.push_back(tag.c_str());
         gua_game_input_action_selector_v1_t native { sizeof(native), selector.id.empty() ? nullptr : selector.id.c_str(),

--- a/native/gua-core/src/gua.cpp
+++ b/native/gua-core/src/gua.cpp
@@ -47,7 +47,7 @@ std::string build_version_json(const char* godot_plugin_version = nullptr)
     return "{\"protocolSchemaVersion\":\"2\",\"coreVersion\":\"" GUA_VERSION
         "\",\"runtimeVersion\":\"" GUA_VERSION "\",\"godotPluginVersion\":" + plugin + ",\"adapterVersions\":{}" +
         ",\"abiVersion\":1,\"buildId\":\"" GUA_BUILD_ID
-        "\",\"capabilities\":[\"semantic_ui_tree_v2\",\"detailed_semantic_state_v1\",\"semantic_actions_v2\",\"context_reset_v1\",\"diagnostics_v1\",\"version_v1\",\"capture_screenshot_v1\",\"virtual_clock_v1\",\"semantic_game_input_v1\",\"raw_keyboard_input_v1\",\"raw_pointer_input_v1\",\"raw_gamepad_input_v1\",\"text_input_v1\",\"game_input_lease_v1\",\"world_object_tree_v1\",\"agent_projection_v1\"]}";
+        "\",\"capabilities\":[\"semantic_ui_tree_v2\",\"detailed_semantic_state_v1\",\"semantic_actions_v2\",\"context_reset_v1\",\"diagnostics_v1\",\"version_v1\",\"capture_screenshot_v1\",\"virtual_clock_v1\",\"semantic_game_input_v1\",\"semantic_game_input_search_v1\",\"raw_keyboard_input_v1\",\"raw_pointer_input_v1\",\"raw_gamepad_input_v1\",\"text_input_v1\",\"game_input_lease_v1\",\"world_object_tree_v1\",\"agent_projection_v1\"]}";
 }
 
 struct AgentFieldRule {
@@ -193,6 +193,10 @@ struct GameInputAction {
     std::string bindings_json = "[]";
     std::string risk = "safe";
     bool requires_confirmation = false;
+    std::string category;
+    std::vector<std::string> aliases;
+    std::vector<std::string> tags;
+    int agent_exposure = GUA_AGENT_EXPOSURE_AUTO;
 };
 
 struct GameInputRequest {
@@ -212,6 +216,7 @@ struct GameInputRequest {
     bool lease_expired = false;
     bool suppress_result = false;
     double remaining_lease_ms = 0.0;
+    int observation_profile = GUA_OBSERVATION_PROFILE_DEBUG;
 };
 
 struct HeldGameInput {
@@ -1108,7 +1113,9 @@ struct gua_context_t {
     bool game_input_frame_in_progress = false;
     bool game_input_staging_valid = true;
     unsigned long long game_input_revision = 0;
+    unsigned long long player_game_input_revision = 0;
     std::string previous_game_input_snapshot;
+    std::string previous_player_game_input_snapshot;
     unsigned long long next_game_input_owner_id = 1;
     std::unordered_set<unsigned long long> game_input_owners;
     unsigned long long next_game_input_request_id = 1;
@@ -1184,6 +1191,31 @@ bool valid_game_input_id(std::string_view value)
     return std::all_of(value.begin(), value.end(), [](char ch) {
         return (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '.' || ch == '-';
     });
+}
+
+bool valid_utf8_text(std::string_view value, std::size_t maximum_code_points)
+{
+    if (value.empty()) return false;
+    std::size_t code_points = 0;
+    for (std::size_t index = 0; index < value.size();) {
+        const unsigned char first = static_cast<unsigned char>(value[index]);
+        std::size_t width = first < 0x80U ? 1U : first >= 0xC2U && first <= 0xDFU ? 2U :
+            first >= 0xE0U && first <= 0xEFU ? 3U : first >= 0xF0U && first <= 0xF4U ? 4U : 0U;
+        if (width == 0 || index + width > value.size()) return false;
+        for (std::size_t offset = 1; offset < width; ++offset)
+            if ((static_cast<unsigned char>(value[index + offset]) & 0xC0U) != 0x80U) return false;
+        if (width == 3U) {
+            const unsigned char second = static_cast<unsigned char>(value[index + 1U]);
+            if ((first == 0xE0U && second < 0xA0U) || (first == 0xEDU && second >= 0xA0U)) return false;
+        }
+        if (width == 4U) {
+            const unsigned char second = static_cast<unsigned char>(value[index + 1U]);
+            if ((first == 0xF0U && second < 0x90U) || (first == 0xF4U && second >= 0x90U)) return false;
+        }
+        index += width;
+        if (++code_points > maximum_code_points) return false;
+    }
+    return true;
 }
 
 void skip_json_whitespace(std::string_view value, std::size_t& index)
@@ -1404,13 +1436,16 @@ bool one_of(int value, std::initializer_list<int> allowed)
 }
 
 int validate_semantic_game_input(const std::vector<GameInputAction>& actions, int operation,
-    std::string_view target, std::string_view value, bool confirmed)
+    std::string_view target, std::string_view value, bool confirmed,
+    int observation_profile = GUA_OBSERVATION_PROFILE_DEBUG)
 {
     if (operation == GUA_GAME_INPUT_RELEASE)
         return valid_game_input_id(target) ? GUA_GAME_INPUT_OK : GUA_GAME_INPUT_ERROR_INVALID_VALUE;
     const auto action = std::find_if(actions.begin(), actions.end(),
         [&](const auto& item) { return item.id == target; });
     if (action == actions.end()) return GUA_GAME_INPUT_ERROR_ACTION_NOT_FOUND;
+    if (observation_profile == GUA_OBSERVATION_PROFILE_PLAYER && action->agent_exposure == GUA_AGENT_EXPOSURE_PRIVATE)
+        return GUA_GAME_INPUT_ERROR_ACTION_NOT_FOUND;
     if (!action->active) return GUA_GAME_INPUT_ERROR_INACTIVE;
     if ((operation == GUA_GAME_INPUT_PRESS || operation == GUA_GAME_INPUT_SET) &&
         action->requires_confirmation && !confirmed)
@@ -1440,12 +1475,15 @@ int validate_semantic_game_input(const std::vector<GameInputAction>& actions, in
     return GUA_GAME_INPUT_OK;
 }
 
-std::string build_game_input_semantic_snapshot(const std::string& context, const std::vector<GameInputAction>& actions)
+std::string build_game_input_semantic_snapshot(const std::string& context, const std::vector<GameInputAction>& actions,
+    int observation_profile = GUA_OBSERVATION_PROFILE_DEBUG)
 {
     std::string json = "{\"context\":\"" + escape_json(context) + "\",\"actions\":[";
-    for (std::size_t index = 0; index < actions.size(); ++index) {
-        const auto& action = actions[index];
-        if (index != 0) json += ",";
+    bool first_action = true;
+    for (const auto& action : actions) {
+        if (observation_profile == GUA_OBSERVATION_PROFILE_PLAYER && action.agent_exposure == GUA_AGENT_EXPOSURE_PRIVATE) continue;
+        if (!first_action) json += ",";
+        first_action = false;
         const char* type = action.value_type == GUA_GAME_INPUT_BUTTON ? "button" :
             action.value_type == GUA_GAME_INPUT_AXIS1D ? "axis1d" :
             action.value_type == GUA_GAME_INPUT_VECTOR2 ? "vector2" : "text";
@@ -1455,17 +1493,71 @@ std::string build_game_input_semantic_snapshot(const std::string& context, const
         json += ",\"holdable\":" + std::string(action.holdable ? "true" : "false") +
             ",\"active\":" + std::string(action.active ? "true" : "false") +
             ",\"bindings\":" + action.bindings_json + ",\"risk\":\"" + escape_json(action.risk) +
-            "\",\"requiresConfirmation\":" + (action.requires_confirmation ? "true" : "false") + "}";
+            "\",\"requiresConfirmation\":" + (action.requires_confirmation ? "true" : "false");
+        if (!action.category.empty()) json += ",\"category\":\"" + escape_json(action.category) + "\"";
+        json += ",\"aliases\":[";
+        for (std::size_t i = 0; i < action.aliases.size(); ++i) { if (i != 0) json += ','; json += "\"" + escape_json(action.aliases[i]) + "\""; }
+        json += "],\"tags\":[";
+        for (std::size_t i = 0; i < action.tags.size(); ++i) { if (i != 0) json += ','; json += "\"" + escape_json(action.tags[i]) + "\""; }
+        json += "],\"agentExposure\":\"" + std::string(action.agent_exposure == GUA_AGENT_EXPOSURE_PRIVATE ? "private" : "auto") + "\"}";
     }
     return json + "]}";
 }
 
-std::string build_game_input_actions_json(const gua_context_t& ctx)
+std::string build_game_input_actions_json(const gua_context_t& ctx, int observation_profile)
 {
-    std::string semantic = build_game_input_semantic_snapshot(ctx.game_input_context, ctx.game_input_actions);
+    std::string semantic = build_game_input_semantic_snapshot(ctx.game_input_context, ctx.game_input_actions, observation_profile);
     semantic.erase(semantic.begin());
+    const auto revision = observation_profile == GUA_OBSERVATION_PROFILE_PLAYER
+        ? ctx.player_game_input_revision : ctx.game_input_revision;
     return "{\"schemaVersion\":1,\"sessionEpoch\":" + std::to_string(ctx.session_epoch) +
-        ",\"revision\":" + std::to_string(ctx.game_input_revision) + "," + semantic;
+        ",\"revision\":" + std::to_string(revision) + "," + semantic;
+}
+
+bool game_input_action_matches(const GameInputAction& action, const gua_game_input_action_selector_v1_t& selector)
+{
+    if (selector.id != nullptr && selector.id[0] != '\0' && action.id != selector.id) return false;
+    if (selector.query != nullptr && selector.query[0] != '\0') {
+        const std::string_view query(selector.query);
+        bool matched = action.id.find(query) != std::string::npos || action.description.find(query) != std::string::npos;
+        for (const auto& alias : action.aliases) matched = matched || alias.find(query) != std::string::npos;
+        if (!matched) return false;
+    }
+    if (selector.value_type != 0 && action.value_type != selector.value_type) return false;
+    if (selector.active == GUA_FILTER_FALSE && action.active) return false;
+    if (selector.active == GUA_FILTER_TRUE && !action.active) return false;
+    if (selector.category != nullptr && selector.category[0] != '\0' && action.category != selector.category) return false;
+    for (std::uint32_t i = 0; i < selector.tag_count; ++i)
+        if (std::find(action.tags.begin(), action.tags.end(), selector.tags[i]) == action.tags.end()) return false;
+    return true;
+}
+
+std::string build_game_input_query_json(const gua_context_t& ctx,
+    const gua_game_input_action_selector_v1_t& selector, int observation_profile)
+{
+    std::vector<const GameInputAction*> matches;
+    if (selector.context == nullptr || selector.context[0] == '\0' || ctx.game_input_context == selector.context) {
+        for (const auto& action : ctx.game_input_actions) {
+            if (observation_profile == GUA_OBSERVATION_PROFILE_PLAYER && action.agent_exposure == GUA_AGENT_EXPOSURE_PRIVATE) continue;
+            if (game_input_action_matches(action, selector)) matches.push_back(&action);
+        }
+    }
+    std::sort(matches.begin(), matches.end(), [](const auto* left, const auto* right) { return left->id < right->id; });
+    const std::size_t limit = selector.limit == 0 ? 20U : selector.limit;
+    const bool truncated = matches.size() > limit;
+    if (truncated) matches.resize(limit);
+    std::vector<GameInputAction> selected;
+    selected.reserve(matches.size());
+    for (const auto* action : matches) selected.push_back(*action);
+    std::string semantic = build_game_input_semantic_snapshot(ctx.game_input_context, selected, observation_profile);
+    const auto actions_at = semantic.find("\"actions\":");
+    const std::string actions_json = semantic.substr(actions_at + 10U, semantic.size() - actions_at - 11U);
+    const auto revision = observation_profile == GUA_OBSERVATION_PROFILE_PLAYER
+        ? ctx.player_game_input_revision : ctx.game_input_revision;
+    return "{\"schemaVersion\":1,\"sessionEpoch\":" + std::to_string(ctx.session_epoch) +
+        ",\"revision\":" + std::to_string(revision) + ",\"context\":\"" + escape_json(ctx.game_input_context) +
+        "\",\"count\":" + std::to_string(selected.size()) + ",\"truncated\":" + (truncated ? "true" : "false") +
+        ",\"actions\":" + actions_json + "}";
 }
 
 bool held_key_matches(const HeldGameInput& held, unsigned long long owner_id, int kind,
@@ -3273,6 +3365,47 @@ extern "C" int gua_register_game_input_action_v1(gua_context_t* ctx, const gua_g
     return 1;
 }
 
+extern "C" int gua_register_game_input_action_v2(gua_context_t* ctx, const gua_game_input_action_descriptor_v2_t* descriptor)
+{
+    if (ctx == nullptr) return 0;
+    const auto reject = [&] {
+        const std::lock_guard lock(ctx->mutex);
+        if (ctx->game_input_frame_in_progress) ctx->game_input_staging_valid = false;
+        return 0;
+    };
+    if (descriptor == nullptr || descriptor->struct_size < sizeof(*descriptor) ||
+        descriptor->base.struct_size < sizeof(descriptor->base) || descriptor->alias_count > 16 || descriptor->tag_count > 16 ||
+        (descriptor->alias_count != 0 && descriptor->aliases == nullptr) ||
+        (descriptor->tag_count != 0 && descriptor->tags == nullptr) ||
+        !one_of(descriptor->agent_exposure, { GUA_AGENT_EXPOSURE_AUTO, GUA_AGENT_EXPOSURE_PRIVATE })) return reject();
+    if (descriptor->category != nullptr && descriptor->category[0] != '\0' && !valid_game_input_id(descriptor->category)) return reject();
+    std::vector<std::string> aliases, tags;
+    std::unordered_set<std::string> unique_aliases, unique_tags;
+    for (std::uint32_t i = 0; i < descriptor->alias_count; ++i) {
+        if (descriptor->aliases[i] == nullptr || !valid_utf8_text(descriptor->aliases[i], 64) ||
+            !unique_aliases.insert(descriptor->aliases[i]).second) return reject();
+        aliases.emplace_back(descriptor->aliases[i]);
+    }
+    for (std::uint32_t i = 0; i < descriptor->tag_count; ++i) {
+        if (descriptor->tags[i] == nullptr || !valid_utf8_text(descriptor->tags[i], 64) ||
+            !unique_tags.insert(descriptor->tags[i]).second) return reject();
+        tags.emplace_back(descriptor->tags[i]);
+    }
+    if (gua_register_game_input_action_v1(ctx, &descriptor->base) == 0) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    if (!ctx->game_input_frame_in_progress || ctx->staging_game_input_actions.empty() ||
+        ctx->staging_game_input_actions.back().id != descriptor->base.id) {
+        ctx->game_input_staging_valid = false;
+        return 0;
+    }
+    auto& action = ctx->staging_game_input_actions.back();
+    action.category = descriptor->category != nullptr ? descriptor->category : "";
+    action.aliases = std::move(aliases);
+    action.tags = std::move(tags);
+    action.agent_exposure = descriptor->agent_exposure;
+    return 1;
+}
+
 extern "C" int gua_end_game_input_frame(gua_context_t* ctx)
 {
     if (ctx == nullptr) return 0;
@@ -3284,7 +3417,9 @@ extern "C" int gua_end_game_input_frame(gua_context_t* ctx)
         return 0;
     }
     const std::string snapshot = build_game_input_semantic_snapshot(
-        ctx->staging_game_input_context, ctx->staging_game_input_actions);
+        ctx->staging_game_input_context, ctx->staging_game_input_actions, GUA_OBSERVATION_PROFILE_DEBUG);
+    const std::string player_snapshot = build_game_input_semantic_snapshot(
+        ctx->staging_game_input_context, ctx->staging_game_input_actions, GUA_OBSERVATION_PROFILE_PLAYER);
     ctx->game_input_context.swap(ctx->staging_game_input_context);
     ctx->game_input_actions.swap(ctx->staging_game_input_actions);
     ctx->staging_game_input_actions.clear();
@@ -3292,6 +3427,10 @@ extern "C" int gua_end_game_input_frame(gua_context_t* ctx)
     if (snapshot != ctx->previous_game_input_snapshot) {
         ++ctx->game_input_revision;
         ctx->previous_game_input_snapshot = snapshot;
+    }
+    if (player_snapshot != ctx->previous_player_game_input_snapshot) {
+        ++ctx->player_game_input_revision;
+        ctx->previous_player_game_input_snapshot = player_snapshot;
     }
     return 1;
 }
@@ -3309,9 +3448,36 @@ extern "C" int gua_abort_game_input_frame(gua_context_t* ctx)
 
 extern "C" int gua_copy_game_input_actions_json(gua_context_t* ctx, char* out_json, int out_json_size)
 {
-    if (ctx == nullptr) return 0;
+    return gua_copy_game_input_actions_json_for_profile(ctx, GUA_OBSERVATION_PROFILE_DEBUG, out_json, out_json_size);
+}
+
+extern "C" int gua_copy_game_input_actions_json_for_profile(gua_context_t* ctx, int observation_profile,
+    char* out_json, int out_json_size)
+{
+    if (ctx == nullptr || !one_of(observation_profile, { GUA_OBSERVATION_PROFILE_DEBUG, GUA_OBSERVATION_PROFILE_PLAYER })) return 0;
     const std::lock_guard lock(ctx->mutex);
-    return copy_json_string(build_game_input_actions_json(*ctx), out_json, out_json_size);
+    return copy_json_string(build_game_input_actions_json(*ctx, observation_profile), out_json, out_json_size);
+}
+
+extern "C" int gua_query_game_input_actions_json(gua_context_t* ctx,
+    const gua_game_input_action_selector_v1_t* selector, int observation_profile, char* out_json, int out_json_size)
+{
+    if (ctx == nullptr || selector == nullptr || selector->struct_size < sizeof(*selector) ||
+        !one_of(observation_profile, { GUA_OBSERVATION_PROFILE_DEBUG, GUA_OBSERVATION_PROFILE_PLAYER }) ||
+        selector->value_type < 0 || selector->value_type > GUA_GAME_INPUT_TEXT ||
+        selector->active < GUA_FILTER_ANY || selector->active > GUA_FILTER_TRUE || selector->limit > 100 ||
+        selector->tag_count > 16 || (selector->tag_count != 0 && selector->tags == nullptr)) return 0;
+    if (selector->id != nullptr && selector->id[0] != '\0' && !valid_game_input_id(selector->id)) return 0;
+    if (selector->query != nullptr && selector->query[0] != '\0' && !valid_utf8_text(selector->query, 128)) return 0;
+    if (selector->context != nullptr && selector->context[0] != '\0' &&
+        !valid_utf8_text(selector->context, std::numeric_limits<std::size_t>::max())) return 0;
+    if (selector->category != nullptr && selector->category[0] != '\0' && !valid_game_input_id(selector->category)) return 0;
+    std::unordered_set<std::string> unique_tags;
+    for (std::uint32_t i = 0; i < selector->tag_count; ++i)
+        if (selector->tags[i] == nullptr || !valid_utf8_text(selector->tags[i], 64) ||
+            !unique_tags.insert(selector->tags[i]).second) return 0;
+    const std::lock_guard lock(ctx->mutex);
+    return copy_json_string(build_game_input_query_json(*ctx, *selector, observation_profile), out_json, out_json_size);
 }
 
 extern "C" uint64_t gua_create_game_input_owner(gua_context_t* ctx)
@@ -3363,7 +3529,14 @@ extern "C" int gua_enqueue_game_input(gua_context_t* ctx,
 extern "C" int gua_enqueue_game_input_v2(gua_context_t* ctx,
     const gua_game_input_request_descriptor_v2_t* descriptor, uint64_t* out_request_id)
 {
+    return gua_enqueue_game_input_for_profile_v2(ctx, descriptor, GUA_OBSERVATION_PROFILE_DEBUG, out_request_id);
+}
+
+extern "C" int gua_enqueue_game_input_for_profile_v2(gua_context_t* ctx,
+    const gua_game_input_request_descriptor_v2_t* descriptor, int observation_profile, uint64_t* out_request_id)
+{
     if (ctx == nullptr || descriptor == nullptr || descriptor->struct_size < sizeof(*descriptor) ||
+        !one_of(observation_profile, { GUA_OBSERVATION_PROFILE_DEBUG, GUA_OBSERVATION_PROFILE_PLAYER }) ||
         descriptor->owner_id == 0 || descriptor->kind < GUA_GAME_INPUT_SEMANTIC || descriptor->kind > GUA_GAME_INPUT_CLEANUP ||
         descriptor->operation < GUA_GAME_INPUT_PRESS || descriptor->operation > GUA_GAME_INPUT_RELEASE_ALL ||
         descriptor->lease_ms > 60000 || !std::isfinite(descriptor->x) || !std::isfinite(descriptor->y) ||
@@ -3378,7 +3551,7 @@ extern "C" int gua_enqueue_game_input_v2(gua_context_t* ctx,
         if (!one_of(descriptor->operation, { GUA_GAME_INPUT_PRESS, GUA_GAME_INPUT_SET, GUA_GAME_INPUT_RELEASE }))
             return GUA_GAME_INPUT_ERROR_INVALID_VALUE;
         const int validation = validate_semantic_game_input(ctx->game_input_actions, descriptor->operation, target, value,
-            descriptor->confirmed != 0);
+            descriptor->confirmed != 0, observation_profile);
         if (validation != GUA_GAME_INPUT_OK) return validation;
     } else if (descriptor->kind == GUA_GAME_INPUT_KEYBOARD) {
         if (!one_of(descriptor->operation, { GUA_GAME_INPUT_PRESS, GUA_GAME_INPUT_DOWN, GUA_GAME_INPUT_UP }) ||
@@ -3424,9 +3597,11 @@ extern "C" int gua_enqueue_game_input_v2(gua_context_t* ctx,
     }
     const unsigned int lease = descriptor->lease_ms == 0 ? 5000U : descriptor->lease_ms;
     const auto request_id = ctx->next_game_input_request_id++;
-    ctx->game_input_requests.push_back(GameInputRequest { request_id, descriptor->owner_id, descriptor->kind,
+    GameInputRequest request { request_id, descriptor->owner_id, descriptor->kind,
         descriptor->operation, target, value, descriptor->x, descriptor->y,
-        lease, descriptor->device_index, descriptor->sensitive != 0, false, descriptor->confirmed != 0 });
+        lease, descriptor->device_index, descriptor->sensitive != 0, false, descriptor->confirmed != 0 };
+    request.observation_profile = observation_profile;
+    ctx->game_input_requests.push_back(std::move(request));
     if (out_request_id != nullptr) *out_request_id = request_id;
     return GUA_GAME_INPUT_OK;
 }
@@ -3439,7 +3614,7 @@ extern "C" int gua_consume_game_input_request(gua_context_t* ctx, gua_game_input
         const auto& request = ctx->game_input_requests.front();
         if (request.kind != GUA_GAME_INPUT_SEMANTIC) break;
         const int validation = validate_semantic_game_input(ctx->game_input_actions, request.operation,
-            request.target, request.value_json, request.confirmed);
+            request.target, request.value_json, request.confirmed, request.observation_profile);
         if (validation == GUA_GAME_INPUT_OK) break;
         append_game_input_result(*ctx, GameInputResult { request.request_id, request.owner_id, false, validation });
         ctx->game_input_requests.pop_front();

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -1684,6 +1684,28 @@ int main()
     assert(search_size > 0 && gua_query_game_input_actions_json(context, &action_selector,
         GUA_OBSERVATION_PROFILE_DEBUG, search.data(), search_size) == search_size);
     assert(search.find("\"count\":1") != std::string::npos && search.find("\"id\":\"discover\"") != std::string::npos);
+    {
+        gua::Context cpp_context;
+        gua::GameInputActionSelector cpp_selector;
+        cpp_selector.query = std::string("before\0after", 12);
+        bool rejected_embedded_nul = false;
+        try { (void)cpp_context.find_game_input_actions_json(cpp_selector); }
+        catch (const std::invalid_argument&) { rejected_embedded_nul = true; }
+        assert(rejected_embedded_nul);
+        gua::GameInputAction cpp_action;
+        cpp_action.id = "jump"; cpp_action.description = "Jump";
+        cpp_action.aliases = { std::string("hop\0hidden", 10) };
+        rejected_embedded_nul = false;
+        try { cpp_context.publish_game_input_actions("gameplay", { cpp_action }); }
+        catch (const std::invalid_argument&) { rejected_embedded_nul = true; }
+        assert(rejected_embedded_nul);
+        cpp_action.aliases.clear();
+        cpp_action.category = std::string("movement\0hidden", 15);
+        rejected_embedded_nul = false;
+        try { cpp_context.publish_game_input_actions("gameplay", { cpp_action }); }
+        catch (const std::invalid_argument&) { rejected_embedded_nul = true; }
+        assert(rejected_embedded_nul);
+    }
     const std::string long_query(129, 'q');
     auto invalid_selector = action_selector;
     invalid_selector.query = long_query.c_str();

--- a/native/gua-core/tests/state_model_tests.cpp
+++ b/native/gua-core/tests/state_model_tests.cpp
@@ -1611,7 +1611,6 @@ int main()
     empty_binding.bindings_json = "[\"\"]";
     assert(gua_register_game_input_action_v1(context, &empty_binding) == 0);
     assert(gua_end_game_input_frame(context) == 0);
-    assert(gua_begin_game_input_frame(context, "gameplay") == 1);
     const gua_game_input_action_descriptor_v1_t move {
         sizeof(gua_game_input_action_descriptor_v1_t), "move", "Move player", GUA_GAME_INPUT_VECTOR2,
         -1.0, 1.0, 1, 1, 1, "[\"KeyW/KeyA/KeyS/KeyD\"]", "safe", 0
@@ -1630,18 +1629,194 @@ int main()
     };
     auto guarded_protected = guarded_safe;
     guarded_protected.requires_confirmation = 1;
+    const char* discover_aliases[] { "open menu", "show inventory" };
+    const char* discover_tags[] { "menu", "inventory" };
+    const gua_game_input_action_descriptor_v1_t discover_base {
+        sizeof(gua_game_input_action_descriptor_v1_t), "discover", "Open the inventory", GUA_GAME_INPUT_BUTTON,
+        0.0, 0.0, 0, 0, 1, "[]", "safe", 0
+    };
+    const gua_game_input_action_descriptor_v2_t discover {
+        sizeof(gua_game_input_action_descriptor_v2_t), discover_base, "navigation", discover_aliases, 2,
+        discover_tags, 2, GUA_AGENT_EXPOSURE_AUTO
+    };
+    auto private_action_base = discover_base;
+    private_action_base.id = "debug-cheat"; private_action_base.description = "Debug cheat";
+    const gua_game_input_action_descriptor_v2_t private_action {
+        sizeof(gua_game_input_action_descriptor_v2_t), private_action_base, "debug", nullptr, 0, nullptr, 0, GUA_AGENT_EXPOSURE_PRIVATE
+    };
+    auto invalid_exposure = private_action;
+    invalid_exposure.agent_exposure = 99;
+    assert(gua_begin_game_input_frame(context, "invalid-exposure") == 1);
+    assert(gua_register_game_input_action_v2(context, &invalid_exposure) == 0);
+    assert(gua_end_game_input_frame(context) == 0);
+    const std::string long_alias(65, 'x');
+    const char* long_aliases[] { long_alias.c_str() };
+    auto invalid_alias = discover;
+    invalid_alias.aliases = long_aliases; invalid_alias.alias_count = 1;
+    assert(gua_begin_game_input_frame(context, "invalid-alias") == 1);
+    assert(gua_register_game_input_action_v2(context, &invalid_alias) == 0);
+    assert(gua_end_game_input_frame(context) == 0);
+    const char* duplicate_tags[] { "menu", "menu" };
+    auto invalid_tags = discover;
+    invalid_tags.tags = duplicate_tags; invalid_tags.tag_count = 2;
+    assert(gua_begin_game_input_frame(context, "invalid-tags") == 1);
+    assert(gua_register_game_input_action_v2(context, &invalid_tags) == 0);
+    assert(gua_end_game_input_frame(context) == 0);
+    assert(gua_begin_game_input_frame(context, "gameplay") == 1);
     assert(gua_register_game_input_action_v1(context, &move) == 1);
     assert(gua_register_game_input_action_v1(context, &interact) == 1);
     assert(gua_register_game_input_action_v1(context, &chat) == 1);
     assert(gua_register_game_input_action_v1(context, &guarded_safe) == 1);
+    assert(gua_register_game_input_action_v2(context, &discover) == 1);
+    assert(gua_register_game_input_action_v2(context, &private_action) == 1);
     assert(gua_end_game_input_frame(context) == 1);
     const int map_size = gua_copy_game_input_actions_json(context, nullptr, 0);
     std::string map(static_cast<std::size_t>(map_size), '\0');
     gua_copy_game_input_actions_json(context, map.data(), map_size);
     assert(map.find("\"context\":\"gameplay\"") != std::string::npos);
+    assert(map.find("\"category\":\"navigation\"") != std::string::npos);
+    assert(map.find("\"agentExposure\":\"private\"") != std::string::npos);
+    const char* query_tags[] { "inventory" };
+    gua_game_input_action_selector_v1_t action_selector { sizeof(gua_game_input_action_selector_v1_t), nullptr,
+        "inventory", 0, GUA_FILTER_TRUE, "gameplay", "navigation", query_tags, 1, 20 };
+    int search_size = gua_query_game_input_actions_json(context, &action_selector, GUA_OBSERVATION_PROFILE_DEBUG, nullptr, 0);
+    std::string search(static_cast<std::size_t>(search_size), '\0');
+    assert(search_size > 0 && gua_query_game_input_actions_json(context, &action_selector,
+        GUA_OBSERVATION_PROFILE_DEBUG, search.data(), search_size) == search_size);
+    assert(search.find("\"count\":1") != std::string::npos && search.find("\"id\":\"discover\"") != std::string::npos);
+    const std::string long_query(129, 'q');
+    auto invalid_selector = action_selector;
+    invalid_selector.query = long_query.c_str();
+    assert(gua_query_game_input_actions_json(context, &invalid_selector, GUA_OBSERVATION_PROFILE_DEBUG, nullptr, 0) == 0);
+    invalid_selector = action_selector; invalid_selector.value_type = 99;
+    assert(gua_query_game_input_actions_json(context, &invalid_selector, GUA_OBSERVATION_PROFILE_DEBUG, nullptr, 0) == 0);
+    const char* repeated_selector_tags[] { "inventory", "inventory" };
+    invalid_selector = action_selector; invalid_selector.tags = repeated_selector_tags; invalid_selector.tag_count = 2;
+    assert(gua_query_game_input_actions_json(context, &invalid_selector, GUA_OBSERVATION_PROFILE_DEBUG, nullptr, 0) == 0);
+    action_selector = gua_game_input_action_selector_v1_t { sizeof(gua_game_input_action_selector_v1_t), nullptr,
+        nullptr, 0, GUA_FILTER_ANY, nullptr, nullptr, nullptr, 0, 100 };
+    search_size = gua_query_game_input_actions_json(context, &action_selector, GUA_OBSERVATION_PROFILE_PLAYER, nullptr, 0);
+    search.assign(static_cast<std::size_t>(search_size), '\0');
+    gua_query_game_input_actions_json(context, &action_selector, GUA_OBSERVATION_PROFILE_PLAYER, search.data(), search_size);
+    assert(search.find("debug-cheat") == std::string::npos && search.find("\"count\":5") != std::string::npos);
+    const int player_map_size = gua_copy_game_input_actions_json_for_profile(context,
+        GUA_OBSERVATION_PROFILE_PLAYER, nullptr, 0);
+    std::string player_map(static_cast<std::size_t>(player_map_size), '\0');
+    gua_copy_game_input_actions_json_for_profile(context, GUA_OBSERVATION_PROFILE_PLAYER,
+        player_map.data(), player_map_size);
+    const auto player_revision_at = player_map.find("\"revision\":");
+    const auto player_revision_end = player_map.find(',', player_revision_at);
+    const std::string player_revision = player_map.substr(player_revision_at, player_revision_end - player_revision_at);
+    auto changed_private_base = private_action_base;
+    changed_private_base.description = "Changed private metadata";
+    const gua_game_input_action_descriptor_v2_t changed_private_action {
+        sizeof(gua_game_input_action_descriptor_v2_t), changed_private_base, "debug", nullptr, 0, nullptr, 0,
+        GUA_AGENT_EXPOSURE_PRIVATE
+    };
+    assert(gua_begin_game_input_frame(context, "gameplay") == 1);
+    assert(gua_register_game_input_action_v1(context, &move) == 1);
+    assert(gua_register_game_input_action_v1(context, &interact) == 1);
+    assert(gua_register_game_input_action_v1(context, &chat) == 1);
+    assert(gua_register_game_input_action_v1(context, &guarded_safe) == 1);
+    assert(gua_register_game_input_action_v2(context, &discover) == 1);
+    assert(gua_register_game_input_action_v2(context, &changed_private_action) == 1);
+    assert(gua_end_game_input_frame(context) == 1);
+    const int unchanged_player_size = gua_copy_game_input_actions_json_for_profile(context,
+        GUA_OBSERVATION_PROFILE_PLAYER, nullptr, 0);
+    std::string unchanged_player(static_cast<std::size_t>(unchanged_player_size), '\0');
+    gua_copy_game_input_actions_json_for_profile(context, GUA_OBSERVATION_PROFILE_PLAYER,
+        unchanged_player.data(), unchanged_player_size);
+    assert(unchanged_player.find(player_revision) != std::string::npos);
+
+    assert(gua_begin_game_input_frame(context, "bulk") == 1);
+    for (int index = 204; index >= 0; --index) {
+        char id[32] {}, description[32] {};
+        std::snprintf(id, sizeof(id), "action-%03d", index);
+        std::snprintf(description, sizeof(description), "Action %03d", index);
+        const gua_game_input_action_descriptor_v1_t bulk { sizeof(bulk), id, description, GUA_GAME_INPUT_BUTTON,
+            0.0, 0.0, 0, 0, 1, "[]", "safe", 0 };
+        assert(gua_register_game_input_action_v1(context, &bulk) == 1);
+    }
+    assert(gua_end_game_input_frame(context) == 1);
+    action_selector = gua_game_input_action_selector_v1_t { sizeof(action_selector), nullptr, "Action", 0,
+        GUA_FILTER_TRUE, "bulk", nullptr, nullptr, 0, 20 };
+    search_size = gua_query_game_input_actions_json(context, &action_selector, GUA_OBSERVATION_PROFILE_DEBUG, nullptr, 0);
+    search.assign(static_cast<std::size_t>(search_size), '\0');
+    gua_query_game_input_actions_json(context, &action_selector, GUA_OBSERVATION_PROFILE_DEBUG, search.data(), search_size);
+    assert(search.find("\"count\":20") != std::string::npos && search.find("\"truncated\":true") != std::string::npos);
+    assert(search.find("action-000") < search.find("action-019") && search.find("action-020") == std::string::npos);
+    action_selector.limit = 100;
+    search_size = gua_query_game_input_actions_json(context, &action_selector, GUA_OBSERVATION_PROFILE_DEBUG, nullptr, 0);
+    search.assign(static_cast<std::size_t>(search_size), '\0');
+    gua_query_game_input_actions_json(context, &action_selector, GUA_OBSERVATION_PROFILE_DEBUG, search.data(), search_size);
+    assert(search.find("\"count\":100") != std::string::npos && search.find("\"truncated\":true") != std::string::npos);
+    assert(gua_begin_game_input_frame(context, "gameplay") == 1);
+    assert(gua_register_game_input_action_v1(context, &move) == 1);
+    assert(gua_register_game_input_action_v1(context, &interact) == 1);
+    assert(gua_register_game_input_action_v1(context, &chat) == 1);
+    assert(gua_register_game_input_action_v1(context, &guarded_safe) == 1);
+    assert(gua_register_game_input_action_v2(context, &discover) == 1);
+    assert(gua_register_game_input_action_v2(context, &private_action) == 1);
+    assert(gua_end_game_input_frame(context) == 1);
 
     const uint64_t owner_a = gua_create_game_input_owner(context);
     const uint64_t owner_b = gua_create_game_input_owner(context);
+    const gua_game_input_request_descriptor_v2_t private_player_request {
+        sizeof(gua_game_input_request_descriptor_v2_t), owner_a, GUA_GAME_INPUT_SEMANTIC, GUA_GAME_INPUT_PRESS,
+        "debug-cheat", "true", 0, 0, 5000, 0, 0, 0
+    };
+    assert(gua_enqueue_game_input_for_profile_v2(context, &private_player_request,
+        GUA_OBSERVATION_PROFILE_PLAYER, nullptr) == GUA_GAME_INPUT_ERROR_ACTION_NOT_FOUND);
+    const gua_game_input_request_descriptor_v2_t stale_player_request {
+        sizeof(gua_game_input_request_descriptor_v2_t), owner_a, GUA_GAME_INPUT_SEMANTIC, GUA_GAME_INPUT_PRESS,
+        "discover", "true", 0, 0, 5000, 0, 0, 0
+    };
+    uint64_t stale_player_id = 0;
+    assert(gua_enqueue_game_input_for_profile_v2(context, &stale_player_request,
+        GUA_OBSERVATION_PROFILE_PLAYER, &stale_player_id) == GUA_GAME_INPUT_OK);
+    const gua_game_input_action_descriptor_v2_t hidden_discover {
+        sizeof(gua_game_input_action_descriptor_v2_t), discover_base, "navigation", discover_aliases, 2,
+        discover_tags, 2, GUA_AGENT_EXPOSURE_PRIVATE
+    };
+    assert(gua_begin_game_input_frame(context, "gameplay") == 1);
+    assert(gua_register_game_input_action_v2(context, &hidden_discover) == 1);
+    assert(gua_end_game_input_frame(context) == 1);
+    gua_game_input_request_v1_t stale_consumed { sizeof(gua_game_input_request_v1_t) };
+    assert(gua_consume_game_input_request(context, &stale_consumed) == 0);
+    const int stale_player_result_size = gua_copy_game_input_result_json(context, owner_a, stale_player_id, nullptr, 0);
+    std::string stale_player_result(static_cast<std::size_t>(stale_player_result_size), '\0');
+    gua_copy_game_input_result_json(context, owner_a, stale_player_id, stale_player_result.data(), stale_player_result_size);
+    assert(stale_player_result.find("\"errorCode\":" + std::to_string(GUA_GAME_INPUT_ERROR_ACTION_NOT_FOUND)) != std::string::npos);
+    assert(gua_begin_game_input_frame(context, "gameplay") == 1);
+    assert(gua_register_game_input_action_v1(context, &move) == 1);
+    assert(gua_register_game_input_action_v1(context, &interact) == 1);
+    assert(gua_register_game_input_action_v1(context, &chat) == 1);
+    assert(gua_register_game_input_action_v1(context, &guarded_safe) == 1);
+    assert(gua_register_game_input_action_v2(context, &discover) == 1);
+    assert(gua_end_game_input_frame(context) == 1);
+    const gua_game_input_request_descriptor_v2_t stale_active_request {
+        sizeof(gua_game_input_request_descriptor_v2_t), owner_a, GUA_GAME_INPUT_SEMANTIC, GUA_GAME_INPUT_PRESS,
+        "interact", "true", 0, 0, 5000, 0, 0, 0
+    };
+    uint64_t stale_active_id = 0;
+    assert(gua_enqueue_game_input_for_profile_v2(context, &stale_active_request,
+        GUA_OBSERVATION_PROFILE_PLAYER, &stale_active_id) == GUA_GAME_INPUT_OK);
+    auto inactive_interact = interact; inactive_interact.active = 0;
+    assert(gua_begin_game_input_frame(context, "gameplay") == 1);
+    assert(gua_register_game_input_action_v1(context, &inactive_interact) == 1);
+    assert(gua_end_game_input_frame(context) == 1);
+    assert(gua_consume_game_input_request(context, &stale_consumed) == 0);
+    const int stale_active_result_size = gua_copy_game_input_result_json(context, owner_a, stale_active_id, nullptr, 0);
+    std::string stale_active_result(static_cast<std::size_t>(stale_active_result_size), '\0');
+    gua_copy_game_input_result_json(context, owner_a, stale_active_id, stale_active_result.data(), stale_active_result_size);
+    assert(stale_active_result.find("\"errorCode\":" + std::to_string(GUA_GAME_INPUT_ERROR_INACTIVE)) != std::string::npos);
+    assert(gua_begin_game_input_frame(context, "gameplay") == 1);
+    assert(gua_register_game_input_action_v1(context, &move) == 1);
+    assert(gua_register_game_input_action_v1(context, &interact) == 1);
+    assert(gua_register_game_input_action_v1(context, &chat) == 1);
+    assert(gua_register_game_input_action_v1(context, &guarded_safe) == 1);
+    assert(gua_register_game_input_action_v2(context, &discover) == 1);
+    assert(gua_end_game_input_frame(context) == 1);
     const gua_game_input_request_descriptor_v1_t unconfirmed_guarded {
         sizeof(gua_game_input_request_descriptor_v1_t), owner_a, GUA_GAME_INPUT_SEMANTIC, GUA_GAME_INPUT_PRESS,
         "guarded", "true", 0, 0, 5000, 0, 0

--- a/native/gua-godot/include/gua/godot/gua_context.hpp
+++ b/native/gua-godot/include/gua/godot/gua_context.hpp
@@ -70,6 +70,8 @@ public:
     void enable_virtual_clock_adapter();
     bool publish_game_input_actions(const String& input_context, const Array& actions);
     String get_game_input_actions_json() const;
+    String get_player_game_input_actions_json() const;
+    String find_game_input_actions_json(const Dictionary& selector, int observation_profile = 0) const;
     void enable_game_input_adapter(int capabilities, int player_capabilities = 0);
     int get_game_input_capabilities(int observation_profile) const;
     uint64_t create_game_input_owner();

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -706,13 +706,18 @@ bool GuaContext::publish_game_input_actions(const String& input_context, const A
         std::vector<CharString> alias_strings, tag_strings;
         std::vector<const char*> alias_pointers, tag_pointers;
         const Array aliases = source.get("aliases", Array()), tags = source.get("tags", Array());
+        const auto contains_nul = [](const String& value) {
+            for (int64_t position = 0; position < value.length(); ++position) if (value.unicode_at(position) == 0) return true;
+            return false;
+        };
+        if (contains_nul(category)) { gua_runtime_abort_game_input_frame(runtime_); return false; }
         alias_strings.reserve(aliases.size()); tag_strings.reserve(tags.size());
         for (int i = 0; i < aliases.size(); ++i) {
-            if (aliases[i].get_type() != Variant::STRING) { gua_runtime_abort_game_input_frame(runtime_); return false; }
+            if (aliases[i].get_type() != Variant::STRING || contains_nul(String(aliases[i]))) { gua_runtime_abort_game_input_frame(runtime_); return false; }
             alias_strings.push_back(String(aliases[i]).utf8());
         }
         for (int i = 0; i < tags.size(); ++i) {
-            if (tags[i].get_type() != Variant::STRING) { gua_runtime_abort_game_input_frame(runtime_); return false; }
+            if (tags[i].get_type() != Variant::STRING || contains_nul(String(tags[i]))) { gua_runtime_abort_game_input_frame(runtime_); return false; }
             tag_strings.push_back(String(tags[i]).utf8());
         }
         for (const auto& value : alias_strings) alias_pointers.push_back(value.get_data());
@@ -755,6 +760,11 @@ String GuaContext::find_game_input_actions_json(const Dictionary& selector, int 
     if (selector.has("limit") && selector["limit"].get_type() != Variant::INT) return String();
     const String id = selector.get("id", String()), query = selector.get("query", String()), context = selector.get("context", String());
     const String category = selector.get("category", String()), value_type = selector.get("value_type", String());
+    const auto contains_nul = [](const String& value) {
+        for (int64_t index = 0; index < value.length(); ++index) if (value.unicode_at(index) == 0) return true;
+        return false;
+    };
+    if (contains_nul(id) || contains_nul(query) || contains_nul(context) || contains_nul(category)) return String();
     const CharString id_utf8 = id.utf8(), query_utf8 = query.utf8(), context_utf8 = context.utf8(), category_utf8 = category.utf8();
     const Array tags = selector.get("tags", Array());
     if (selector.has("tags") && selector["tags"].get_type() != Variant::ARRAY) return String();
@@ -762,7 +772,7 @@ String GuaContext::find_game_input_actions_json(const Dictionary& selector, int 
     if (limit < 1 || limit > 100 || tags.size() > 16) return String();
     std::vector<CharString> tag_strings; std::vector<const char*> tag_pointers;
     for (int i = 0; i < tags.size(); ++i) {
-        if (tags[i].get_type() != Variant::STRING || String(tags[i]).is_empty()) return String();
+        if (tags[i].get_type() != Variant::STRING || String(tags[i]).is_empty() || contains_nul(String(tags[i]))) return String();
         tag_strings.push_back(String(tags[i]).utf8());
     }
     for (const auto& tag : tag_strings) tag_pointers.push_back(tag.get_data());

--- a/native/gua-godot/src/gua_context.cpp
+++ b/native/gua-godot/src/gua_context.cpp
@@ -672,13 +672,26 @@ bool GuaContext::publish_game_input_actions(const String& input_context, const A
             return false;
         }
         const Dictionary source = actions[index];
+        for (const char* field : { "id", "description", "value_type", "risk", "category", "agent_exposure" }) {
+            if (source.has(field) && source[field].get_type() != Variant::STRING) {
+                gua_runtime_abort_game_input_frame(runtime_);
+                return false;
+            }
+        }
+        if ((source.has("aliases") && source["aliases"].get_type() != Variant::ARRAY) ||
+            (source.has("tags") && source["tags"].get_type() != Variant::ARRAY)) {
+            gua_runtime_abort_game_input_frame(runtime_);
+            return false;
+        }
         const String id = source.get("id", String());
         const String description = source.get("description", String());
         const String type = source.get("value_type", String("button"));
         const String risk = source.get("risk", String("safe"));
+        const String category = source.get("category", String());
+        const String exposure = source.get("agent_exposure", String("auto"));
         const String bindings_json = JSON::stringify(source.get("bindings", Array()));
         const CharString id_utf8 = id.utf8(), description_utf8 = description.utf8();
-        const CharString bindings_utf8 = bindings_json.utf8(), risk_utf8 = risk.utf8();
+        const CharString bindings_utf8 = bindings_json.utf8(), risk_utf8 = risk.utf8(), category_utf8 = category.utf8();
         if (type != "button" && type != "axis1d" && type != "vector2" && type != "text") {
             gua_runtime_abort_game_input_frame(runtime_);
             return false;
@@ -690,7 +703,21 @@ bool GuaContext::publish_game_input_actions(const String& input_context, const A
             gua_runtime_abort_game_input_frame(runtime_);
             return false;
         }
-        const gua_game_input_action_descriptor_v1_t descriptor {
+        std::vector<CharString> alias_strings, tag_strings;
+        std::vector<const char*> alias_pointers, tag_pointers;
+        const Array aliases = source.get("aliases", Array()), tags = source.get("tags", Array());
+        alias_strings.reserve(aliases.size()); tag_strings.reserve(tags.size());
+        for (int i = 0; i < aliases.size(); ++i) {
+            if (aliases[i].get_type() != Variant::STRING) { gua_runtime_abort_game_input_frame(runtime_); return false; }
+            alias_strings.push_back(String(aliases[i]).utf8());
+        }
+        for (int i = 0; i < tags.size(); ++i) {
+            if (tags[i].get_type() != Variant::STRING) { gua_runtime_abort_game_input_frame(runtime_); return false; }
+            tag_strings.push_back(String(tags[i]).utf8());
+        }
+        for (const auto& value : alias_strings) alias_pointers.push_back(value.get_data());
+        for (const auto& value : tag_strings) tag_pointers.push_back(value.get_data());
+        const gua_game_input_action_descriptor_v1_t base {
             sizeof(gua_game_input_action_descriptor_v1_t), id_utf8.get_data(), description_utf8.get_data(), value_type,
             source.get("minimum", 0.0), source.get("maximum", 0.0), has_range ? 1 : 0,
             static_cast<bool>(source.get("holdable", false)) ? 1 : 0,
@@ -698,7 +725,11 @@ bool GuaContext::publish_game_input_actions(const String& input_context, const A
             bindings_utf8.get_data(), risk_utf8.get_data(),
             static_cast<bool>(source.get("requires_confirmation", false)) ? 1 : 0
         };
-        if (gua_runtime_register_game_input_action_v1(runtime_, &descriptor) == 0) {
+        const gua_game_input_action_descriptor_v2_t descriptor { sizeof(descriptor), base,
+            category.is_empty() ? nullptr : category_utf8.get_data(), alias_pointers.empty() ? nullptr : alias_pointers.data(),
+            static_cast<uint32_t>(alias_pointers.size()), tag_pointers.empty() ? nullptr : tag_pointers.data(),
+            static_cast<uint32_t>(tag_pointers.size()), exposure == "private" ? GUA_AGENT_EXPOSURE_PRIVATE : GUA_AGENT_EXPOSURE_AUTO };
+        if ((exposure != "auto" && exposure != "private") || gua_runtime_register_game_input_action_v2(runtime_, &descriptor) == 0) {
             gua_runtime_abort_game_input_frame(runtime_);
             return false;
         }
@@ -709,6 +740,45 @@ bool GuaContext::publish_game_input_actions(const String& input_context, const A
 String GuaContext::get_game_input_actions_json() const
 {
     return copy_runtime_json(runtime_, gua_runtime_copy_game_input_actions_json);
+}
+
+String GuaContext::get_player_game_input_actions_json() const
+{
+    return copy_runtime_json(runtime_, gua_runtime_copy_player_game_input_actions_json);
+}
+
+String GuaContext::find_game_input_actions_json(const Dictionary& selector, int observation_profile) const
+{
+    for (const char* field : { "id", "query", "context", "category", "value_type" })
+        if (selector.has(field) && selector[field].get_type() != Variant::STRING) return String();
+    if (selector.has("active") && selector["active"].get_type() != Variant::BOOL) return String();
+    if (selector.has("limit") && selector["limit"].get_type() != Variant::INT) return String();
+    const String id = selector.get("id", String()), query = selector.get("query", String()), context = selector.get("context", String());
+    const String category = selector.get("category", String()), value_type = selector.get("value_type", String());
+    const CharString id_utf8 = id.utf8(), query_utf8 = query.utf8(), context_utf8 = context.utf8(), category_utf8 = category.utf8();
+    const Array tags = selector.get("tags", Array());
+    if (selector.has("tags") && selector["tags"].get_type() != Variant::ARRAY) return String();
+    const int limit = selector.get("limit", 20);
+    if (limit < 1 || limit > 100 || tags.size() > 16) return String();
+    std::vector<CharString> tag_strings; std::vector<const char*> tag_pointers;
+    for (int i = 0; i < tags.size(); ++i) {
+        if (tags[i].get_type() != Variant::STRING || String(tags[i]).is_empty()) return String();
+        tag_strings.push_back(String(tags[i]).utf8());
+    }
+    for (const auto& tag : tag_strings) tag_pointers.push_back(tag.get_data());
+    const int native_type = value_type == "button" ? GUA_GAME_INPUT_BUTTON : value_type == "axis1d" ? GUA_GAME_INPUT_AXIS1D :
+        value_type == "vector2" ? GUA_GAME_INPUT_VECTOR2 : value_type == "text" ? GUA_GAME_INPUT_TEXT : 0;
+    if (!value_type.is_empty() && native_type == 0) return String();
+    int active = GUA_FILTER_ANY;
+    if (selector.has("active")) active = static_cast<bool>(selector["active"]) ? GUA_FILTER_TRUE : GUA_FILTER_FALSE;
+    gua_game_input_action_selector_v1_t native { sizeof(native), id.is_empty() ? nullptr : id_utf8.get_data(),
+        query.is_empty() ? nullptr : query_utf8.get_data(), native_type, active, context.is_empty() ? nullptr : context_utf8.get_data(),
+        category.is_empty() ? nullptr : category_utf8.get_data(), tag_pointers.empty() ? nullptr : tag_pointers.data(),
+        static_cast<uint32_t>(tag_pointers.size()), static_cast<uint32_t>(limit) };
+    const auto copy = [&](char* output, int size) { return gua_runtime_query_game_input_actions_json(runtime_, &native, observation_profile, output, size); };
+    const int required = copy(nullptr, 0); if (required <= 0) return String();
+    std::vector<char> output(static_cast<std::size_t>(required)); copy(output.data(), required);
+    return String::utf8(output.data());
 }
 
 void GuaContext::enable_game_input_adapter(int capabilities, int player_capabilities)
@@ -936,6 +1006,8 @@ void GuaContext::_bind_methods()
     ClassDB::bind_method(D_METHOD("enable_virtual_clock_adapter"), &GuaContext::enable_virtual_clock_adapter);
     ClassDB::bind_method(D_METHOD("publish_game_input_actions", "input_context", "actions"), &GuaContext::publish_game_input_actions);
     ClassDB::bind_method(D_METHOD("get_game_input_actions_json"), &GuaContext::get_game_input_actions_json);
+    ClassDB::bind_method(D_METHOD("get_player_game_input_actions_json"), &GuaContext::get_player_game_input_actions_json);
+    ClassDB::bind_method(D_METHOD("find_game_input_actions_json", "selector", "observation_profile"), &GuaContext::find_game_input_actions_json, DEFVAL(0));
     ClassDB::bind_method(D_METHOD("enable_game_input_adapter", "capabilities", "player_capabilities"),
         &GuaContext::enable_game_input_adapter, DEFVAL(0));
     ClassDB::bind_method(D_METHOD("get_game_input_capabilities", "observation_profile"),

--- a/native/gua-runtime/include/gua/runtime.h
+++ b/native/gua-runtime/include/gua/runtime.h
@@ -100,6 +100,7 @@ void gua_runtime_set_player_game_input_capabilities(gua_runtime_t* runtime, uint
 uint32_t gua_runtime_get_game_input_capabilities(gua_runtime_t* runtime, int observation_profile);
 int gua_runtime_begin_game_input_frame(gua_runtime_t* runtime, const char* input_context);
 int gua_runtime_register_game_input_action_v1(gua_runtime_t* runtime, const gua_game_input_action_descriptor_v1_t* descriptor);
+int gua_runtime_register_game_input_action_v2(gua_runtime_t* runtime, const gua_game_input_action_descriptor_v2_t* descriptor);
 int gua_runtime_end_game_input_frame(gua_runtime_t* runtime);
 int gua_runtime_abort_game_input_frame(gua_runtime_t* runtime);
 uint64_t gua_runtime_create_game_input_owner(gua_runtime_t* runtime);
@@ -113,6 +114,9 @@ int gua_runtime_consume_game_input_request(gua_runtime_t* runtime, gua_game_inpu
 int gua_runtime_complete_game_input_request(gua_runtime_t* runtime, uint64_t request_id, int succeeded, int error_code);
 int gua_runtime_tick_game_input_leases(gua_runtime_t* runtime, double elapsed_ms);
 int gua_runtime_copy_game_input_actions_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
+int gua_runtime_copy_player_game_input_actions_json(gua_runtime_t* runtime, char* out_json, int out_json_size);
+int gua_runtime_query_game_input_actions_json(gua_runtime_t* runtime, const gua_game_input_action_selector_v1_t* selector,
+    int observation_profile, char* out_json, int out_json_size);
 int gua_runtime_copy_game_input_state_json(gua_runtime_t* runtime, uint64_t owner_id, char* out_json, int out_json_size);
 int gua_runtime_copy_game_input_result_json(gua_runtime_t* runtime, uint64_t owner_id, uint64_t request_id, char* out_json, int out_json_size);
 /* Adapter opt-in: enable only after the host publishes world frames. */

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -1023,6 +1023,16 @@ extern "C" int gua_runtime_register_game_input_action_v1(gua_runtime_t* runtime,
     return gua_register_game_input_action_v1(runtime->context, descriptor);
 }
 
+int copy_game_input_result_unlocked(gua_runtime_t* runtime, uint64_t owner_id, uint64_t request_id,
+    char* out_json, int out_json_size)
+{
+    const int required_size = gua_copy_game_input_result_json(runtime->context, owner_id, request_id, out_json, out_json_size);
+    if (required_size > 0 && out_json != nullptr && out_json_size >= required_size &&
+        std::string_view(out_json, static_cast<std::size_t>(required_size - 1)).starts_with("{\"completed\":true"))
+        runtime->game_input_request_profiles.erase(request_id);
+    return required_size;
+}
+
 extern "C" int gua_runtime_register_game_input_action_v2(gua_runtime_t* runtime, const gua_game_input_action_descriptor_v2_t* descriptor)
 {
     if (!valid_runtime(runtime)) return 0;
@@ -1172,7 +1182,7 @@ extern "C" int gua_runtime_copy_game_input_result_json(gua_runtime_t* runtime, u
 {
     if (!valid_runtime(runtime)) return copy_json_string("{}", out_json, out_json_size);
     const std::lock_guard lock(runtime->context_mutex);
-    return gua_copy_game_input_result_json(runtime->context, owner_id, request_id, out_json, out_json_size);
+    return copy_game_input_result_unlocked(runtime, owner_id, request_id, out_json, out_json_size);
 }
 
 extern "C" void gua_runtime_set_world_object_tree_enabled(gua_runtime_t* runtime, int enabled)
@@ -1783,6 +1793,9 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
             return json;
         },
         .query_game_input_actions_json = [runtime](const gua::ws::GameInputQuerySelector& selector) {
+            const auto contains_nul = [](const std::string& value) { return value.find('\0') != std::string::npos; };
+            if (contains_nul(selector.id) || contains_nul(selector.query) || contains_nul(selector.context) ||
+                contains_nul(selector.category) || std::any_of(selector.tags.begin(), selector.tags.end(), contains_nul)) return std::string();
             std::vector<const char*> tag_pointers;
             tag_pointers.reserve(selector.tags.size());
             for (const auto& tag : selector.tags) tag_pointers.push_back(tag.c_str());
@@ -1855,10 +1868,10 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
         },
         .poll_game_input_result_json = [runtime](unsigned long long owner_id, unsigned long long request_id) {
             const std::lock_guard lock(runtime->context_mutex);
-            const int size = gua_copy_game_input_result_json(runtime->context, owner_id, request_id, nullptr, 0);
+            const int size = copy_game_input_result_unlocked(runtime, owner_id, request_id, nullptr, 0);
             if (size <= 0) return std::string("null");
             std::string json(static_cast<std::size_t>(size), '\0');
-            gua_copy_game_input_result_json(runtime->context, owner_id, request_id, json.data(), size);
+            copy_game_input_result_unlocked(runtime, owner_id, request_id, json.data(), size);
             json.resize(static_cast<std::size_t>(size - 1));
             return json;
         },

--- a/native/gua-runtime/src/runtime.cpp
+++ b/native/gua-runtime/src/runtime.cpp
@@ -148,6 +148,7 @@ void filter_runtime_capabilities(std::string& json, bool virtual_clock_enabled, 
 {
     if (!virtual_clock_enabled) remove_capability(json, "virtual_clock_v1");
     if ((game_input_capabilities & GUA_RUNTIME_GAME_INPUT_SEMANTIC) == 0) remove_capability(json, "semantic_game_input_v1");
+    if ((game_input_capabilities & GUA_RUNTIME_GAME_INPUT_SEMANTIC) == 0) remove_capability(json, "semantic_game_input_search_v1");
     if ((game_input_capabilities & GUA_RUNTIME_GAME_INPUT_KEYBOARD) == 0) remove_capability(json, "raw_keyboard_input_v1");
     if ((game_input_capabilities & GUA_RUNTIME_GAME_INPUT_POINTER) == 0) remove_capability(json, "raw_pointer_input_v1");
     if ((game_input_capabilities & GUA_RUNTIME_GAME_INPUT_GAMEPAD) == 0) remove_capability(json, "raw_gamepad_input_v1");
@@ -1022,6 +1023,13 @@ extern "C" int gua_runtime_register_game_input_action_v1(gua_runtime_t* runtime,
     return gua_register_game_input_action_v1(runtime->context, descriptor);
 }
 
+extern "C" int gua_runtime_register_game_input_action_v2(gua_runtime_t* runtime, const gua_game_input_action_descriptor_v2_t* descriptor)
+{
+    if (!valid_runtime(runtime)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    return gua_register_game_input_action_v2(runtime->context, descriptor);
+}
+
 extern "C" int gua_runtime_end_game_input_frame(gua_runtime_t* runtime)
 {
     if (!valid_runtime(runtime)) return 0;
@@ -1082,7 +1090,7 @@ extern "C" int gua_runtime_enqueue_game_input_for_profile_v2(gua_runtime_t* runt
     if (required == UINT32_MAX || (required != 0 && (available & required) == 0))
         return GUA_GAME_INPUT_ERROR_UNSUPPORTED;
     uint64_t request_id = 0;
-    const int result = gua_enqueue_game_input_v2(runtime->context, descriptor, &request_id);
+    const int result = gua_enqueue_game_input_for_profile_v2(runtime->context, descriptor, observation_profile, &request_id);
     if (result == GUA_GAME_INPUT_OK) {
         runtime->game_input_request_profiles[request_id] = { observation_profile, descriptor->owner_id, false };
         if (out_request_id != nullptr) *out_request_id = request_id;
@@ -1129,7 +1137,27 @@ extern "C" int gua_runtime_copy_game_input_actions_json(gua_runtime_t* runtime, 
 {
     if (!valid_runtime(runtime)) return copy_json_string("{}", out_json, out_json_size);
     const std::lock_guard lock(runtime->context_mutex);
-    return gua_copy_game_input_actions_json(runtime->context, out_json, out_json_size);
+    return gua_copy_game_input_actions_json_for_profile(runtime->context, runtime->observation_profile, out_json, out_json_size);
+}
+
+extern "C" int gua_runtime_copy_player_game_input_actions_json(gua_runtime_t* runtime, char* out_json, int out_json_size)
+{
+    if (!valid_runtime(runtime)) return copy_json_string("{}", out_json, out_json_size);
+    const std::lock_guard lock(runtime->context_mutex);
+    if ((effective_game_input_capabilities(runtime, GUA_OBSERVATION_PROFILE_PLAYER) & GUA_RUNTIME_GAME_INPUT_SEMANTIC) == 0)
+        return copy_json_string("{}", out_json, out_json_size);
+    return gua_copy_game_input_actions_json_for_profile(runtime->context, GUA_OBSERVATION_PROFILE_PLAYER, out_json, out_json_size);
+}
+
+extern "C" int gua_runtime_query_game_input_actions_json(gua_runtime_t* runtime,
+    const gua_game_input_action_selector_v1_t* selector, int observation_profile, char* out_json, int out_json_size)
+{
+    if (!valid_runtime(runtime) || selector == nullptr ||
+        (observation_profile != GUA_OBSERVATION_PROFILE_DEBUG && observation_profile != GUA_OBSERVATION_PROFILE_PLAYER)) return 0;
+    const std::lock_guard lock(runtime->context_mutex);
+    if (runtime->observation_profile == GUA_OBSERVATION_PROFILE_PLAYER && observation_profile != GUA_OBSERVATION_PROFILE_PLAYER) return 0;
+    if ((effective_game_input_capabilities(runtime, observation_profile) & GUA_RUNTIME_GAME_INPUT_SEMANTIC) == 0) return 0;
+    return gua_query_game_input_actions_json(runtime->context, selector, observation_profile, out_json, out_json_size);
 }
 
 extern "C" int gua_runtime_copy_game_input_state_json(gua_runtime_t* runtime, uint64_t owner_id, char* out_json, int out_json_size)
@@ -1748,9 +1776,26 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
         },
         .get_game_input_actions_json = [runtime] {
             const std::lock_guard lock(runtime->context_mutex);
-            const int size = gua_copy_game_input_actions_json(runtime->context, nullptr, 0);
+            const int size = gua_copy_game_input_actions_json_for_profile(runtime->context, runtime->observation_profile, nullptr, 0);
             std::string json(static_cast<std::size_t>(size), '\0');
-            gua_copy_game_input_actions_json(runtime->context, json.data(), size);
+            gua_copy_game_input_actions_json_for_profile(runtime->context, runtime->observation_profile, json.data(), size);
+            json.resize(static_cast<std::size_t>(size - 1));
+            return json;
+        },
+        .query_game_input_actions_json = [runtime](const gua::ws::GameInputQuerySelector& selector) {
+            std::vector<const char*> tag_pointers;
+            tag_pointers.reserve(selector.tags.size());
+            for (const auto& tag : selector.tags) tag_pointers.push_back(tag.c_str());
+            gua_game_input_action_selector_v1_t native { sizeof(gua_game_input_action_selector_v1_t),
+                selector.id.empty() ? nullptr : selector.id.c_str(), selector.query.empty() ? nullptr : selector.query.c_str(),
+                selector.value_type, selector.active, selector.context.empty() ? nullptr : selector.context.c_str(),
+                selector.category.empty() ? nullptr : selector.category.c_str(),
+                tag_pointers.empty() ? nullptr : tag_pointers.data(), static_cast<std::uint32_t>(tag_pointers.size()), selector.limit };
+            const std::lock_guard lock(runtime->context_mutex);
+            const int size = gua_query_game_input_actions_json(runtime->context, &native, runtime->observation_profile, nullptr, 0);
+            if (size <= 0) return std::string();
+            std::string json(static_cast<std::size_t>(size), '\0');
+            gua_query_game_input_actions_json(runtime->context, &native, runtime->observation_profile, json.data(), size);
             json.resize(static_cast<std::size_t>(size - 1));
             return json;
         },
@@ -1802,7 +1847,8 @@ extern "C" int gua_runtime_start_inspector_bridge(gua_runtime_t* runtime, int po
                 command.target.c_str(), command.value_json.c_str(), command.x, command.y, command.lease_ms,
                 command.device_index, command.sensitive ? 1 : 0, command.confirmed ? 1 : 0 };
             std::uint64_t request_id = 0;
-            const int result = gua_enqueue_game_input_v2(runtime->context, &descriptor, &request_id);
+            const int result = gua_enqueue_game_input_for_profile_v2(runtime->context, &descriptor,
+                runtime->observation_profile, &request_id);
             if (result == GUA_GAME_INPUT_OK)
                 runtime->game_input_request_profiles[request_id] = { runtime->observation_profile, owner_id, false };
             return result == GUA_GAME_INPUT_OK ? static_cast<long long>(request_id) : static_cast<long long>(result);

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -48,6 +48,11 @@ struct GameInputQuerySelector {
     unsigned int limit = 20;
 };
 
+namespace detail {
+[[nodiscard]] bool valid_game_input_query_selector(const GameInputQuerySelector& selector);
+[[nodiscard]] bool valid_game_input_query_request_json(std::string_view json);
+}
+
 struct ActionCommand {
     std::string type;
     std::string node_id;

--- a/native/gua-ws-bridge/include/gua/ws_bridge.hpp
+++ b/native/gua-ws-bridge/include/gua/ws_bridge.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace gua::ws {
 
@@ -34,6 +35,17 @@ struct WorldQuerySelector {
     std::string state_string;
     double state_number = 0;
     bool state_bool = false;
+};
+
+struct GameInputQuerySelector {
+    std::string id;
+    std::string query;
+    int value_type = 0;
+    int active = 0;
+    std::string context;
+    std::string category;
+    std::vector<std::string> tags;
+    unsigned int limit = 20;
 };
 
 struct ActionCommand {
@@ -92,6 +104,7 @@ struct BridgeHandlers {
     std::function<void(unsigned long long owner_id)> release_game_input_owner;
     std::function<bool(unsigned int capability)> game_input_supported;
     std::function<std::string()> get_game_input_actions_json;
+    std::function<std::string(const GameInputQuerySelector& selector)> query_game_input_actions_json;
     std::function<std::string(unsigned long long owner_id)> get_game_input_state_json;
     std::function<long long(unsigned long long owner_id, const GameInputCommand& command)> enqueue_game_input;
     std::function<std::string(unsigned long long owner_id, unsigned long long request_id)> poll_game_input_result_json;

--- a/native/gua-ws-bridge/src/ws_bridge.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge.cpp
@@ -12,12 +12,14 @@
 #include <cstring>
 #include <future>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 namespace {
@@ -557,6 +559,8 @@ std::optional<std::vector<std::string>> json_string_array_field(std::string_view
         if (index == std::string_view::npos) return std::nullopt;
         if (json[index] == ']') return values;
         if (json[index++] != ',') return std::nullopt;
+        index = json.find_first_not_of(" \t\r\n", index);
+        if (index == std::string_view::npos || json[index] == ']') return std::nullopt;
     }
 }
 
@@ -658,6 +662,54 @@ bool valid_optional_non_empty_string(std::string_view json, std::string_view fie
     if (!json_has_field(json, field)) return true;
     const auto value = json_string_field(json, field);
     return value.has_value() && !value->empty();
+}
+
+bool valid_game_input_identifier(std::string_view value)
+{
+    if (value.empty() || value.size() >= 128U || value.front() < 'a' || value.front() > 'z') return false;
+    return std::all_of(value.begin(), value.end(), [](char ch) {
+        return (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '.' || ch == '-';
+    });
+}
+
+bool valid_game_input_text(std::string_view value, std::size_t maximum_code_points)
+{
+    if (value.empty()) return false;
+    std::size_t code_points = 0;
+    for (std::size_t index = 0; index < value.size();) {
+        const unsigned char first = static_cast<unsigned char>(value[index]);
+        if (first == 0U) return false;
+        const std::size_t width = first < 0x80U ? 1U : first >= 0xC2U && first <= 0xDFU ? 2U :
+            first >= 0xE0U && first <= 0xEFU ? 3U : first >= 0xF0U && first <= 0xF4U ? 4U : 0U;
+        if (width == 0U || index + width > value.size()) return false;
+        for (std::size_t offset = 1; offset < width; ++offset)
+            if ((static_cast<unsigned char>(value[index + offset]) & 0xC0U) != 0x80U) return false;
+        if (width == 3U) {
+            const unsigned char second = static_cast<unsigned char>(value[index + 1U]);
+            if ((first == 0xE0U && second < 0xA0U) || (first == 0xEDU && second >= 0xA0U)) return false;
+        }
+        if (width == 4U) {
+            const unsigned char second = static_cast<unsigned char>(value[index + 1U]);
+            if ((first == 0xF0U && second < 0x90U) || (first == 0xF4U && second >= 0x90U)) return false;
+        }
+        index += width;
+        if (++code_points > maximum_code_points) return false;
+    }
+    return true;
+}
+
+bool valid_game_input_selector(const gua::ws::GameInputQuerySelector& selector)
+{
+    if (selector.value_type < 0 || selector.value_type > 4 || selector.active < 0 || selector.active > 2 ||
+        selector.limit < 1U || selector.limit > 100U ||
+        (!selector.id.empty() && !valid_game_input_identifier(selector.id)) ||
+        (!selector.query.empty() && !valid_game_input_text(selector.query, 128U)) ||
+        (!selector.context.empty() && !valid_game_input_text(selector.context, std::numeric_limits<std::size_t>::max())) ||
+        (!selector.category.empty() && !valid_game_input_identifier(selector.category)) || selector.tags.size() > 16U) return false;
+    std::unordered_set<std::string> unique_tags;
+    for (const auto& tag : selector.tags)
+        if (!valid_game_input_text(tag, 64U) || !unique_tags.insert(tag).second) return false;
+    return true;
 }
 
 bool valid_optional_int_range(std::string_view json, std::string_view field, int minimum, int maximum)
@@ -858,7 +910,8 @@ Command parse_command(std::string_view json)
             valid_optional_non_empty_string(json, "actionId") && valid_optional_non_empty_string(json, "query") &&
             valid_optional_non_empty_string(json, "context") && valid_optional_non_empty_string(json, "category") &&
             valid_optional_int_range(json, "valueType", 1, 4) && valid_optional_int_range(json, "active", 0, 2) &&
-            valid_optional_int_range(json, "limit", 1, 100));
+            valid_optional_int_range(json, "limit", 1, 100) &&
+            gua::ws::detail::valid_game_input_query_selector(command.game_input_selector));
     command.value = json_string_field(json, "value").value_or("");
     command.delta_x = static_cast<float>(json_number_field(json, "deltaX").value_or(0));
     command.delta_y = static_cast<float>(json_number_field(json, "deltaY").value_or(0));
@@ -949,6 +1002,17 @@ std::string_view game_input_error_name(long long code)
 }
 
 } // namespace
+
+bool gua::ws::detail::valid_game_input_query_selector(const GameInputQuerySelector& selector)
+{
+    return valid_game_input_selector(selector);
+}
+
+bool gua::ws::detail::valid_game_input_query_request_json(std::string_view json)
+{
+    const Command command = parse_command(json);
+    return command.type == "find_game_input_actions" && command.game_input_selector_valid;
+}
 
 namespace gua::ws {
 

--- a/native/gua-ws-bridge/src/ws_bridge.cpp
+++ b/native/gua-ws-bridge/src/ws_bridge.cpp
@@ -36,6 +36,7 @@ struct Command {
     std::string key;
     gua::ws::QuerySelector selector;
     gua::ws::WorldQuerySelector world_selector;
+    gua::ws::GameInputQuerySelector game_input_selector;
     std::string value;
     float delta_x = 0;
     float delta_y = 0;
@@ -72,6 +73,7 @@ struct Command {
     double input_x = 0;
     double input_y = 0;
     bool world_selector_valid = true;
+    bool game_input_selector_valid = true;
 };
 
 struct ClientConnection {
@@ -527,6 +529,37 @@ std::optional<std::string> json_string_field(std::string_view json, std::string_
     return std::nullopt;
 }
 
+std::optional<std::vector<std::string>> json_string_array_field(std::string_view json, std::string_view field)
+{
+    const auto start = json_top_level_field_start(json, field);
+    if (!start.has_value()) return std::vector<std::string> {};
+    std::size_t index = *start;
+    if (index >= json.size() || json[index++] != '[') return std::nullopt;
+    std::vector<std::string> values;
+    while (true) {
+        index = json.find_first_not_of(" \t\r\n", index);
+        if (index == std::string_view::npos) return std::nullopt;
+        if (json[index] == ']') return values;
+        if (json[index] != '"') return std::nullopt;
+        const std::size_t value_start = index;
+        bool escaped = false;
+        for (++index; index < json.size(); ++index) {
+            if (escaped) { escaped = false; continue; }
+            if (json[index] == '\\') { escaped = true; continue; }
+            if (json[index] == '"') break;
+        }
+        if (index >= json.size()) return std::nullopt;
+        const std::string wrapped = std::string("{\"value\":") + std::string(json.substr(value_start, index - value_start + 1U)) + "}";
+        const auto parsed = json_string_field(wrapped, "value");
+        if (!parsed.has_value()) return std::nullopt;
+        values.push_back(*parsed);
+        index = json.find_first_not_of(" \t\r\n", index + 1U);
+        if (index == std::string_view::npos) return std::nullopt;
+        if (json[index] == ']') return values;
+        if (json[index++] != ',') return std::nullopt;
+    }
+}
+
 std::optional<int> json_int_field(std::string_view json, std::string_view field)
 {
     const auto value_start = json_top_level_field_start(json, field);
@@ -806,6 +839,26 @@ Command parse_command(std::string_view json)
              (command.world_selector.state_type == 1 && state_string_present && json_string_field(json, "stateString").has_value() && !state_number_present && !state_bool_present) ||
              (command.world_selector.state_type == 2 && state_number_present && json_number_field(json, "stateNumber").has_value() && !state_string_present && !state_bool_present) ||
              (command.world_selector.state_type == 3 && state_bool_present && json_bool_field_optional(json, "stateBool").has_value() && !state_string_present && !state_number_present))));
+    command.game_input_selector.id = json_string_field(json, "actionId").value_or("");
+    command.game_input_selector.query = json_string_field(json, "query").value_or("");
+    command.game_input_selector.value_type = json_int_field(json, "valueType").value_or(0);
+    command.game_input_selector.active = json_int_field(json, "active").value_or(0);
+    command.game_input_selector.context = json_string_field(json, "context").value_or("");
+    command.game_input_selector.category = json_string_field(json, "category").value_or("");
+    const auto game_input_tags = json_string_array_field(json, "tags");
+    if (game_input_tags.has_value()) command.game_input_selector.tags = *game_input_tags;
+    const auto game_input_limit = json_int_field(json, "limit");
+    command.game_input_selector.limit = static_cast<unsigned int>(game_input_limit.value_or(20));
+    constexpr std::array game_input_query_fields { std::string_view("id"), std::string_view("type"),
+        std::string_view("actionId"), std::string_view("query"), std::string_view("valueType"),
+        std::string_view("active"), std::string_view("context"), std::string_view("category"),
+        std::string_view("tags"), std::string_view("limit") };
+    command.game_input_selector_valid = command.type != "find_game_input_actions" ||
+        (json_has_only_top_level_fields(json, game_input_query_fields) && game_input_tags.has_value() &&
+            valid_optional_non_empty_string(json, "actionId") && valid_optional_non_empty_string(json, "query") &&
+            valid_optional_non_empty_string(json, "context") && valid_optional_non_empty_string(json, "category") &&
+            valid_optional_int_range(json, "valueType", 1, 4) && valid_optional_int_range(json, "active", 0, 2) &&
+            valid_optional_int_range(json, "limit", 1, 100));
     command.value = json_string_field(json, "value").value_or("");
     command.delta_x = static_cast<float>(json_number_field(json, "deltaX").value_or(0));
     command.delta_y = static_cast<float>(json_number_field(json, "deltaY").value_or(0));
@@ -1234,6 +1287,13 @@ private:
                         handlers_.game_input_supported(1U)
                     ? ok_response(command.id, handlers_.get_game_input_actions_json())
                     : error_response(command.id, "unsupported");
+            }
+            if (command.type == "find_game_input_actions") {
+                if (!command.game_input_selector_valid) return error_response(command.id, "invalid game input selector");
+                if (!handlers_.query_game_input_actions_json || !handlers_.game_input_supported || !handlers_.game_input_supported(1U))
+                    return error_response(command.id, "unsupported");
+                const auto result = handlers_.query_game_input_actions_json(command.game_input_selector);
+                return result.empty() ? error_response(command.id, "invalid game input selector") : ok_response(command.id, result);
             }
             if (command.type == "get_game_input_state") {
                 return game_input_owner_id != 0 && handlers_.get_game_input_state_json

--- a/native/gua-ws-bridge/tests/bridge_lifetime_tests.cpp
+++ b/native/gua-ws-bridge/tests/bridge_lifetime_tests.cpp
@@ -2,9 +2,36 @@
 
 #include <cassert>
 #include <chrono>
+#include <string>
+#include <vector>
 
 int main()
 {
+    const gua::ws::GameInputQuerySelector valid { .id = "jump", .query = "Jump", .value_type = 1,
+        .active = 2, .context = "gameplay", .category = "movement", .tags = { "core", "player" }, .limit = 20 };
+    assert(gua::ws::detail::valid_game_input_query_selector(valid));
+    auto invalid = valid;
+    invalid.id = "Invalid";
+    assert(!gua::ws::detail::valid_game_input_query_selector(invalid));
+    invalid = valid; invalid.category = std::string(128, 'a');
+    assert(!gua::ws::detail::valid_game_input_query_selector(invalid));
+    invalid = valid; invalid.query = std::string(129, 'q');
+    assert(!gua::ws::detail::valid_game_input_query_selector(invalid));
+    invalid = valid; invalid.tags = { std::string(65, 't') };
+    assert(!gua::ws::detail::valid_game_input_query_selector(invalid));
+    invalid = valid; invalid.tags = { "same", "same" };
+    assert(!gua::ws::detail::valid_game_input_query_selector(invalid));
+    invalid = valid; invalid.tags = std::vector<std::string>(17, "tag");
+    assert(!gua::ws::detail::valid_game_input_query_selector(invalid));
+    invalid = valid; invalid.limit = 101;
+    assert(!gua::ws::detail::valid_game_input_query_selector(invalid));
+    invalid = valid; invalid.query = std::string("before\0after", 12);
+    assert(!gua::ws::detail::valid_game_input_query_selector(invalid));
+    assert(gua::ws::detail::valid_game_input_query_request_json(
+        R"({"id":1,"type":"find_game_input_actions","tags":["x"]})"));
+    assert(!gua::ws::detail::valid_game_input_query_request_json(
+        R"({"id":1,"type":"find_game_input_actions","tags":["x",]})"));
+
     gua::ws::BridgeServer bridge({}, { .port = 0 });
     bridge.start();
     assert(bridge.running());

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -47,16 +47,11 @@ export function handleMessage(message: string | Buffer, target: DemoRuntime = ru
       case "clock_run_for": return ok(command.id, target.runClockFor(command.durationMs, command.stepMs));
       case "clock_resume": return ok(command.id, target.resumeClock());
       case "get_game_input_actions": return ok(command.id, target.getGameInputActions());
-      case "find_game_input_actions": return ok(command.id, target.findGameInputActions({
-        id: command.actionId,
-        query: command.query,
-        valueType: command.valueType === undefined ? undefined : ({ 1: "button", 2: "axis1d", 3: "vector2", 4: "text" } as const)[command.valueType],
-        active: command.active === undefined || command.active === 0 ? undefined : command.active === 2,
-        context: command.context,
-        category: command.category,
-        tags: command.tags,
-        limit: command.limit,
-      }));
+      case "find_game_input_actions": {
+        const selector = gameInputSelectorFromWire(command as unknown as Record<string, unknown>);
+        return selector === null ? { id: command.id, ok: false, error: "invalid game input selector" } :
+          ok(command.id, target.findGameInputActions(selector));
+      }
       case "get_game_input_state": return ok(command.id, target.getGameInputState());
       case "poll_game_input": return ok(command.id, { completed: true, succeeded: true, errorCode: 0 });
       case "poll_events":
@@ -92,6 +87,35 @@ export function handleMessage(message: string | Buffer, target: DemoRuntime = ru
   } catch (error) {
     return { id: command.id, ok: false, error: (error as Error).message };
   }
+}
+
+function gameInputSelectorFromWire(command: Record<string, unknown>): GuaGameInputActionSelector | null {
+  const allowed = new Set(["id", "type", "actionId", "query", "valueType", "active", "context", "category", "tags", "limit"]);
+  if (Object.keys(command).some((field) => !allowed.has(field))) return null;
+  const text = (field: string, maximumCodePoints?: number): string | undefined | null => {
+    const value = command[field];
+    if (value === undefined) return undefined;
+    if (typeof value !== "string" || value.length === 0 || value.includes("\0") ||
+        maximumCodePoints !== undefined && [...value].length > maximumCodePoints) return null;
+    return value;
+  };
+  const actionId = text("actionId"), query = text("query", 128), context = text("context"), category = text("category");
+  if (actionId === null || query === null || context === null || category === null ||
+      actionId !== undefined && !/^[a-z][a-z0-9_.-]{0,126}$/.test(actionId) ||
+      category !== undefined && !/^[a-z][a-z0-9_.-]{0,126}$/.test(category)) return null;
+  const valueType = command.valueType;
+  const active = command.active;
+  const limit = command.limit ?? 20;
+  if (valueType !== undefined && (!Number.isInteger(valueType) || (valueType as number) < 1 || (valueType as number) > 4) ||
+      active !== undefined && (!Number.isInteger(active) || (active as number) < 0 || (active as number) > 2) ||
+      !Number.isInteger(limit) || (limit as number) < 1 || (limit as number) > 100) return null;
+  const tagValues = command.tags ?? [];
+  if (!Array.isArray(tagValues) || tagValues.length > 16 || tagValues.some((tag) => typeof tag !== "string" ||
+      tag.length === 0 || tag.includes("\0") || [...tag].length > 64) || new Set(tagValues).size !== tagValues.length) return null;
+  return { id: actionId, query: query ?? undefined,
+    valueType: valueType === undefined ? undefined : ({ 1: "button", 2: "axis1d", 3: "vector2", 4: "text" } as const)[valueType as 1 | 2 | 3 | 4],
+    active: active === undefined || active === 0 ? undefined : active === 2,
+    context: context ?? undefined, category: category ?? undefined, tags: tagValues as string[], limit: limit as number };
 }
 
 function ok(id: number, result: GuaInspectorResult): GuaInspectorResponse {

--- a/packages/bridge-ws/src/index.ts
+++ b/packages/bridge-ws/src/index.ts
@@ -7,6 +7,8 @@ import type {
   GuaClockStatus,
   GuaContextStatus,
   GuaGameInputActions,
+  GuaGameInputActionSearchResult,
+  GuaGameInputActionSelector,
   GuaGameInputState,
   GameInputCommandInput,
   GuaWorldObjectTree,
@@ -45,6 +47,16 @@ export function handleMessage(message: string | Buffer, target: DemoRuntime = ru
       case "clock_run_for": return ok(command.id, target.runClockFor(command.durationMs, command.stepMs));
       case "clock_resume": return ok(command.id, target.resumeClock());
       case "get_game_input_actions": return ok(command.id, target.getGameInputActions());
+      case "find_game_input_actions": return ok(command.id, target.findGameInputActions({
+        id: command.actionId,
+        query: command.query,
+        valueType: command.valueType === undefined ? undefined : ({ 1: "button", 2: "axis1d", 3: "vector2", 4: "text" } as const)[command.valueType],
+        active: command.active === undefined || command.active === 0 ? undefined : command.active === 2,
+        context: command.context,
+        category: command.category,
+        tags: command.tags,
+        limit: command.limit,
+      }));
       case "get_game_input_state": return ok(command.id, target.getGameInputState());
       case "poll_game_input": return ok(command.id, { completed: true, succeeded: true, errorCode: 0 });
       case "poll_events":
@@ -198,6 +210,17 @@ export class DemoRuntime {
     { id: "jump", description: "Jump", valueType: "button", holdable: true, active: true, bindings: ["Space"], risk: "safe", requiresConfirmation: false },
     { id: "move", description: "Move", valueType: "vector2", range: { minimum: -1, maximum: 1 }, holdable: true, active: true, bindings: ["Gamepad.leftStick"], risk: "safe", requiresConfirmation: false },
   ] }; }
+  findGameInputActions(selector: GuaGameInputActionSelector): GuaGameInputActionSearchResult {
+    const map = this.getGameInputActions();
+    const matches = map.actions.filter((action) => (!selector.id || action.id === selector.id) &&
+      (!selector.query || action.id.includes(selector.query) || action.description?.includes(selector.query) || action.aliases?.some((alias) => alias.includes(selector.query!))) &&
+      (!selector.valueType || action.valueType === selector.valueType) && (selector.active === undefined || action.active === selector.active) &&
+      (!selector.context || selector.context === map.context) && (!selector.category || action.category === selector.category) &&
+      (!selector.tags || selector.tags.every((tag) => action.tags?.includes(tag))))
+      .sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+    const limit = selector.limit ?? 20;
+    return { ...map, count: Math.min(matches.length, limit), truncated: matches.length > limit, actions: matches.slice(0, limit) };
+  }
   getGameInputState(): GuaGameInputState { return { schemaVersion: 1, held: [...this.heldGameInputs] }; }
   performGameInput(command: GameInputCommandInput): { requestId: number } {
     const requestId = this.nextGameInputRequestId++;

--- a/packages/bridge-ws/test/clock.test.ts
+++ b/packages/bridge-ws/test/clock.test.ts
@@ -9,6 +9,13 @@ describe("DemoRuntime virtual clock", () => {
 
     const exact = handleMessage(JSON.stringify({ id: 10, type: "find_game_input_actions", actionId: "jump", valueType: 1, active: 2, limit: 1 }), runtime);
     expect(exact).toMatchObject({ id: 10, ok: true, result: { count: 1, actions: [{ id: "jump" }] } });
+
+    for (const invalid of [
+      { actionId: "Invalid" }, { limit: 0 }, { tags: ["same", "same"] }, { query: "before\0after" },
+    ]) {
+      expect(handleMessage(JSON.stringify({ id: 11, type: "find_game_input_actions", ...invalid }), runtime))
+        .toEqual({ id: 11, ok: false, error: "invalid game input selector" });
+    }
   });
 
   test("rejects installation until the current timeline is reset", () => {

--- a/packages/bridge-ws/test/clock.test.ts
+++ b/packages/bridge-ws/test/clock.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, test } from "bun:test";
 import { DemoRuntime, handleMessage } from "../src/index";
 
 describe("DemoRuntime virtual clock", () => {
+  test("maps the flat search wire fields without treating correlation id as an action id", () => {
+    const runtime = new DemoRuntime(() => 0);
+    const all = handleMessage(JSON.stringify({ id: 9, type: "find_game_input_actions", limit: 20 }), runtime);
+    expect(all).toMatchObject({ id: 9, ok: true, result: { count: 2, truncated: false } });
+
+    const exact = handleMessage(JSON.stringify({ id: 10, type: "find_game_input_actions", actionId: "jump", valueType: 1, active: 2, limit: 1 }), runtime);
+    expect(exact).toMatchObject({ id: 10, ok: true, result: { count: 1, actions: [{ id: "jump" }] } });
+  });
+
   test("rejects installation until the current timeline is reset", () => {
     const runtime = new DemoRuntime(() => 0);
     expect(runtime.installClock(100, 10).nowMs).toBe(100);

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -4,6 +4,7 @@ import {
   type GuaInspectorClient,
   type GuaClockStatus,
   type GuaGameInputActions,
+  type GuaGameInputActionSelector,
   type GuaGameInputState,
   type GameInputCommandInput,
   type GuaNode,
@@ -14,6 +15,7 @@ import {
   WebSocketInspectorClient,
   createCoalescedAsyncRunner,
   createInspectorState,
+  findGameInputActionsCompatible,
   formatBounds,
   getSelectedNode,
   hasCompleteBounds,
@@ -97,7 +99,7 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
       setState((current) => updateInspectorState(current, snapshot));
       await refreshClock();
       try {
-        const [actions, inputState] = await Promise.all([inspectorClient.getGameInputActions(), inspectorClient.getGameInputState()]);
+        const [actions, inputState] = await Promise.all([findGameInputActionsCompatible(inspectorClient, { limit: 20 }), inspectorClient.getGameInputState()]);
         setGameInputActions(actions); setGameInputState(inputState);
       } catch { setGameInputActions(null); setGameInputState(null); }
       setStatus("idle");
@@ -216,7 +218,7 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
         (action) => inspectorClient.performAction(action),
         parsedSecrets as Record<string, string>,
         (command) => inspectorClient.performGameInput(command),
-        () => inspectorClient.getGameInputActions(),
+        (actionId) => findGameInputActionsCompatible(inspectorClient, { id: actionId, limit: 1 }),
         (action) => window.confirm(`Action '${action.id}' (${action.risk}) requires confirmation. Continue?`),
       );
       await refresh();
@@ -298,10 +300,11 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
         <GameInputPanel
           actions={gameInputActions}
           state={gameInputState}
+          onSearch={async (selector) => setGameInputActions(await findGameInputActionsCompatible(inspectorClient, selector))}
           onInput={async (command) => {
             const currentCommand = await prepareManualGameInput(
               command,
-              () => inspectorClient.getGameInputActions(),
+              (actionId) => findGameInputActionsCompatible(inspectorClient, { id: actionId, limit: 1 }),
               (action) => window.confirm(`Action '${action.id}' (${action.risk}) requires confirmation. Continue?`),
             );
             if (currentCommand === null) return;
@@ -341,16 +344,39 @@ export function GuaInspectorApp({ client }: GuaInspectorAppProps) {
   );
 }
 
-function GameInputPanel({ actions, state, onInput, onError }: {
+function GameInputPanel({ actions, state, onSearch, onInput, onError }: {
   actions: GuaGameInputActions | null; state: GuaGameInputState | null;
+  onSearch(selector: GuaGameInputActionSelector): Promise<void>;
   onInput(command: GameInputCommandInput): Promise<void>; onError(message: string): void;
 }) {
   const [rawCode, setRawCode] = useState("Space");
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState("");
+  const [tags, setTags] = useState("");
+  const [valueType, setValueType] = useState("");
+  const [activeOnly, setActiveOnly] = useState(true);
   const run = (command: GameInputCommandInput) => {
     void onInput(command).catch((caught) => onError((caught as Error).message));
   };
   return <section className="gua-panel gua-game-input-panel">
     <PanelHeader title="Game Input" detail={actions === null ? "unsupported" : `${actions.context} · r${actions.revision}`} />
+    <form className="gua-game-action-search" onSubmit={(event) => {
+      event.preventDefault();
+      void onSearch({ query: query || undefined, category: category || undefined,
+        tags: tags ? tags.split(",").map((tag) => tag.trim()).filter(Boolean) : undefined,
+        valueType: valueType ? valueType as GuaGameInputActionSelector["valueType"] : undefined,
+        active: activeOnly ? true : undefined, limit: 20 }).catch((caught) => onError((caught as Error).message));
+    }}>
+      <input aria-label="Search game actions" placeholder="Search actions" value={query} onChange={(event) => setQuery(event.currentTarget.value)} />
+      <input aria-label="Game action category" placeholder="Category" value={category} onChange={(event) => setCategory(event.currentTarget.value)} />
+      <input aria-label="Game action tags" placeholder="Tags (comma separated)" value={tags} onChange={(event) => setTags(event.currentTarget.value)} />
+      <select aria-label="Game action value type" value={valueType} onChange={(event) => setValueType(event.currentTarget.value)}>
+        <option value="">Any type</option><option value="button">button</option><option value="axis1d">axis1d</option>
+        <option value="vector2">vector2</option><option value="text">text</option>
+      </select>
+      <label><input type="checkbox" checked={activeOnly} onChange={(event) => setActiveOnly(event.currentTarget.checked)} />Active</label>
+      <button type="submit">Find</button>
+    </form>
     {actions?.actions.map((action) => <div className="gua-game-action" key={action.id}>
       <span><strong>{action.id}</strong><small>{action.valueType} · {action.active ? "active" : "inactive"} · {action.risk}</small></span>
       {action.valueType === "button" ? <>

--- a/packages/inspector/src/automation.ts
+++ b/packages/inspector/src/automation.ts
@@ -107,7 +107,7 @@ export async function replayRecording(
   perform: (action: SemanticActionInput) => Promise<ActionOutcome>,
   secrets: Record<string, string> = {},
   performGameInput?: (command: GameInputCommandInput) => Promise<unknown>,
-  getGameInputActions?: () => Promise<GuaGameInputActions>,
+  getGameInputActions?: (actionId: string) => Promise<GuaGameInputActions>,
   confirmGameInputAction?: (action: GuaGameInputAction) => boolean | Promise<boolean>,
 ): Promise<void> {
   validateRecording(recording);
@@ -162,13 +162,13 @@ export async function replayRecording(
 
 export async function prepareManualGameInput(
   command: GameInputCommandInput,
-  getGameInputActions: () => Promise<GuaGameInputActions>,
+  getGameInputActions: (actionId: string) => Promise<GuaGameInputActions>,
   confirmGameInputAction?: (action: GuaGameInputAction) => boolean | Promise<boolean>,
 ): Promise<GameInputCommandInput | null> {
   if (command.type !== "press_game_input_action" && command.type !== "set_game_input_action") return command;
   const current = { ...command } as GameInputCommandInput & { confirmed?: boolean };
   delete current.confirmed;
-  const action = (await getGameInputActions()).actions.find((candidate) => candidate.id === command.actionId);
+  const action = (await getGameInputActions(command.actionId)).actions.find((candidate) => candidate.id === command.actionId);
   if (action === undefined) throw new Error(`Game input action '${command.actionId}' is not currently published.`);
   if (!action.requiresConfirmation) return current;
   if (confirmGameInputAction === undefined || !await confirmGameInputAction(action)) return null;

--- a/packages/inspector/src/core.ts
+++ b/packages/inspector/src/core.ts
@@ -63,8 +63,10 @@ export interface GuaScreenshot {
 export interface GuaClockStatus { schemaVersion: 1; installed: boolean; state: "running" | "paused"; nowMs: number; defaultStepMs: number; pendingMs: number; generation: number; completedOperationSequence: number; operationSequence?: number; completionSessionEpoch?: number; completionAfterFrameSequence?: number; }
 export interface GuaContextStatus { sessionEpoch: number; frameSequence: number; revision: number; nodeCount: number; pendingRequestCount: number; inFlightRequestCount: number; unconsumedEventCount: number; logCount: number; hasScreenshot: boolean; firstPendingAction: number; firstPendingNodeId: string; firstEventAction: number; firstEventNodeId: string; }
 export type GuaGameInputValueType = "button" | "axis1d" | "vector2" | "text";
-export interface GuaGameInputAction { id: string; description?: string; valueType: GuaGameInputValueType; range?: { minimum: number; maximum: number }; holdable: boolean; active: boolean; bindings: unknown[]; risk: string; requiresConfirmation: boolean; }
+export interface GuaGameInputAction { id: string; description?: string; valueType: GuaGameInputValueType; range?: { minimum: number; maximum: number }; holdable: boolean; active: boolean; bindings: unknown[]; risk: string; requiresConfirmation: boolean; category?: string; aliases?: string[]; tags?: string[]; agentExposure?: "auto" | "private"; }
 export interface GuaGameInputActions { schemaVersion: 1; sessionEpoch: number; revision: number; context: string; actions: GuaGameInputAction[]; }
+export interface GuaGameInputActionSelector { id?: string; query?: string; valueType?: GuaGameInputValueType; active?: boolean; context?: string; category?: string; tags?: string[]; limit?: number; }
+export interface GuaGameInputActionSearchResult extends GuaGameInputActions { count: number; truncated: boolean; }
 export interface GuaHeldGameInput { kind: number; target: string; deviceIndex: number; value: unknown; remainingLeaseMs: number; }
 export interface GuaGameInputState { schemaVersion: 1; held: GuaHeldGameInput[]; }
 export type GameInputCommandInput =
@@ -112,6 +114,7 @@ export interface GuaInspectorClient {
   runClockFor(durationMs: number, stepMs?: number): Promise<GuaClockStatus>;
   resumeClock(): Promise<GuaClockStatus>;
   getGameInputActions(): Promise<GuaGameInputActions>;
+  findGameInputActions(selector: GuaGameInputActionSelector): Promise<GuaGameInputActionSearchResult>;
   getGameInputState(): Promise<GuaGameInputState>;
   performGameInput(command: GameInputCommandInput): Promise<{ requestId: number }>;
 }
@@ -135,6 +138,8 @@ export type GuaInspectorCommand =
   | { id: number; type: "press_key"; nodeId?: string; key: string; modifiers?: number }
   | ({ id: number } & GameInputCommandInput)
   | { id: number; type: "get_game_input_actions" | "get_game_input_state" }
+  | { id: number; type: "find_game_input_actions"; actionId?: string; query?: string; valueType?: 1 | 2 | 3 | 4;
+      active?: 0 | 1 | 2; context?: string; category?: string; tags?: string[]; limit?: number }
   | { id: number; type: "poll_game_input"; requestId: number };
 
 type GuaInspectorCommandInput =
@@ -156,6 +161,7 @@ type GuaInspectorCommandInput =
   | { type: "press_key"; nodeId?: string; key: string; modifiers?: number }
   | GameInputCommandInput
   | { type: "get_game_input_actions" | "get_game_input_state" }
+  | ({ type: "find_game_input_actions" } & GuaGameInputActionSelector)
   | { type: "poll_game_input"; requestId: number };
 
 export type GuaInspectorResponse =
@@ -430,6 +436,16 @@ export class MockInspectorClient implements GuaInspectorClient {
     { id: "jump", description: "Jump", valueType: "button", holdable: true, active: true, bindings: ["Space"], risk: "safe", requiresConfirmation: false },
     { id: "move", description: "Move", valueType: "vector2", range: { minimum: -1, maximum: 1 }, holdable: true, active: true, bindings: ["Gamepad.leftStick"], risk: "safe", requiresConfirmation: false },
   ] }; }
+  async findGameInputActions(selector: GuaGameInputActionSelector): Promise<GuaGameInputActionSearchResult> {
+    const map = await this.getGameInputActions();
+    const actions = map.actions.filter((action) => (!selector.id || action.id === selector.id) &&
+      (!selector.query || action.id.includes(selector.query) || action.description?.includes(selector.query) || action.aliases?.some((alias) => alias.includes(selector.query!))) &&
+      (!selector.valueType || action.valueType === selector.valueType) && (selector.active === undefined || action.active === selector.active) &&
+      (!selector.context || selector.context === map.context) && (!selector.category || action.category === selector.category) &&
+      (!selector.tags || selector.tags.every((tag) => action.tags?.includes(tag)))).sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+    const limit = selector.limit ?? 20;
+    return { ...map, count: Math.min(actions.length, limit), truncated: actions.length > limit, actions: actions.slice(0, limit) };
+  }
   async getGameInputState(): Promise<GuaGameInputState> { return { schemaVersion: 1, held: [] }; }
   async performGameInput(command: GameInputCommandInput): Promise<{ requestId: number }> { this.logs = [...this.logs, { sequence: this.logs.length + 1, level: "info", message: `game_input(${command.type})` }]; return { requestId: this.logs.length }; }
 }
@@ -487,6 +503,27 @@ export function createCoalescedAsyncRunner(task: () => Promise<void>): () => Pro
   };
 }
 
+export async function findGameInputActionsCompatible(
+  client: GuaInspectorClient,
+  selector: GuaGameInputActionSelector,
+): Promise<GuaGameInputActionSearchResult> {
+  try {
+    return await client.findGameInputActions(selector);
+  } catch (error) {
+    if (!/unsupported|unknown command/i.test((error as Error).message)) throw error;
+    const map = await client.getGameInputActions();
+    const limit = selector.limit ?? 20;
+    const matches = map.actions.filter((action) => (!selector.id || action.id === selector.id) &&
+      (!selector.query || action.id.includes(selector.query) || action.description?.includes(selector.query) || action.aliases?.some((alias) => alias.includes(selector.query!))) &&
+      (!selector.valueType || action.valueType === selector.valueType) && (selector.active === undefined || action.active === selector.active) &&
+      (!selector.context || selector.context === map.context) && (!selector.category || action.category === selector.category) &&
+      (!selector.tags || selector.tags.every((tag) => action.tags?.includes(tag))))
+      .sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+    const actions = matches.slice(0, limit);
+    return { ...map, count: actions.length, truncated: matches.length > actions.length, actions };
+  }
+}
+
 export class WebSocketInspectorClient implements GuaInspectorClient {
   private socket: WebSocket | null = null;
   private connectPromise: Promise<WebSocket> | null = null;
@@ -540,6 +577,12 @@ export class WebSocketInspectorClient implements GuaInspectorClient {
   }
   async resumeClock(): Promise<GuaClockStatus> { return this.request({ type: "clock_resume" }); }
   async getGameInputActions(): Promise<GuaGameInputActions> { return this.request({ type: "get_game_input_actions" }); }
+  async findGameInputActions(selector: GuaGameInputActionSelector): Promise<GuaGameInputActionSearchResult> {
+    const valueType = selector.valueType === undefined ? undefined : ({ button: 1, axis1d: 2, vector2: 3, text: 4 } as const)[selector.valueType];
+    const { id, ...rest } = selector;
+    return this.request({ type: "find_game_input_actions", ...rest, actionId: id, valueType,
+      active: selector.active === undefined ? undefined : selector.active ? 2 : 1 } as unknown as GuaInspectorCommandInput);
+  }
   async getGameInputState(): Promise<GuaGameInputState> { return this.request({ type: "get_game_input_state" }); }
   async performGameInput(command: GameInputCommandInput): Promise<{ requestId: number }> {
     const receipt = await this.request<{ requestId: number }>(command);

--- a/packages/inspector/src/styles.css
+++ b/packages/inspector/src/styles.css
@@ -322,6 +322,8 @@ button:disabled {
 
 .gua-game-input-panel { grid-column: 1 / -1; }
 .gua-game-action, .gua-game-raw { align-items: center; border-top: 1px solid #2b333d; display: flex; gap: 8px; padding: 8px 0; }
+.gua-game-action-search { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; }
+.gua-game-action-search input, .gua-game-action-search select { min-width: 110px; }
 .gua-game-action > span { display: grid; margin-right: auto; }
 .gua-game-action small { color: #96a3b3; }
 .gua-held-inputs { color: #c8d2df; margin: 8px 0 0; }

--- a/packages/inspector/test/automation.test.ts
+++ b/packages/inspector/test/automation.test.ts
@@ -1,19 +1,28 @@
 import { describe, expect, test } from "bun:test";
 
 import { InspectorRecorder, prepareManualGameInput, replayRecording, validateRecording } from "../src/automation";
-import { MockInspectorClient, createCoalescedAsyncRunner, formatBounds, hasCompleteBounds, readSnapshot, worldObjectDepths, type GuaWorldObject } from "../src/core";
+import { MockInspectorClient, createCoalescedAsyncRunner, findGameInputActionsCompatible, formatBounds, hasCompleteBounds, readSnapshot, worldObjectDepths, type GuaWorldObject } from "../src/core";
 
 describe("InspectorRecorder", () => {
+  test("falls back to a bounded legacy action map when search is unsupported", async () => {
+    const client = new MockInspectorClient();
+    client.findGameInputActions = async () => { throw new Error("unknown command"); };
+    const result = await findGameInputActionsCompatible(client, { id: "move", limit: 1 });
+    expect(result).toMatchObject({ count: 1, truncated: false, actions: [{ id: "move" }] });
+  });
+
   test("re-resolves confirmation immediately before manual game input", async () => {
     const prompts: string[] = [];
+    const resolvedIds: string[] = [];
     const command = await prepareManualGameInput(
       { type: "press_game_input_action", actionId: "launch" },
-      async () => ({ schemaVersion: 1, sessionEpoch: 1, revision: 2, context: "combat", actions: [{
+      async (actionId) => { resolvedIds.push(actionId); return { schemaVersion: 1, sessionEpoch: 1, revision: 2, context: "combat", actions: [{
         id: "launch", valueType: "button", holdable: false, active: true, bindings: [], risk: "dangerous", requiresConfirmation: true,
-      }] }),
+      }] }; },
       (action) => { prompts.push(action.id); return true; },
     );
     expect(command).toEqual({ type: "press_game_input_action", actionId: "launch", confirmed: true });
+    expect(resolvedIds).toEqual(["launch"]);
     expect(prompts).toEqual(["launch"]);
   });
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -189,10 +189,10 @@ export const guaMcpToolDefinitions: readonly McpTool[] = [
   ...worldObservationTools,
   { name: "get_game_input_actions", description: "Read the host-published semantic game action map.", inputSchema: objectSchema({}) },
   { name: "find_game_input_actions", description: "Search the current host-authorized semantic game action map.", inputSchema: objectSchema({
-    id: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 }, query: { type: "string", minLength: 1, maxLength: 128 },
+    id: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 }, query: { type: "string", minLength: 1, maxLength: 128, pattern: "^[^\\u0000]+$" },
     valueType: { type: "string", enum: ["button", "axis1d", "vector2", "text"] }, active: { type: "boolean" },
-    context: { type: "string", minLength: 1 }, category: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 },
-    tags: { type: "array", maxItems: 16, uniqueItems: true, items: { type: "string", minLength: 1, maxLength: 64 } },
+    context: { type: "string", minLength: 1, pattern: "^[^\\u0000]+$" }, category: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 },
+    tags: { type: "array", maxItems: 16, uniqueItems: true, items: { type: "string", minLength: 1, maxLength: 64, pattern: "^[^\\u0000]+$" } },
     limit: { type: "integer", minimum: 1, maximum: 100, default: 20 },
   }) },
   { name: "press_game_input_action", description: "Press a semantic button action and wait for host completion.", inputSchema: objectSchema({

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -147,6 +147,7 @@ export const guaMcpTools = [
   "scroll",
   "press_key",
   "get_game_input_actions",
+  "find_game_input_actions",
   "press_game_input_action",
   "set_game_input_action",
   "release_game_input_action",
@@ -187,6 +188,13 @@ export const guaMcpToolDefinitions: readonly McpTool[] = [
   ...guaWebMcpToolDefinitions.map(toMcpToolDefinition),
   ...worldObservationTools,
   { name: "get_game_input_actions", description: "Read the host-published semantic game action map.", inputSchema: objectSchema({}) },
+  { name: "find_game_input_actions", description: "Search the current host-authorized semantic game action map.", inputSchema: objectSchema({
+    id: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 }, query: { type: "string", minLength: 1, maxLength: 128 },
+    valueType: { type: "string", enum: ["button", "axis1d", "vector2", "text"] }, active: { type: "boolean" },
+    context: { type: "string", minLength: 1 }, category: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 },
+    tags: { type: "array", maxItems: 16, uniqueItems: true, items: { type: "string", minLength: 1, maxLength: 64 } },
+    limit: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+  }) },
   { name: "press_game_input_action", description: "Press a semantic button action and wait for host completion.", inputSchema: objectSchema({
     actionId: stringProperty("Stable host-published action id."), confirmed: { type: "boolean" },
   }, ["actionId"]) },
@@ -533,6 +541,7 @@ async function executeTool(
         modifiers: readIntegerArg(args, "modifiers", 0),
       });
     case "get_game_input_actions": return bridge.getGameInputActions();
+    case "find_game_input_actions": return bridge.findGameInputActions(gameInputSearchCommand(args));
     case "get_game_input_state": return bridge.getGameInputState();
     case "press_game_input_action":
       return performGameInput(bridge, automation, { type: name, actionId: readStringArg(args, "actionId"),
@@ -691,6 +700,19 @@ type GameInputCommandInput =
   | { type: "reset_gamepad"; gamepadIndex?: number }
   | { type: "text_input"; text: string; sensitive?: boolean; secretKey?: string };
 
+function gameInputSearchCommand(input: Record<string, unknown>): Omit<Extract<BridgeCommandInput, { type: "find_game_input_actions" }>, "type"> {
+  const valueType = readOptionalStringArg(input, "valueType");
+  const valueTypeCode = valueType === undefined ? undefined : ({ button: 1, axis1d: 2, vector2: 3, text: 4 } as const)[valueType as "button" | "axis1d" | "vector2" | "text"];
+  if (valueType !== undefined && valueTypeCode === undefined) throw new Error("valueType is invalid.");
+  const tags = input.tags;
+  if (tags !== undefined && (!Array.isArray(tags) || !tags.every((tag) => typeof tag === "string" && tag.length > 0)))
+    throw new Error("tags must contain non-empty strings.");
+  return compactResult({ actionId: readOptionalStringArg(input, "id"), query: readOptionalStringArg(input, "query"),
+    valueType: valueTypeCode, active: input.active === undefined ? undefined : readRequiredBooleanArg(input, "active") ? 2 : 1,
+    context: readOptionalStringArg(input, "context"), category: readOptionalStringArg(input, "category"),
+    tags: tags as string[] | undefined, limit: readIntegerArg(input, "limit", 20) });
+}
+
 async function performGameInput(
   bridge: GuaBridgeClient,
   automation: GuaAutomationManager | undefined,
@@ -699,7 +721,7 @@ async function performGameInput(
   signal?: AbortSignal,
 ): Promise<{ ok: true; requestId: number; completion: GameInputCompletion }> {
   if (input.type === "press_game_input_action" || input.type === "set_game_input_action") {
-    const snapshot = await bridge.getGameInputActions();
+    const snapshot = await findGameInputActionSnapshot(bridge, input.actionId);
     if (!isRecord(snapshot) || !Array.isArray(snapshot.actions)) throw new Error("Gua returned an invalid game input action map.");
     const action = snapshot.actions.find((candidate) => isRecord(candidate) && candidate.id === input.actionId);
     if (isRecord(action) && action.requiresConfirmation === true && input.confirmed !== true) {
@@ -920,7 +942,7 @@ function readSecret(secrets: Record<string, unknown>, key: string): string {
 }
 
 async function decodeGameInputSecret(bridge: GuaBridgeClient, actionId: string, secret: string): Promise<unknown> {
-  const snapshot = await bridge.getGameInputActions();
+  const snapshot = await findGameInputActionSnapshot(bridge, actionId);
   if (!isRecord(snapshot) || !Array.isArray(snapshot.actions)) throw new Error("Gua returned an invalid game input action map.");
   const action = snapshot.actions.find((candidate) => isRecord(candidate) && candidate.id === actionId);
   if (!isRecord(action) || typeof action.valueType !== "string") throw new Error(`Unknown game input action '${actionId}'.`);
@@ -948,6 +970,18 @@ async function decodeGameInputSecret(bridge: GuaBridgeClient, actionId: string, 
     return { x: value.x, y: value.y };
   }
   throw new Error(`Unsupported value type for game input action '${actionId}'.`);
+}
+
+async function findGameInputActionSnapshot(bridge: GuaBridgeClient, actionId: string): Promise<unknown> {
+  const compatible = bridge as GuaBridgeClient & { findGameInputActions?: (selector: { actionId: string; limit: number }) => Promise<unknown> };
+  if (typeof compatible.findGameInputActions === "function") {
+    try { return await compatible.findGameInputActions({ actionId, limit: 1 }); }
+    catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!/unsupported|unknown command/i.test(message)) throw error;
+    }
+  }
+  return bridge.getGameInputActions();
 }
 
 function compactResult<T extends Record<string, unknown>>(value: T): T {
@@ -1020,6 +1054,9 @@ export class GuaBridgeClient {
 
   async getClock(): Promise<unknown> { return this.request({ type: "get_clock" }); }
   async getGameInputActions(): Promise<unknown> { return this.request({ type: "get_game_input_actions" }); }
+  async findGameInputActions(selector: Omit<Extract<BridgeCommandInput, { type: "find_game_input_actions" }>, "type">): Promise<unknown> {
+    return this.request({ type: "find_game_input_actions", ...selector });
+  }
   async getGameInputState(): Promise<unknown> { return this.request({ type: "get_game_input_state" }); }
   async performGameInput(input: GameInputCommandInput): Promise<GuaActionReceipt> {
     return this.request<GuaActionReceipt>(input as BridgeCommandInput);
@@ -1227,6 +1264,7 @@ type BridgeCommandInput =
   | { type: "poll_events"; requestId: number }
   | { type: "poll_game_input"; requestId: number }
   | { type: "get_game_input_actions" | "get_game_input_state" }
+  | { type: "find_game_input_actions"; actionId?: string; query?: string; valueType?: number; active?: number; context?: string; category?: string; tags?: string[]; limit?: number }
   | { type: "get_clock" | "clock_pause" | "clock_resume" }
   | { type: "clock_install"; initialTimeMs?: number; stepMs?: number }
   | { type: "clock_run_for"; durationMs: number; stepMs?: number }

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -6,7 +6,8 @@ engine bridge in the same page. It does not start an MCP server or WebSocket.
 Alongside Semantic UI Tree actions, the Godot and Unity bridge helpers register
 the read-only `get_world_object_tree`, `find_world_objects`, and
 `wait_for_world_object` tools when the engine-owned world adapter is available.
-The helpers also register Semantic Game Action and Raw Input tools only for
+The helpers also register the fixed `find_game_input_actions` discovery tool and
+Semantic Game Action / Raw Input tools only for
 capabilities reported by an initialized engine input pump. One page-local input
 owner is used for all such calls; timeout, cancellation, unregister, port
 replacement, and engine shutdown release its held input.

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -441,22 +441,29 @@ async function waitForWorldObject(
 
 function gameInputSelector(input: Record<string, unknown>): GuaGameInputActionSelector {
   rejectUnknownArguments(input, new Set(["id", "query", "valueType", "active", "context", "category", "tags", "limit"]));
-  const stringValue = (key: string): string | undefined => {
+  const stringValue = (key: string, maximumCodePoints?: number): string | undefined => {
     const value = input[key];
     if (value === undefined) return undefined;
-    if (typeof value !== "string" || value.length === 0) throw new GuaWebError("invalid_request", `${key} must be a non-empty string.`);
+    if (typeof value !== "string" || value.length === 0 || value.includes("\0") ||
+        maximumCodePoints !== undefined && [...value].length > maximumCodePoints)
+      throw new GuaWebError("invalid_request", `${key} is invalid.`);
     return value;
   };
   const tags = input.tags;
-  if (tags !== undefined && (!Array.isArray(tags) || !tags.every((tag) => typeof tag === "string" && tag.length > 0)))
-    throw new GuaWebError("invalid_request", "tags must contain non-empty strings.");
+  if (tags !== undefined && (!Array.isArray(tags) || tags.length > 16 || !tags.every((tag) => typeof tag === "string" &&
+      tag.length > 0 && !tag.includes("\0") && [...tag].length <= 64) || new Set(tags).size !== tags.length))
+    throw new GuaWebError("invalid_request", "tags are invalid.");
   const valueType = stringValue("valueType");
   if (valueType !== undefined && !["button", "axis1d", "vector2", "text"].includes(valueType))
     throw new GuaWebError("invalid_request", "valueType is invalid.");
   if (input.active !== undefined && typeof input.active !== "boolean") throw new GuaWebError("invalid_request", "active must be boolean.");
+  const id = stringValue("id"), category = stringValue("category");
+  if (id !== undefined && !/^[a-z][a-z0-9_.-]{0,126}$/.test(id) ||
+      category !== undefined && !/^[a-z][a-z0-9_.-]{0,126}$/.test(category))
+    throw new GuaWebError("invalid_request", "id or category is invalid.");
   return {
-    id: stringValue("id"), query: stringValue("query"), valueType: valueType as GuaGameInputValueType | undefined,
-    active: input.active as boolean | undefined, context: stringValue("context"), category: stringValue("category"),
+    id, query: stringValue("query", 128), valueType: valueType as GuaGameInputValueType | undefined,
+    active: input.active as boolean | undefined, context: stringValue("context"), category,
     tags: tags as string[] | undefined, limit: optionalInteger(input, "limit", 20, 1, 100),
   };
 }

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -62,7 +62,7 @@ export interface GuaUiTree {
 export interface GuaScreenshot { dataUri: string; width: number; height: number }
 
 export const guaGameInputCapabilities = [
-  "semantic_game_input_v1", "raw_keyboard_input_v1", "raw_pointer_input_v1", "raw_gamepad_input_v1",
+  "semantic_game_input_v1", "semantic_game_input_search_v1", "raw_keyboard_input_v1", "raw_pointer_input_v1", "raw_gamepad_input_v1",
   "text_input_v1", "game_input_lease_v1",
 ] as const;
 export type GuaGameInputCapability = (typeof guaGameInputCapabilities)[number];
@@ -70,9 +70,18 @@ export type GuaGameInputValueType = "button" | "axis1d" | "vector2" | "text";
 export interface GuaGameInputAction {
   id: string; description: string; valueType: GuaGameInputValueType; range?: { minimum: number; maximum: number };
   holdable: boolean; active: boolean; bindings: string[]; risk: string; requiresConfirmation: boolean;
+  category?: string; aliases?: string[]; tags?: string[]; agentExposure?: "auto" | "private";
 }
 export interface GuaGameInputActionMap {
   schemaVersion: 1; sessionEpoch: number; revision: number; context: string; actions: GuaGameInputAction[];
+}
+export interface GuaGameInputActionSelector {
+  id?: string; query?: string; valueType?: GuaGameInputValueType; active?: boolean; context?: string;
+  category?: string; tags?: string[]; limit?: number;
+}
+export interface GuaGameInputActionSearchResult {
+  schemaVersion: 1; sessionEpoch: number; revision: number; context: string; count: number; truncated: boolean;
+  actions: GuaGameInputAction[];
 }
 export interface GuaGameInputState { schemaVersion: 1; held: unknown[] }
 export type GuaGameInputRequest =
@@ -122,6 +131,7 @@ export interface GuaBrowserBridge {
   findWorldObjects?(selector: GuaWorldSelector, options?: GuaBridgeCallOptions): Promise<GuaWorldQueryResult>;
   getGameInputCapabilities?(): Promise<GuaGameInputCapability[]>;
   getGameInputActions?(): Promise<GuaGameInputActionMap>;
+  findGameInputActions?(selector: GuaGameInputActionSelector): Promise<GuaGameInputActionSearchResult>;
   getGameInputState?(): Promise<GuaGameInputState>;
   performGameInput?(request: GuaGameInputRequest, options?: GuaBridgeCallOptions): Promise<GuaGameInputCompletion>;
 }
@@ -216,6 +226,7 @@ export async function registerGuaWebMcp(
           executionOptions?.signal,
           pollIntervalMs,
           defaultTimeoutMs,
+          gameInputCapabilities.includes("semantic_game_input_search_v1"),
         ),
       }, { signal: controller.signal });
       registeredTools.push(definition.name);
@@ -247,6 +258,7 @@ function gameInputDefinitions(capabilities: GuaGameInputCapability[], bridge: Gu
   if (capabilities.includes("semantic_game_input_v1") && bridge.getGameInputActions) {
     for (const name of ["get_game_input_actions", "press_game_input_action", "set_game_input_action", "release_game_input_action"]) enabled.add(name);
   }
+  if (capabilities.includes("semantic_game_input_search_v1") && bridge.findGameInputActions) enabled.add("find_game_input_actions");
   if (capabilities.length > 0) enabled.add("release_all_game_inputs");
   if (capabilities.length > 0 && bridge.getGameInputState) enabled.add("get_game_input_state");
   if (capabilities.includes("raw_keyboard_input_v1")) for (const name of ["key_down", "key_up", "press_physical_key"]) enabled.add(name);
@@ -263,6 +275,7 @@ async function executeTool(
   signal: AbortSignal | undefined,
   pollIntervalMs: number,
   defaultTimeoutMs: number,
+  gameInputSearchSupported: boolean,
 ): Promise<unknown> {
   try {
     throwIfAborted(signal);
@@ -319,6 +332,11 @@ async function executeTool(
       if (!bridge.getGameInputActions) throw new GuaWebError("engine_unsupported", "The engine bridge does not support semantic game input.");
       return toolResult(await withTimeout(bridge.getGameInputActions(), defaultTimeoutMs, signal, "Timed out reading the game input action map."));
     }
+    if (name === "find_game_input_actions") {
+      if (!bridge.findGameInputActions) throw new GuaWebError("engine_unsupported", "The engine bridge does not support game input search.");
+      return toolResult(await withTimeout(bridge.findGameInputActions(gameInputSelector(input)), defaultTimeoutMs, signal,
+        "Timed out searching the game input action map."));
+    }
     if (name === "get_game_input_state") {
       rejectUnknownArguments(input, new Set());
       if (!bridge.getGameInputState) throw new GuaWebError("engine_unsupported", "The engine bridge does not expose page-owned game input state.");
@@ -327,9 +345,12 @@ async function executeTool(
     if (isGameInputTool(name)) {
       if (!bridge.performGameInput) throw new GuaWebError("engine_unsupported", "The engine bridge does not support game input.");
       const request = gameInputRequest(name, input);
-      if ((request.type === "press_game_input_action" || request.type === "set_game_input_action") && bridge.getGameInputActions) {
-        const map = await withTimeout(bridge.getGameInputActions(), defaultTimeoutMs, signal, "Timed out validating the game input action map.");
-        const action = map.actions.find((candidate) => candidate.id === request.actionId);
+      if ((request.type === "press_game_input_action" || request.type === "set_game_input_action") && (bridge.getGameInputActions || (gameInputSearchSupported && bridge.findGameInputActions))) {
+        const actions = gameInputSearchSupported && bridge.findGameInputActions
+          ? (await withTimeout(bridge.findGameInputActions({ id: request.actionId, limit: 1 }), defaultTimeoutMs, signal,
+              "Timed out validating the game input action map.")).actions
+          : (await withTimeout(bridge.getGameInputActions!(), defaultTimeoutMs, signal, "Timed out validating the game input action map.")).actions;
+        const action = actions.find((candidate) => candidate.id === request.actionId);
         if (!action) throw new GuaWebError("invalid_request", `Unknown game input action: ${request.actionId}`);
         if (action.requiresConfirmation && request.confirmed !== true) {
           throw new GuaWebError("invalid_request", `Game input action '${request.actionId}' requires confirmed=true.`);
@@ -416,6 +437,28 @@ async function waitForWorldObject(
     await delay(Math.min(pollIntervalMs, Math.max(0, deadline - performance.now())), signal);
   } while (true);
   throw new GuaWebError("timeout", "Timed out waiting for a Gua world object.", { timeoutMs });
+}
+
+function gameInputSelector(input: Record<string, unknown>): GuaGameInputActionSelector {
+  rejectUnknownArguments(input, new Set(["id", "query", "valueType", "active", "context", "category", "tags", "limit"]));
+  const stringValue = (key: string): string | undefined => {
+    const value = input[key];
+    if (value === undefined) return undefined;
+    if (typeof value !== "string" || value.length === 0) throw new GuaWebError("invalid_request", `${key} must be a non-empty string.`);
+    return value;
+  };
+  const tags = input.tags;
+  if (tags !== undefined && (!Array.isArray(tags) || !tags.every((tag) => typeof tag === "string" && tag.length > 0)))
+    throw new GuaWebError("invalid_request", "tags must contain non-empty strings.");
+  const valueType = stringValue("valueType");
+  if (valueType !== undefined && !["button", "axis1d", "vector2", "text"].includes(valueType))
+    throw new GuaWebError("invalid_request", "valueType is invalid.");
+  if (input.active !== undefined && typeof input.active !== "boolean") throw new GuaWebError("invalid_request", "active must be boolean.");
+  return {
+    id: stringValue("id"), query: stringValue("query"), valueType: valueType as GuaGameInputValueType | undefined,
+    active: input.active as boolean | undefined, context: stringValue("context"), category: stringValue("category"),
+    tags: tags as string[] | undefined, limit: optionalInteger(input, "limit", 20, 1, 100),
+  };
 }
 
 function rejectUnknownArguments(input: Record<string, unknown>, allowed: Set<string>): void {

--- a/packages/webmcp/src/ports.ts
+++ b/packages/webmcp/src/ports.ts
@@ -1,6 +1,7 @@
 import {
   GuaWebError, guaGameInputCapabilities, type GuaBridgeCallOptions, type GuaBrowserBridge,
   type GuaGameInputActionMap, type GuaGameInputCapability, type GuaGameInputCompletion, type GuaGameInputRequest,
+  type GuaGameInputActionSearchResult, type GuaGameInputActionSelector,
   type GuaGameInputState, type GuaScreenshot, type GuaUiTree, type GuaWebActionCompletion, type GuaWebActionRequest,
 } from "./index.js";
 import {
@@ -21,6 +22,7 @@ export type GuaInPageCommand =
   | { type: "perform_action"; request: GuaWebActionRequest }
   | { type: "get_game_input_capabilities" }
   | { type: "get_game_input_actions" }
+  | ({ type: "find_game_input_actions" } & GuaGameInputActionSelector)
   | { type: "get_game_input_state" }
   | { type: "perform_game_input"; request: GuaGameInputRequest }
   | { type: "get_screenshot" };
@@ -59,6 +61,7 @@ export function createGuaInPageBridge(port: GuaInPagePort, options: GuaInPageBri
   if (options.gameInput) {
     bridge.getGameInputCapabilities = async () => parseGameInputCapabilities(await invoke(port, { type: "get_game_input_capabilities" }));
     bridge.getGameInputActions = async () => parseGameInputActions(await invoke(port, { type: "get_game_input_actions" }));
+    bridge.findGameInputActions = async (selector) => parseGameInputActionSearch(await invoke(port, { type: "find_game_input_actions", ...selector }));
     bridge.getGameInputState = async () => parseGameInputState(await invoke(port, { type: "get_game_input_state" }));
     bridge.performGameInput = async (request, callOptions) => parseGameInputCompletion(await invoke(
       port, { type: "perform_game_input", request: validateGameInputRequest(request) }, callOptions,
@@ -342,6 +345,17 @@ function parseGameInputActions(value: unknown): GuaGameInputActionMap {
   return parsed as GuaGameInputActionMap;
 }
 
+function parseGameInputActionSearch(value: unknown): GuaGameInputActionSearchResult {
+  const parsed = parseJson(value);
+  const record = asRecord(parsed);
+  if (!record || record.schemaVersion !== 1 || !Number.isInteger(record.sessionEpoch) || (record.sessionEpoch as number) < 1 ||
+      !Number.isInteger(record.revision) || (record.revision as number) < 0 || !isNonEmptyString(record.context) ||
+      !Number.isInteger(record.count) || (record.count as number) < 0 || typeof record.truncated !== "boolean" ||
+      !Array.isArray(record.actions) || record.count !== record.actions.length || !record.actions.every(isGameInputAction))
+    throw new GuaWebError("invalid_request", "The engine returned an invalid game input action search result.");
+  return parsed as GuaGameInputActionSearchResult;
+}
+
 function isGameInputAction(value: unknown): boolean {
   const action = asRecord(value);
   if (!action || !isNonEmptyString(action.id) || typeof action.description !== "string" ||
@@ -349,6 +363,10 @@ function isGameInputAction(value: unknown): boolean {
       typeof action.holdable !== "boolean" || typeof action.active !== "boolean" ||
       !Array.isArray(action.bindings) || !action.bindings.every(isNonEmptyString) ||
       typeof action.risk !== "string" || typeof action.requiresConfirmation !== "boolean") return false;
+  if (action.category !== undefined && !isNonEmptyString(action.category)) return false;
+  if (action.aliases !== undefined && (!Array.isArray(action.aliases) || !action.aliases.every(isNonEmptyString))) return false;
+  if (action.tags !== undefined && (!Array.isArray(action.tags) || !action.tags.every(isNonEmptyString))) return false;
+  if (action.agentExposure !== undefined && action.agentExposure !== "auto" && action.agentExposure !== "private") return false;
   if (action.minimum !== undefined || action.maximum !== undefined) return false;
   if (action.range === undefined) return true;
   const range = asRecord(action.range);

--- a/packages/webmcp/src/tool-definitions.ts
+++ b/packages/webmcp/src/tool-definitions.ts
@@ -20,7 +20,7 @@ export const guaWebMcpToolNames = [
 export type GuaWebMcpToolName = (typeof guaWebMcpToolNames)[number];
 
 export const guaGameInputToolNames = [
-  "get_game_input_actions", "press_game_input_action", "set_game_input_action", "release_game_input_action",
+  "get_game_input_actions", "find_game_input_actions", "press_game_input_action", "set_game_input_action", "release_game_input_action",
   "get_game_input_state", "release_all_game_inputs", "key_down", "key_up", "press_physical_key", "pointer_move",
   "pointer_button_down", "pointer_button_up", "pointer_wheel", "gamepad_button_down", "gamepad_button_up",
   "set_gamepad_axis", "reset_gamepad", "text_input",
@@ -121,6 +121,14 @@ export const guaWebMcpToolDefinitions: readonly GuaToolDefinition<GuaWebMcpToolN
 
 export const guaGameInputToolDefinitions: readonly GuaToolDefinition<GuaGameInputToolName>[] = [
   { name: "get_game_input_actions", description: "Read the host-published semantic game action map.", inputSchema: objectSchema({}) },
+  { name: "find_game_input_actions", description: "Search the current host-authorized semantic game action map.", inputSchema: objectSchema({
+    id: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 },
+    query: { type: "string", minLength: 1, maxLength: 128 },
+    valueType: { type: "string", enum: ["button", "axis1d", "vector2", "text"] }, active: { type: "boolean" },
+    context: { type: "string", minLength: 1 }, category: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 },
+    tags: { type: "array", maxItems: 16, uniqueItems: true, items: { type: "string", minLength: 1, maxLength: 64 } },
+    limit: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+  }) },
   { name: "press_game_input_action", description: "Press a semantic button action and wait for host completion.", inputSchema: objectSchema({
     actionId: stringProperty("Stable host-published action id."), confirmed: { type: "boolean" },
   }, ["actionId"]) },

--- a/packages/webmcp/src/tool-definitions.ts
+++ b/packages/webmcp/src/tool-definitions.ts
@@ -123,10 +123,10 @@ export const guaGameInputToolDefinitions: readonly GuaToolDefinition<GuaGameInpu
   { name: "get_game_input_actions", description: "Read the host-published semantic game action map.", inputSchema: objectSchema({}) },
   { name: "find_game_input_actions", description: "Search the current host-authorized semantic game action map.", inputSchema: objectSchema({
     id: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 },
-    query: { type: "string", minLength: 1, maxLength: 128 },
+    query: { type: "string", minLength: 1, maxLength: 128, pattern: "^[^\\u0000]+$" },
     valueType: { type: "string", enum: ["button", "axis1d", "vector2", "text"] }, active: { type: "boolean" },
-    context: { type: "string", minLength: 1 }, category: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 },
-    tags: { type: "array", maxItems: 16, uniqueItems: true, items: { type: "string", minLength: 1, maxLength: 64 } },
+    context: { type: "string", minLength: 1, pattern: "^[^\\u0000]+$" }, category: { type: "string", pattern: "^[a-z][a-z0-9_.-]*$", maxLength: 127 },
+    tags: { type: "array", maxItems: 16, uniqueItems: true, items: { type: "string", minLength: 1, maxLength: 64, pattern: "^[^\\u0000]+$" } },
     limit: { type: "integer", minimum: 1, maximum: 100, default: 20 },
   }) },
   { name: "press_game_input_action", description: "Press a semantic button action and wait for host completion.", inputSchema: objectSchema({

--- a/packages/webmcp/test/godot-web-port.test.ts
+++ b/packages/webmcp/test/godot-web-port.test.ts
@@ -24,6 +24,7 @@ const godotGlobals = globalThis as typeof globalThis & {
   __guaGodotCancelAction?: GodotCallback<[requestId: string]>;
   __guaGodotGetGameInputCapabilities?: GodotCallback;
   __guaGodotGetGameInputActions?: GodotCallback;
+  __guaGodotFindGameInputActions?: GodotCallback<[request: string]>;
   __guaGodotGetGameInputState?: GodotCallback;
   __guaGodotEnqueueGameInput?: GodotCallback<[request: string]>;
   __guaGodotPollGameInput?: GodotCallback<[requestId: string]>;
@@ -41,6 +42,7 @@ afterEach(() => {
   delete godotGlobals.__guaGodotCancelAction;
   delete godotGlobals.__guaGodotGetGameInputCapabilities;
   delete godotGlobals.__guaGodotGetGameInputActions;
+  delete godotGlobals.__guaGodotFindGameInputActions;
   delete godotGlobals.__guaGodotGetGameInputState;
   delete godotGlobals.__guaGodotEnqueueGameInput;
   delete godotGlobals.__guaGodotPollGameInput;
@@ -71,6 +73,13 @@ async function installGodotWebPort(
   godotGlobals.__guaGodotCancelAction = godotCallback((requestId) => { cancelled.push(requestId); return options.cancellationResult ?? 1; });
   godotGlobals.__guaGodotGetGameInputCapabilities = godotCallback(() => JSON.stringify(["raw_keyboard_input_v1"]));
   godotGlobals.__guaGodotGetGameInputActions = godotCallback(() => JSON.stringify({ schemaVersion: 1, sessionEpoch: 1, revision: 1, context: "", actions: [] }));
+  godotGlobals.__guaGodotFindGameInputActions = godotCallback((request) => {
+    const selector = JSON.parse(request) as { id?: string };
+    return JSON.stringify({ schemaVersion: 1, sessionEpoch: 1, revision: 2, context: "gameplay", count: 1,
+      truncated: false, actions: [{ id: selector.id, description: "Jump", valueType: "button", holdable: true,
+        active: true, bindings: ["Space"], risk: "safe", requiresConfirmation: false, category: "movement",
+        aliases: ["hop"], tags: ["gameplay"], agentExposure: "auto" }] });
+  });
   godotGlobals.__guaGodotGetGameInputState = godotCallback(() => JSON.stringify({ schemaVersion: 1, held: [] }));
   godotGlobals.__guaGodotEnqueueGameInput = godotCallback(options.enqueueGameInput ?? (() => JSON.stringify({ requestId: 23 })));
   godotGlobals.__guaGodotPollGameInput = godotCallback(options.pollGameInput ?? (() => "null"));
@@ -80,6 +89,12 @@ async function installGodotWebPort(
 }
 
 describe("Godot Web same-page port", () => {
+  test("routes bounded semantic action search through the Godot callback", async () => {
+    const port = await installGodotWebPort([]);
+    await expect(port.invoke({ type: "find_game_input_actions", id: "jump", limit: 1 })).resolves.toMatchObject({
+      context: "gameplay", count: 1, truncated: false, actions: [{ id: "jump", category: "movement" }],
+    });
+  });
   test("routes World Object Tree reads and queries through Godot callbacks", async () => {
     const port = await installGodotWebPort([]);
     await expect(port.invoke({ type: "get_world_object_tree" })).resolves.toMatchObject({ scene: "level" });

--- a/packages/webmcp/test/webmcp.test.ts
+++ b/packages/webmcp/test/webmcp.test.ts
@@ -145,20 +145,27 @@ describe("registerGuaWebMcp", () => {
     const bridge: GuaBrowserBridge = {
       getUiTree: async () => tree(),
       performAction: async (request) => ({ requestId: 1, action: request.action, succeeded: true }),
-      getGameInputCapabilities: async () => ["semantic_game_input_v1", "raw_keyboard_input_v1", "game_input_lease_v1"],
+      getGameInputCapabilities: async () => ["semantic_game_input_v1", "semantic_game_input_search_v1", "raw_keyboard_input_v1", "game_input_lease_v1"],
       getGameInputActions: async () => ({ schemaVersion: 1, sessionEpoch: 1, revision: 2, context: "play", actions: [{
         id: "jump", description: "Jump", valueType: "button", holdable: false, active: true,
         bindings: ["Space"], risk: "safe", requiresConfirmation: false,
       }] }),
+      findGameInputActions: async (selector) => ({ schemaVersion: 1, sessionEpoch: 1, revision: 2, context: "play",
+        count: selector.id === "jump" || selector.query === "Jump" ? 1 : 0, truncated: false, actions: selector.id === "jump" || selector.query === "Jump" ? [{
+          id: "jump", description: "Jump", valueType: "button", holdable: false, active: true,
+          bindings: ["Space"], risk: "safe", requiresConfirmation: false,
+        }] : [] }),
       getGameInputState: async () => ({ schemaVersion: 1, held: [] }),
       performGameInput: async (request) => { requests.push(request); return { completed: true, requestId: 21, succeeded: true, errorCode: 0 }; },
     };
     const registration = await registerGuaWebMcp(bridge, { document: page.document });
     expect(registration.registeredTools).toEqual(expect.arrayContaining([
-      "get_game_input_actions", "press_game_input_action", "get_game_input_state", "release_all_game_inputs", "key_down",
+      "get_game_input_actions", "find_game_input_actions", "press_game_input_action", "get_game_input_state", "release_all_game_inputs", "key_down",
     ]));
     expect(registration.registeredTools).not.toContain("pointer_move");
     expect(registration.registeredTools).not.toContain("set_gamepad_axis");
+    const found = await page.tools.get("find_game_input_actions")!.execute({ query: "Jump", active: true }) as { content: Array<{ text: string }> };
+    expect(JSON.parse(found.content[0]!.text).actions[0].id).toBe("jump");
     await page.tools.get("press_game_input_action")!.execute({ actionId: "jump" });
     expect(requests).toContainEqual({ type: "press_game_input_action", actionId: "jump", confirmed: false });
   });
@@ -237,6 +244,7 @@ describe("registerGuaWebMcp", () => {
         id: "self_destruct", description: "Danger", valueType: "button", holdable: false, active: true,
         bindings: [], risk: "dangerous", requiresConfirmation: true,
       }] }),
+      findGameInputActions: async () => { throw new Error("legacy runtime must use get_game_input_actions"); },
       getGameInputState: async () => ({ schemaVersion: 1, held: [] }),
       performGameInput: async (request) => { requests.push(request); return { completed: true, requestId: 22, succeeded: true, errorCode: 0 }; },
     };

--- a/packages/webmcp/test/webmcp.test.ts
+++ b/packages/webmcp/test/webmcp.test.ts
@@ -142,6 +142,7 @@ describe("registerGuaWebMcp", () => {
   test("advertises game-input tools only for initialized engine capabilities", async () => {
     const page = modelDocument();
     const requests: unknown[] = [];
+    const searchSelectors: unknown[] = [];
     const bridge: GuaBrowserBridge = {
       getUiTree: async () => tree(),
       performAction: async (request) => ({ requestId: 1, action: request.action, succeeded: true }),
@@ -150,11 +151,11 @@ describe("registerGuaWebMcp", () => {
         id: "jump", description: "Jump", valueType: "button", holdable: false, active: true,
         bindings: ["Space"], risk: "safe", requiresConfirmation: false,
       }] }),
-      findGameInputActions: async (selector) => ({ schemaVersion: 1, sessionEpoch: 1, revision: 2, context: "play",
+      findGameInputActions: async (selector) => { searchSelectors.push(selector); return { schemaVersion: 1, sessionEpoch: 1, revision: 2, context: "play",
         count: selector.id === "jump" || selector.query === "Jump" ? 1 : 0, truncated: false, actions: selector.id === "jump" || selector.query === "Jump" ? [{
           id: "jump", description: "Jump", valueType: "button", holdable: false, active: true,
           bindings: ["Space"], risk: "safe", requiresConfirmation: false,
-        }] : [] }),
+        }] : [] }; },
       getGameInputState: async () => ({ schemaVersion: 1, held: [] }),
       performGameInput: async (request) => { requests.push(request); return { completed: true, requestId: 21, succeeded: true, errorCode: 0 }; },
     };
@@ -166,6 +167,13 @@ describe("registerGuaWebMcp", () => {
     expect(registration.registeredTools).not.toContain("set_gamepad_axis");
     const found = await page.tools.get("find_game_input_actions")!.execute({ query: "Jump", active: true }) as { content: Array<{ text: string }> };
     expect(JSON.parse(found.content[0]!.text).actions[0].id).toBe("jump");
+    for (const invalid of [{ id: "Invalid" }, { tags: ["same", "same"] }, { query: "q".repeat(129) }, { query: "before\0after" }]) {
+      const rejected = await page.tools.get("find_game_input_actions")!.execute(invalid) as { isError: boolean; content: Array<{ text: string }> };
+      expect(rejected.isError).toBe(true);
+      expect(JSON.parse(rejected.content[0]!.text).error.code).toBe("invalid_request");
+    }
+    expect(searchSelectors).toHaveLength(1);
+    expect(searchSelectors[0]).toMatchObject({ query: "Jump", active: true, limit: 20 });
     await page.tools.get("press_game_input_action")!.execute({ actionId: "jump" });
     expect(requests).toContainEqual({ type: "press_game_input_action", actionId: "jump", confirmed: false });
   });

--- a/protocol/schema/commands.schema.json
+++ b/protocol/schema/commands.schema.json
@@ -17,6 +17,7 @@
     { "$ref": "#/$defs/clockInstall" },
     { "$ref": "#/$defs/clockRunFor" },
     { "$ref": "#/$defs/gameInputAction" },
+    { "$ref": "#/$defs/findGameInputActions" },
     { "$ref": "#/$defs/rawKey" },
     { "$ref": "#/$defs/pointerInput" },
     { "$ref": "#/$defs/gamepadInput" },
@@ -219,6 +220,22 @@
           ] } }
         }
       ]
+    },
+    "findGameInputActions": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "find_game_input_actions" },
+        "actionId": { "type": "string", "pattern": "^[a-z][a-z0-9_.-]*$", "maxLength": 127 },
+        "query": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "valueType": { "type": "integer", "minimum": 1, "maximum": 4 },
+        "active": { "type": "integer", "minimum": 0, "maximum": 2 },
+        "context": { "type": "string", "minLength": 1 },
+        "category": { "type": "string", "pattern": "^[a-z][a-z0-9_.-]*$", "maxLength": 127 },
+        "tags": { "type": "array", "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 64 } },
+        "limit": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 }
+      }
     },
     "keyboardCode": {
       "type": "string",

--- a/protocol/schema/commands.schema.json
+++ b/protocol/schema/commands.schema.json
@@ -228,12 +228,12 @@
       "properties": {
         "type": { "const": "find_game_input_actions" },
         "actionId": { "type": "string", "pattern": "^[a-z][a-z0-9_.-]*$", "maxLength": 127 },
-        "query": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "query": { "type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[^\\u0000]+$" },
         "valueType": { "type": "integer", "minimum": 1, "maximum": 4 },
         "active": { "type": "integer", "minimum": 0, "maximum": 2 },
-        "context": { "type": "string", "minLength": 1 },
+        "context": { "type": "string", "minLength": 1, "pattern": "^[^\\u0000]+$" },
         "category": { "type": "string", "pattern": "^[a-z][a-z0-9_.-]*$", "maxLength": 127 },
-        "tags": { "type": "array", "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 64 } },
+        "tags": { "type": "array", "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[^\\u0000]+$" } },
         "limit": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 }
       }
     },

--- a/protocol/schema/game-input-action-search.schema.json
+++ b/protocol/schema/game-input-action-search.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gua.dev/schema/game-input-action-search.schema.json",
+  "title": "Gua Game Input Action Search Result",
+  "type": "object",
+  "required": ["schemaVersion", "sessionEpoch", "revision", "context", "count", "truncated", "actions"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "sessionEpoch": { "type": "integer", "minimum": 1 },
+    "revision": { "type": "integer", "minimum": 0 },
+    "context": { "type": "string", "minLength": 1 },
+    "count": { "type": "integer", "minimum": 0, "maximum": 100 },
+    "truncated": { "type": "boolean" },
+    "actions": { "type": "array", "maxItems": 100, "items": { "$ref": "game-input-actions.schema.json#/$defs/action" } }
+  }
+}

--- a/protocol/schema/game-input-actions.schema.json
+++ b/protocol/schema/game-input-actions.schema.json
@@ -29,7 +29,11 @@
         "active": { "type": "boolean" },
         "bindings": { "type": "array", "items": { "type": "string", "minLength": 1 } },
         "risk": { "enum": ["safe", "caution", "dangerous"] },
-        "requiresConfirmation": { "type": "boolean" }
+        "requiresConfirmation": { "type": "boolean" },
+        "category": { "type": "string", "pattern": "^[a-z][a-z0-9_.-]*$", "maxLength": 127 },
+        "aliases": { "type": "array", "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 64 } },
+        "tags": { "type": "array", "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 64 } },
+        "agentExposure": { "enum": ["auto", "private"] }
       }
     }
   }

--- a/protocol/schema/game-input-actions.schema.json
+++ b/protocol/schema/game-input-actions.schema.json
@@ -31,8 +31,8 @@
         "risk": { "enum": ["safe", "caution", "dangerous"] },
         "requiresConfirmation": { "type": "boolean" },
         "category": { "type": "string", "pattern": "^[a-z][a-z0-9_.-]*$", "maxLength": 127 },
-        "aliases": { "type": "array", "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 64 } },
-        "tags": { "type": "array", "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 64 } },
+        "aliases": { "type": "array", "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[^\\u0000]+$" } },
+        "tags": { "type": "array", "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[^\\u0000]+$" } },
         "agentExposure": { "enum": ["auto", "private"] }
       }
     }

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -330,7 +330,7 @@ actions are visible; action maps are not inferred from engine assets or the UI
 tree. Hosts validate IDs, active context, finite values, ranges, and holdability
 both when enqueueing and when consuming requests.
 
-Semantic commands are `get_game_input_actions`, `press_game_input_action`,
+Semantic commands are `get_game_input_actions`, `find_game_input_actions`, `press_game_input_action`,
 `set_game_input_action`, `release_game_input_action`, `get_game_input_state`,
 and `release_all_game_inputs`. Raw commands are `key_down`, `key_up`,
 `press_physical_key`, pointer move/button/wheel operations, standard-mapping
@@ -344,6 +344,23 @@ W3C `KeyboardEvent.code` values enumerated by `commands.schema.json` through
 alphanumeric, navigation, left/right modifier locations, F1-F24, numpad
 digit/operator, and PrintScreen codes; clients must not assume every optional
 or platform-specific W3C code is available.
+
+Descriptor v2 adds optional `category`, `aliases`, `tags`, and `agentExposure`.
+Category follows the Action ID ASCII identifier and byte limits. Aliases and
+tags contain at most 16 distinct, non-empty values of 1-64 Unicode code points;
+metadata is compared exactly without Unicode normalization or case folding.
+`find_game_input_actions` accepts exact `id`, ordinal case-sensitive substring
+`query` over ID/description/aliases, `valueType`, `active`, exact `context`,
+exact `category`, all-of `tags`, and `limit`. Conditions are ANDed and Action IDs
+are sorted ordinally. Results contain projected `revision`, actual `context`,
+returned `count`, `truncated`, and `actions`, but never the total match count.
+The public C++/.NET/MCP/WebMCP selector field remains `id`; the flat WebSocket
+command encodes that field as `actionId` because its top-level `id` is reserved
+for request correlation.
+Player projection removes `private` actions before all filtering and truncation,
+so result shape does not reveal their presence. Its independent revision does
+not advance for private-only changes. Descriptor metadata is observable and
+must not contain secrets.
 Before dispatching `press_game_input_action` or `set_game_input_action`, clients
 resolve the current descriptor and require `confirmed=true` when
 `requiresConfirmation` is set. The confirmation decision travels through the
@@ -379,7 +396,8 @@ injection. A completed result is acknowledged and removed after a successful
 full-buffer copy; implementations retain at most 1024 unacknowledged results per owner
 and discard results owned by a released session.
 
-Adapters advertise only initialized paths from `semantic_game_input_v1`,
+Adapters advertise search additively as `semantic_game_input_search_v1` and only
+initialized input paths from `semantic_game_input_v1`,
 `raw_keyboard_input_v1`, `raw_pointer_input_v1`, `raw_gamepad_input_v1`,
 `text_input_v1`, and `game_input_lease_v1`. Raw input is opt-in; an adapter with
 no active pump and neutral-release path must omit the capability and return

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -349,6 +349,10 @@ Descriptor v2 adds optional `category`, `aliases`, `tags`, and `agentExposure`.
 Category follows the Action ID ASCII identifier and byte limits. Aliases and
 tags contain at most 16 distinct, non-empty values of 1-64 Unicode code points;
 metadata is compared exactly without Unicode normalization or case folding.
+Aliases and tags reject embedded U+0000 before conversion to the stable
+NUL-terminated v1 C ABI.
+Selector query, context, and tag strings reject embedded U+0000 because the
+stable v1 C ABI represents them as NUL-terminated UTF-8 strings.
 `find_game_input_actions` accepts exact `id`, ordinal case-sensitive substring
 `query` over ID/description/aliases, `valueType`, `active`, exact `context`,
 exact `category`, all-of `tags`, and `limit`. Conditions are ANDed and Action IDs


### PR DESCRIPTION
https://github.com/link1345/gua/issues/97

## Summary

- ゲーム入力アクションのスキーマ、C/C++ API、.NET/Unity バインディングを整合
- Godot、WebMCP、WebSocket ブリッジ、MCP、Inspector 間の入力処理と仮想時計を統一
- セレクター、状態モデル、WebMCP、Inspector のテストとドキュメントを更新

## Testing

- 未実行（依頼なし）