### PR TITLE
Unity UPMの対応プラットフォーム説明を更新

### DIFF
--- a/bindings/unity/Documentation~/index.md
+++ b/bindings/unity/Documentation~/index.md
@@ -1,15 +1,16 @@
 # Gua for Unity
 
-The package automatically starts the Gua runtime in Play Mode and Windows
-players, reflects UI Toolkit, uGUI, and TextMeshPro runtime controls, and listens on
+The package automatically starts the Gua runtime in Play Mode and desktop Mono
+players on Windows x64, Linux x64, Intel macOS, and Apple Silicon macOS. It
+reflects UI Toolkit, uGUI, and TextMeshPro runtime controls and listens on
 `GUA_BRIDGE_PORT` (8765 by default). Add `GuaId` only where a stable explicit id
 is required; semantic registration is otherwise automatic.
 
-The stable support range is Windows x64, Unity 6000.5 or newer, and Mono. The
-package contains precompiled managed assemblies and Windows Editor/Player native
-libraries. Other IL2CPP targets, other operating systems, IMGUI, and EditorWindow
-UI automation remain outside that stable range; the WebGL path below is
-experimental.
+The stable support range is Unity 6000.5 or newer with Mono on Windows x64,
+Linux x64, Intel macOS, and Apple Silicon macOS. The package contains
+precompiled managed assemblies and OS/CPU-scoped native libraries for the
+supported Editors and Players. IL2CPP, IMGUI, and EditorWindow UI automation
+remain outside that stable range; the WebGL path below is experimental.
 
 ## Unity WebGL and browser-native WebMCP (experimental)
 

--- a/bindings/unity/Samples~/Runtime UI Fixture/README.md
+++ b/bindings/unity/Samples~/Runtime UI Fixture/README.md
@@ -16,5 +16,6 @@ physics, animation, or audio behavior.
 The `Tick` callback receives a `GuaClockDelta`; use `TotalMilliseconds` or
 `TotalSeconds` to retain steps below the 100 ns resolution of `TimeSpan`.
 
-The package targets Windows x64, Unity 6000.5 or newer, and the Mono scripting
-backend. Import TextMeshPro Essential Resources before building a Player.
+The package targets Unity 6000.5 or newer with the Mono scripting backend on
+Windows x64, Linux x64, Intel macOS, and Apple Silicon macOS. Import TextMeshPro
+Essential Resources before building a Player.


### PR DESCRIPTION
## 概要

公式UPMパッケージ内に残っていたWindows限定の古い説明を、現在の配布内容に合わせて更新します。

## 変更内容

- Unity 6000.5以降のMonoでWindows x64、Linux x64、Intel macOS、Apple Silicon macOSを対応範囲として記載
- UPM同梱サンプルのREADMEも同じ対応範囲へ統一
- WebGLはexperimental、IL2CPP・IMGUI・EditorWindow UIは安定対応範囲外であることを維持

## 影響

ドキュメントのみの変更です。ランタイム挙動や公開済みv1.0.7のタグ・リリースアセットは変更しません。次回以降のUPMリリースへ反映されます。

## 確認

- git diff --check
- UPM packaging経路とWindows／Linux／Universal 2 macOSのplugin metadataを確認
- 読み取り専用の独立監査でactionable findingなし