### PR TITLE
WebMCPの成功結果を構造化データで返す

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -94,6 +94,8 @@ World Object Tree観測ツール、capabilityで制御されたSemantic Game Act
 定義は`gua-world-tools`として公開します。`gui-mcp`もWebSocket接続も不要で、WebMCP非対応
 ブラウザでもゲーム本体はそのまま動作します。各タブがゲームとツール登録を所有し、
 独自のブラウザセッションルーターは持ちません。
+成功した呼び出しは、JSON文字列をMCP形式のtext contentで包まず、Guaの構造化結果を
+直接返します。
 ゲーム入力は現在のページが所有し、request-correlatedなhost completionを待ちます。
 timeout、キャンセル、ツール登録解除、engine終了時には全入力を解放します。Raw toolは
 hostが入力pumpとcleanup経路を明示的に初期化するまで公開しません。

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ neither `gui-mcp` nor a WebSocket connection, and browsers without WebMCP remain
 fully functional. Each tab owns its game and tool registrations; there is no
 custom browser session router. See the [browser-native WebMCP guide](https://gua.orizika.com/webmcp/)
 or the [`gua-webmcp` package reference](packages/webmcp/README.md).
+Successful calls return their structured Gua result directly instead of wrapping
+serialized JSON in an MCP-style text content block.
 Game input is owned by the current page, waits for request-correlated host
 completion, and is released on timeout, cancellation, unregister, or engine
 shutdown. Raw tools remain absent until the host explicitly initializes their

--- a/packages/webmcp/README.md
+++ b/packages/webmcp/README.md
@@ -42,7 +42,8 @@ must cancel an accepted request that is still queued when the signal aborts;
 `registerGuaWebMcp` uses this to propagate caller cancellation and its configured
 action timeout into Godot or Unity. If the host already consumed the action, the
 caller remains cancelled while the engine bridge drains its eventual correlated
-completion. `getScreenshot` is an optional read
+completion. Successful tool executions return the structured Gua result directly;
+they do not wrap serialized JSON in an MCP-style text content block. `getScreenshot` is an optional read
 of the latest published image, and the tool is not registered when the engine
 has no drawable-frame readback path.
 

--- a/packages/webmcp/src/index.ts
+++ b/packages/webmcp/src/index.ts
@@ -281,22 +281,22 @@ async function executeTool(
   try {
     throwIfAborted(signal);
     if (name === "get_ui_tree") {
-      return toolResult(await withTimeout(
+      return await withTimeout(
         bridge.getUiTree(),
         defaultTimeoutMs,
         signal,
         "Timed out reading the current Gua semantic UI tree.",
-      ));
+      );
     }
     if (name === "get_world_object_tree") {
       rejectUnknownArguments(input, new Set());
       if (!bridge.getWorldObjectTree) throw new GuaWebError("engine_unsupported", "The engine bridge does not support the World Object Tree.");
-      return toolResult(await withTimeout(
+      return await withTimeout(
         bridge.getWorldObjectTree({ signal, timeoutMs: defaultTimeoutMs }),
         defaultTimeoutMs,
         signal,
         "Timed out reading the current Gua World Object Tree.",
-      ));
+      );
     }
     if (name === "find_world_objects" || name === "wait_for_world_object") {
       if (!bridge.findWorldObjects) throw new GuaWebError("engine_unsupported", "The engine bridge does not support world object queries.");
@@ -312,36 +312,36 @@ async function executeTool(
           "Timed out querying the current Gua World Object Tree.",
         ), selector);
         if (!result.valid) throw new GuaWebError("invalid_request", result.error ?? "The host rejected the world selector.");
-        return toolResult(result);
+        return result;
       }
       const timeoutMs = input.timeoutMs === undefined
         ? Math.min(defaultTimeoutMs, 300_000)
         : optionalInteger(input, "timeoutMs", defaultTimeoutMs, 1, 300_000);
-      return toolResult(await waitForWorldObject(bridge, selector, timeoutMs, pollIntervalMs, signal));
+      return await waitForWorldObject(bridge, selector, timeoutMs, pollIntervalMs, signal);
     }
     if (name === "get_screenshot") {
       if (!bridge.getScreenshot) throw new GuaWebError("engine_unsupported", "The engine bridge does not support screenshots.");
-      return toolResult(await withTimeout(
+      return await withTimeout(
         bridge.getScreenshot(),
         defaultTimeoutMs,
         signal,
         "Timed out reading the latest Gua screenshot.",
-      ));
+      );
     }
     if (name === "get_game_input_actions") {
       rejectUnknownArguments(input, new Set());
       if (!bridge.getGameInputActions) throw new GuaWebError("engine_unsupported", "The engine bridge does not support semantic game input.");
-      return toolResult(await withTimeout(bridge.getGameInputActions(), defaultTimeoutMs, signal, "Timed out reading the game input action map."));
+      return await withTimeout(bridge.getGameInputActions(), defaultTimeoutMs, signal, "Timed out reading the game input action map.");
     }
     if (name === "find_game_input_actions") {
       if (!bridge.findGameInputActions) throw new GuaWebError("engine_unsupported", "The engine bridge does not support game input search.");
-      return toolResult(await withTimeout(bridge.findGameInputActions(gameInputSelector(input)), defaultTimeoutMs, signal,
-        "Timed out searching the game input action map."));
+      return await withTimeout(bridge.findGameInputActions(gameInputSelector(input)), defaultTimeoutMs, signal,
+        "Timed out searching the game input action map.");
     }
     if (name === "get_game_input_state") {
       rejectUnknownArguments(input, new Set());
       if (!bridge.getGameInputState) throw new GuaWebError("engine_unsupported", "The engine bridge does not expose page-owned game input state.");
-      return toolResult(await withTimeout(bridge.getGameInputState(), defaultTimeoutMs, signal, "Timed out reading page-owned game input state."));
+      return await withTimeout(bridge.getGameInputState(), defaultTimeoutMs, signal, "Timed out reading page-owned game input state.");
     }
     if (isGameInputTool(name)) {
       if (!bridge.performGameInput) throw new GuaWebError("engine_unsupported", "The engine bridge does not support game input.");
@@ -364,12 +364,12 @@ async function executeTool(
       if (!completion.succeeded) throw new GuaWebError("action_failed", `The host rejected ${request.type}.`, {
         requestId: completion.requestId, hostError: completion.errorCode,
       });
-      return toolResult(completion);
+      return completion;
     }
     if (name === "wait_for_node") {
       const nodeId = requiredString(input, "nodeId");
       const timeoutMs = optionalInteger(input, "timeoutMs", defaultTimeoutMs, 0, maxBrowserTimerDelayMs);
-      return toolResult(await waitForNode(bridge, nodeId, timeoutMs, pollIntervalMs, signal));
+      return await waitForNode(bridge, nodeId, timeoutMs, pollIntervalMs, signal);
     }
     const request = actionRequest(name, input);
     await validateAction(bridge, request, defaultTimeoutMs, signal);
@@ -393,7 +393,7 @@ async function executeTool(
     const safeCompletion = (request.action === "set_value" && request.sensitive) || completion.sensitive
       ? { ...completion, value: "", sensitive: true }
       : completion;
-    return toolResult(safeCompletion);
+    return safeCompletion;
   } catch (error) {
     if (name === "text_input" && input.sensitive === true) {
       const code = error instanceof GuaWebError ? error.code : "action_failed";
@@ -668,7 +668,6 @@ async function performGameInputWithCancellation(
   }
 }
 
-function toolResult(value: unknown) { return { content: [{ type: "text", text: JSON.stringify(value) }] }; }
 function requiredString(input: Record<string, unknown>, key: string, allowEmpty = false): string {
   if (typeof input[key] !== "string" || (!allowEmpty && (input[key] as string).length === 0)) {
     throw new GuaWebError("invalid_request", `${key} must be ${allowEmpty ? "a string" : "a non-empty string"}.`);

--- a/packages/webmcp/test/webmcp.test.ts
+++ b/packages/webmcp/test/webmcp.test.ts
@@ -8,9 +8,11 @@ import {
   registerGuaWebMcp,
   guaWebMcpToolDefinitions,
   type GuaBrowserBridge,
+  type GuaGameInputActionSearchResult,
   type GuaWorldObject,
   type GuaWorldObjectTree,
   type GuaUiTree,
+  type GuaWebActionCompletion,
   type GuaWebActionRequest,
 } from "../src/index";
 
@@ -135,9 +137,9 @@ describe("registerGuaWebMcp", () => {
     const waitSchema = page.tools.get("wait_for_node")!.inputSchema as { properties: { timeoutMs: { maximum?: number } } };
     expect(waitSchema.properties.timeoutMs.maximum).toBe(2_147_483_647);
 
-    const result = await page.tools.get("click_node")!.execute({ nodeId: "start" }) as { content: Array<{ text: string }> };
+    const result = await page.tools.get("click_node")!.execute({ nodeId: "start" }) as GuaWebActionCompletion;
     expect(requests).toEqual([{ action: "click", nodeId: "start" }]);
-    expect(JSON.parse(result.content[0]!.text).requestId).toBe(41);
+    expect(result.requestId).toBe(41);
 
     registration.unregister();
     expect(page.signals.get("click_node")?.aborted).toBe(true);
@@ -169,8 +171,8 @@ describe("registerGuaWebMcp", () => {
     ]));
     expect(registration.registeredTools).not.toContain("pointer_move");
     expect(registration.registeredTools).not.toContain("set_gamepad_axis");
-    const found = await page.tools.get("find_game_input_actions")!.execute({ query: "Jump", active: true }) as { content: Array<{ text: string }> };
-    expect(JSON.parse(found.content[0]!.text).actions[0].id).toBe("jump");
+    const found = await page.tools.get("find_game_input_actions")!.execute({ query: "Jump", active: true }) as GuaGameInputActionSearchResult;
+    expect(found.actions[0]!.id).toBe("jump");
     for (const invalid of [{ id: "Invalid" }, { tags: ["same", "same"] }, { query: "q".repeat(129) }, { query: "before\0after" }]) {
       const rejected = await page.tools.get("find_game_input_actions")!.execute(invalid) as { isError: boolean; content: Array<{ text: string }> };
       expect(rejected.isError).toBe(true);
@@ -324,11 +326,11 @@ describe("registerGuaWebMcp", () => {
     ]));
     expect(registration.registeredTools).not.toContain("interact_world_object");
 
-    const treeResult = await page.tools.get("get_world_object_tree")!.execute({}) as { content: Array<{ text: string }> };
-    expect(JSON.parse(treeResult.content[0]!.text).objects[0].id).toBe("door");
+    const treeResult = await page.tools.get("get_world_object_tree")!.execute({}) as GuaWorldObjectTree;
+    expect(treeResult.objects[0]!.id).toBe("door");
     await page.tools.get("find_world_objects")!.execute({ parentId: "room", directChild: true, stateKey: "locked", stateValue: true });
-    const waitResult = await page.tools.get("wait_for_world_object")!.execute({ id: "door", timeoutMs: 100 }) as { content: Array<{ text: string }> };
-    expect(JSON.parse(waitResult.content[0]!.text).id).toBe("door");
+    const waitResult = await page.tools.get("wait_for_world_object")!.execute({ id: "door", timeoutMs: 100 }) as GuaWorldObject;
+    expect(waitResult.id).toBe("door");
     expect(selectors).toEqual([
       { parentId: "room", directChild: true, state: { key: "locked", value: true } },
       { id: "door" },
@@ -421,10 +423,10 @@ describe("registerGuaWebMcp", () => {
     };
     const registration = await registerGuaWebMcp(bridge, { document: page.document, pollIntervalMs: 0 });
     expect(registration.registeredTools).not.toContain("get_screenshot");
-    const waited = await page.tools.get("wait_for_node")!.execute({ nodeId: "password", timeoutMs: 100 }) as { content: Array<{ text: string }> };
-    expect(JSON.parse(waited.content[0]!.text).id).toBe("password");
-    const result = await page.tools.get("set_value")!.execute({ nodeId: "password", value: "secret-marker", sensitive: true }) as { content: Array<{ text: string }> };
-    expect(result.content[0]!.text).not.toContain("secret-marker");
+    const waited = await page.tools.get("wait_for_node")!.execute({ nodeId: "password", timeoutMs: 100 }) as GuaUiTree["nodes"][number];
+    expect(waited.id).toBe("password");
+    const result = await page.tools.get("set_value")!.execute({ nodeId: "password", value: "secret-marker", sensitive: true }) as GuaWebActionCompletion;
+    expect(JSON.stringify(result)).not.toContain("secret-marker");
   });
 
   test("allows set_value to clear a control with an empty string", async () => {
@@ -629,11 +631,11 @@ describe("registerGuaWebMcp", () => {
     const second = modelDocument();
     await registerGuaWebMcp(bridgeWithTree(tree([button("first")])), { document: first.document });
     await registerGuaWebMcp(bridgeWithTree(tree([button("second")])), { document: second.document });
-    const firstTree = await first.tools.get("get_ui_tree")!.execute({}) as { content: Array<{ text: string }> };
-    const secondTree = await second.tools.get("get_ui_tree")!.execute({}) as { content: Array<{ text: string }> };
-    expect(firstTree.content[0]!.text).toContain("first");
-    expect(firstTree.content[0]!.text).not.toContain("second");
-    expect(secondTree.content[0]!.text).toContain("second");
+    const firstTree = await first.tools.get("get_ui_tree")!.execute({}) as GuaUiTree;
+    const secondTree = await second.tools.get("get_ui_tree")!.execute({}) as GuaUiTree;
+    expect(firstTree.nodes[0]!.id).toBe("first");
+    expect(firstTree.nodes.some((node) => node.id === "second")).toBe(false);
+    expect(secondTree.nodes[0]!.id).toBe("second");
   });
 });
 

--- a/protocol/specs/protocol.md
+++ b/protocol/specs/protocol.md
@@ -513,6 +513,9 @@ transport consumer, not a replacement for `gui-mcp` or the Inspector bridge. One
 page calls one engine-owned in-page bridge; it does not open a WebSocket, select
 a remote endpoint, or introduce a Gua session ID. Browser tabs remain isolated
 by their ordinary JavaScript and engine instances.
+Successful tool executions return the structured Gua result directly from the
+WebMCP callback. They do not wrap serialized JSON in an MCP-style text content
+block; browser serialization remains a transport detail.
 
 The browser-safe surface shares the base tool names and semantics for
 `get_ui_tree`, v1 semantic actions, `wait_for_node`, and optional


### PR DESCRIPTION
## 概要

WebMCPツールの成功結果からMCP形式のTextContentラッパーを取り除き、Guaの構造化結果を直接返すようにします。

## 変更内容

- get_ui_tree、get_world_object_treeを含む全WebMCP成功経路で構造化オブジェクトを直接返却
- 非同期処理のreturn awaitを維持し、timeout・abort・bridge rejectionの既存エラー正規化を保持
- 成功結果のテストをJSON文字列の再パースから直接フィールド検証へ変更
- README（日英）、パッケージREADME、プロトコル仕様を更新
- エラー時のcontent/isError形式は互換性のため変更なし

## 検証

- packages/webmcp: bun run test（70件成功、243 assertions）
- packages/webmcp: bun run check
- リポジトリルート: bun run check（全5 workspace成功）
- git diff --check origin/main --
- gua_auditorによる独立監査（actionable findingなし）