### PR TITLE
Unity PlayerのWorld公開失敗を修正

### DIFF
--- a/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
+++ b/bindings/dotnet/tests/Gua.Unity.Integration.Tests/UnityIntegrationTests.cs
@@ -53,7 +53,7 @@ public sealed class UnityIntegrationTests
     }
 
     [Test]
-    public void RenderedPlayer_ReflectsUiAndDispatchesButtonListener()
+    public async Task RenderedPlayer_ReflectsUiAndDispatchesButtonListener()
     {
         var player = Environment.GetEnvironmentVariable("GUA_UNITY_PLAYER");
         if (string.IsNullOrWhiteSpace(player)) Assert.Ignore("Set GUA_UNITY_PLAYER to run the Unity integration fixture.");
@@ -79,11 +79,16 @@ public sealed class UnityIntegrationTests
         Assert.That(host.RemoteContext.GetRemoteTree().Nodes.All(node => Encoding.UTF8.GetByteCount(node.Id) <= 127), Is.True,
             "Unity must keep node IDs round-trippable through the fixed-size C ABI action request.");
 
+        var playerWorld = await host.RemoteContext.WaitForWorldObjectAsync(
+            new GuaWorldSelector(Id: "player-world"), TimeSpan.FromSeconds(15));
+        Assert.That(playerWorld.Id, Is.EqualTo("player-world"));
         var nearbyDoors = host.RemoteContext.QueryWorldObjects(new GuaWorldSelector(
             Kind: "door", State: new GuaWorldStateCriterion("locked", true))
             { Near = new GuaWorldNear("player-world", 5), Limit = 1 });
+        var nearbyDoorIds = nearbyDoors.Matches.Select(match => match.Id).ToArray();
         Assert.That(nearbyDoors.Valid, Is.True);
-        Assert.That(nearbyDoors.Matches.Select(match => match.Id), Is.EqualTo(new[] { "door-a" }));
+        Assert.That(nearbyDoorIds, Is.EqualTo(new[] { "door-a" }),
+            $"Unexpected spatial query result: {JsonSerializer.Serialize(nearbyDoors)}");
         Assert.That(nearbyDoors.Spatial?.Truncated, Is.True);
         Assert.That(nearbyDoors.Spatial?.Distances.Single().Distance, Is.EqualTo(5));
         Assert.That(nearbyDoors.SessionEpoch, Is.Not.Null);

--- a/bindings/unity/Runtime/GuaUnityRuntime.cs
+++ b/bindings/unity/Runtime/GuaUnityRuntime.cs
@@ -639,7 +639,7 @@ public sealed partial class GuaUnityRuntime : MonoBehaviour
             foreach (var source in FindObjectsByType<GuaWorldObject>(FindObjectsInactive.Include, FindObjectsSortMode.None)
                 .Where(item => item.gameObject.scene.IsValid() && item.gameObject.scene.isLoaded)
                 .OrderBy(item => ScenePath(item.gameObject.scene), StringComparer.Ordinal)
-                .ThenBy(item => item.gameObject.scene.handle)
+                .ThenBy(item => item.gameObject.scene.handle.GetRawData())
                 .ThenBy(item => HierarchyPath(item.transform), StringComparer.Ordinal)
                 .ThenBy(item => item.Id, StringComparer.Ordinal))
             {


### PR DESCRIPTION
## 概要

- Unity 6000.5でWorld Object収集中に発生する比較例外を修正
- Player SmokeでWorldスナップショットの公開を待ってから照会
- 失敗時にspatial queryの実結果を表示するよう診断を改善

## 原因

Unity 6000.5では `Scene.handle` が `IComparable` を実装しない `SceneHandle` 型になったため、複数のWorld Objectを `ThenBy` で並べ替える際に例外が発生し、Worldフレームが公開されていませんでした。比較キーには `SceneHandle.GetRawData()` の `UInt64` 値を使用します。

元の失敗Run: https://github.com/link1345/gua/actions/runs/33698633048

## 検証

- Unity 6000.5.3f1でUPMパッケージのコンパイル成功
- ローカルWindows Playerのビルド成功
- 失敗していたPlayer Smoke成功
- Unity統合テスト: 2成功、環境依存2スキップ
- World selector重点テスト: 2/2成功
- native CTest: 4/4成功
- 読み取り専用の累積差分監査: actionableな指摘なし