### PR TITLE
Unityワールドオブジェクト型の曖昧参照を修正

### DIFF
--- a/bindings/unity/Samples~/Runtime UI Fixture/GuaRuntimeUiSample.cs
+++ b/bindings/unity/Samples~/Runtime UI Fixture/GuaRuntimeUiSample.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using UnityEngine.UIElements;
+using GuaUnityWorldObject = Gua.Unity.GuaWorldObject;
 
 public static class GuaRuntimeUiSample
 {
@@ -36,7 +37,7 @@ public static class GuaRuntimeUiSample
 
         var doorObject = new GameObject("Door A");
         doorObject.transform.position = new Vector3(640, 180, 0);
-        var door = doorObject.AddComponent<GuaWorldObject>();
+        var door = doorObject.AddComponent<GuaUnityWorldObject>();
         door.Id = "door-a";
         door.Kind = "door";
         door.Label = "Door A";
@@ -53,11 +54,11 @@ public static class GuaRuntimeUiSample
         AddWorldObject("3D Target", "target-3d", "target", GuaWorldSpace.World3D, new Vector3(1, 2, 2));
     }
 
-    private static GuaWorldObject AddWorldObject(string name, string id, string kind, GuaWorldSpace space, Vector3 position)
+    private static GuaUnityWorldObject AddWorldObject(string name, string id, string kind, GuaWorldSpace space, Vector3 position)
     {
         var objectGameObject = new GameObject(name);
         objectGameObject.transform.position = position;
-        var worldObject = objectGameObject.AddComponent<GuaWorldObject>();
+        var worldObject = objectGameObject.AddComponent<GuaUnityWorldObject>();
         worldObject.Id = id;
         worldObject.Kind = kind;
         worldObject.Space = space;

--- a/examples/unity-smoke/Assets/GuaUnityFixture.cs
+++ b/examples/unity-smoke/Assets/GuaUnityFixture.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using UnityEngine.UIElements;
+using GuaUnityWorldObject = Gua.Unity.GuaWorldObject;
 using Object = UnityEngine.Object;
 
 public static class GuaUnityFixture
@@ -117,11 +118,11 @@ public static class GuaUnityFixture
         AddWorldObject("3D Target", "target-3d", "target", GuaWorldSpace.World3D, new Vector3(1, 2, 2));
     }
 
-    private static GuaWorldObject AddWorldObject(string name, string id, string kind, GuaWorldSpace space, Vector3 position)
+    private static GuaUnityWorldObject AddWorldObject(string name, string id, string kind, GuaWorldSpace space, Vector3 position)
     {
         var objectGameObject = new GameObject(name);
         objectGameObject.transform.position = position;
-        var worldObject = objectGameObject.AddComponent<GuaWorldObject>();
+        var worldObject = objectGameObject.AddComponent<GuaUnityWorldObject>();
         worldObject.Id = id;
         worldObject.Kind = kind;
         worldObject.Space = space;


### PR DESCRIPTION
Unity UPMビルドで Gua.Core.GuaWorldObject と Gua.Unity.GuaWorldObject が曖昧参照となり、CS0104で失敗する問題を修正します。Unity componentに明示的なaliasを付け、release smoke fixtureとUPM同梱サンプルの型参照を統一しました。ローカルではUnity 6000.5.3f1のbatchmodeコンパイル、scripts/build-unity-package.ps1、git diff --checkが成功し、独立監査でもactionable findingなしを確認しています。