### PR TITLE
Unity Editorスモークの起動待機時間を120秒へ延長

### DIFF
--- a/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
@@ -31,7 +31,9 @@ public sealed class UnityIntegrationTests
         {
             UnityExecutablePath = Environment.GetEnvironmentVariable("UNITY_EXECUTABLE"),
             ProjectPath = Environment.GetEnvironmentVariable("GUA_UNITY_PROJECT"),
-            ConnectTimeout = TimeSpan.FromSeconds(60),
+            // A cold Intel macOS import can still be reloading assemblies when the
+            // default 60-second deadline expires, even with the API Updater disabled.
+            ConnectTimeout = TimeSpan.FromSeconds(120),
             SceneTimeout = TimeSpan.FromSeconds(15),
             AdditionalArguments = EditorAdditionalArguments(batchMode, disableAssemblyUpdater),
         });


### PR DESCRIPTION
## 概要

- Unity Editor integration fixtureのbridge接続待機時間を60秒から120秒へ延長します。
- Windows、Linux、macOSの全環境で同じ有限期限を使用します。

## 背景

Gua Release run 33574050248のmacOS x64 Editor smokeでは、cold importによりProject Loadingが57.399秒、Asset Database refreshが52.046秒かかりました。sceneを正常に開き、Play Mode向けAssembly Reloadを開始した直後に、従来の60秒期限へ到達してテストホストがUnityを終了していました。

ログにはコンパイルエラー、Guaアダプター例外、Unityの異常終了はなく、Gua Runtime起動前のcold importが接続期限をほぼ使い切ったことが直接原因です。

同runのWindows Editor smokeは、テスト開始前にUnity Licensing Client自身がboot drive serial取得失敗とObjectDisposedExceptionで終了した外部障害であり、このPRの修正対象には含めていません。

## 検証

- EditorStartupArguments_CanDisableUpdaterAfterBatchMode: 1件成功
- Gua.Unity.Integration.Tests全体: 1件成功、外部Unity環境依存3件skip
- git diff --check: 成功
- gua_auditor独立監査: actionable findingなし

## 検証境界

この変更を含むmacOS x64のリモート実行は未実施です。マージ後のRelease実行で、cold import後にbridge起動まで完了することを確認する必要があります。